### PR TITLE
fix: add searchbar in `640px to 1023px` screens

### DIFF
--- a/src/components/Shared/Navbar/MenuItems.tsx
+++ b/src/components/Shared/Navbar/MenuItems.tsx
@@ -278,6 +278,7 @@ const MenuItems: FC<Props> = ({ pingData }) => {
         <Login />
       </Modal>
       <Button
+        className="w-max"
         icon={
           <img
             className="mr-0.5 w-4 h-4"

--- a/src/components/Shared/Navbar/index.tsx
+++ b/src/components/Shared/Navbar/index.tsx
@@ -118,7 +118,7 @@ const Navbar: FC = () => {
                 </Link>
                 <div className="hidden sm:block sm:ml-6">
                   <div className="flex items-center space-x-4">
-                    <div className="hidden lg:block">
+                    <div className="hidden sm:block">
                       <Search />
                     </div>
                     <NavItems />


### PR DESCRIPTION
Updated searchbar to show in Header from `640px` screens.

Resolves #155 