### PR TITLE
prevent self followership

### DIFF
--- a/src/components/Shared/Follow.tsx
+++ b/src/components/Shared/Follow.tsx
@@ -18,6 +18,7 @@ import {
   ERROR_MESSAGE,
   LENSHUB_PROXY,
   RELAY_ON,
+  SELF_FOLLOW,
   WRONG_NETWORK
 } from 'src/constants'
 import {
@@ -166,6 +167,8 @@ const Follow: FC<Props> = ({
       toast.error(CONNECT_WALLET)
     } else if (activeChain?.id !== CHAIN_ID) {
       toast.error(WRONG_NETWORK)
+    } else if (currentUser?.id === profile?.id) {
+      toast.error(SELF_FOLLOW)
     } else {
       createFollowTypedData({
         variables: {

--- a/src/components/Shared/SuperFollow/FollowModule.tsx
+++ b/src/components/Shared/SuperFollow/FollowModule.tsx
@@ -29,6 +29,7 @@ import {
   LENSHUB_PROXY,
   POLYGONSCAN_URL,
   RELAY_ON,
+  SELF_FOLLOW,
   WRONG_NETWORK
 } from 'src/constants'
 import {
@@ -258,6 +259,8 @@ const FollowModule: FC<Props> = ({
       toast.error(CONNECT_WALLET)
     } else if (activeChain?.id !== CHAIN_ID) {
       toast.error(WRONG_NETWORK)
+    } else if (currentUser?.id === profile?.id) {
+      toast.error(SELF_FOLLOW)
     } else {
       createFollowTypedData({
         variables: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,6 +30,7 @@ export const WRONG_NETWORK = IS_MAINNET
   ? 'Please change network to Polygon mainnet.'
   : 'Please change network to Polygon Mumbai testnet.'
 export const SIGN_ERROR = 'Failed to sign data'
+export const SELF_FOLLOW = 'You cannot follow yourself.'
 
 // URLs
 export const STATIC_ASSETS = 'https://assets.lenster.xyz/images'


### PR DESCRIPTION
Presently, a user can follow itself. Looking at the way social profiles work (Twitter, Instagram, Facebook, etc.), a user shouldn't be able to follow their own profile.  

Alice should be able to follow Bob. However, Alice shouldn't be able to follow Alice.

So, I made changes to prevent a user from following him(er)self. I have also attached a video demo

https://www.loom.com/share/caf0897b729c458585c5ef1c2c166370

cc @sasicodes @m1guelpf 