### PR TITLE
fix: remove input ring on error and focus

### DIFF
--- a/src/components/UI/Input.tsx
+++ b/src/components/UI/Input.tsx
@@ -51,12 +51,13 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
         <div
           className={clsx(
             { '!border-red-500': error },
+            { 'focus-within:ring-1': !error },
             { 'rounded-r-xl': prefix },
             { 'rounded-xl': !prefix },
             {
               'opacity-60 bg-gray-500 bg-opacity-20': props.disabled
             },
-            'flex items-center border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700/80 focus-within:border-brand-500 focus-within:ring-1 focus-within:ring-brand-400 w-full'
+            'flex items-center border bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700/80 focus-within:border-brand-500 focus-within:ring-brand-400 w-full'
           )}
         >
           <input


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/danschewy/lenster/fix/input-error-ring?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=danschewy&repo=lenster&branch=fix/input-error-ring">VS Code</a>

<!-- open-in-codesandbox:complete -->


Remove purple input ring when error and focused

<img width="509" alt="Screen Shot 2022-07-31 at 6 14 03 AM" src="https://user-images.githubusercontent.com/6502595/182021546-4004b35c-6234-4865-9141-013db4533b55.png">

Related to:
https://github.com/lensterxyz/lenster/issues/68
https://github.com/lensterxyz/lenster/pull/173
https://github.com/lensterxyz/lenster/pull/177
https://github.com/lensterxyz/lenster/pull/173#discussion_r933920236
