### PR TITLE
fix: template literals having non-string type

### DIFF
--- a/src/components/Post/index.tsx
+++ b/src/components/Post/index.tsx
@@ -102,7 +102,11 @@ const ViewPost: NextPage = () => {
   return (
     <GridLayout>
       <Seo
-        title={`${post?.__typename} by @${post?.profile?.handle} • ${APP_NAME}`}
+        title={
+          post?.__typename && post?.profile?.handle
+            ? `${post.__typename} by @${post.profile.handle} • ${APP_NAME}`
+            : APP_NAME
+        }
       />
       <GridItemEight className="space-y-5">
         <Card>

--- a/src/lib/getAttribute.ts
+++ b/src/lib/getAttribute.ts
@@ -16,8 +16,8 @@ type Query =
 const getAttribute = (
   attributes: Maybe<Attribute[]> | undefined,
   query: Query
-): string | undefined => {
-  return attributes?.find((o) => o.key === query)?.value
+): string => {
+  return attributes?.find((o) => o.key === query)?.value || ''
 }
 
 export default getAttribute


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/lensterxyz/lenster/fix/117(JS-0378)?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=lensterxyz&repo=lenster&branch=fix/117(JS-0378)">VS Code</a>

<!-- open-in-codesandbox:complete -->


Resolves #117 