### PR TITLE
fix: forbidden non-null assertion usage

### DIFF
--- a/src/components/Shared/Attachment.tsx
+++ b/src/components/Shared/Attachment.tsx
@@ -44,7 +44,10 @@ const Attachment: FC<Props> = ({ attachments, setAttachments }) => {
     setLoading(true)
 
     try {
-      if (hasVideos(evt.target.files) || evt.target.files!.length > 4) {
+      if (
+        evt.target.files &&
+        (hasVideos(evt.target.files) || evt.target.files.length > 4)
+      ) {
         toast.error('Please choose either 1 video or up to 4 photos.')
       } else {
         const attachment = await uploadAssetsToIPFS(evt.target.files)


### PR DESCRIPTION
Removed non-null assertion usage.

Fixes [JS-0339](https://deepsource.io/gh/lensterxyz/lenster/issue/JS-0339/occurrences).