### PR TITLE
fix: focus interactive elements

### DIFF
--- a/src/components/Post/Actions/index.tsx
+++ b/src/components/Post/Actions/index.tsx
@@ -16,6 +16,7 @@ const PostActions: FC<Props> = ({ post }) => {
 
   return postType !== 'community' ? (
     <div
+      tabIndex={0}
       className="flex gap-6 items-center pt-3 -ml-2 text-gray-500 sm:gap-8"
       onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
       role="button"

--- a/src/components/Post/Actions/index.tsx
+++ b/src/components/Post/Actions/index.tsx
@@ -16,10 +16,8 @@ const PostActions: FC<Props> = ({ post }) => {
 
   return postType !== 'community' ? (
     <div
-      tabIndex={0}
       className="flex gap-6 items-center pt-3 -ml-2 text-gray-500 sm:gap-8"
       onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
-      role="button"
     >
       <Comment post={post} />
       <Mirror post={post} />


### PR DESCRIPTION
Elements with the `button` interactive role must be tabbable

Resolves [JS-0751](https://deepsource.io/gh/lensterxyz/lenster/issue/JS-0751/occurrences)