### PR TITLE
updating cookie expiry value to 1 day

### DIFF
--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -15,7 +15,7 @@ import { API_URL, ERROR_MESSAGE } from './constants'
 export const COOKIE_CONFIG: CookieAttributes = {
   sameSite: 'None',
   secure: true,
-  expires: 360
+  expires: 1
 }
 
 const REFRESH_AUTHENTICATION_MUTATION = `


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/0xkeivin/lenster/enhancement/set-cookies-expiry-1day?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=0xkeivin&repo=lenster&branch=enhancement/set-cookies-expiry-1day">VS Code</a>

<!-- open-in-codesandbox:complete -->


## Current Behavior
Currently, the default expiry is set to `360` days.

## Suggested Behavior
Suggesting a value of `1` day for a good mix of user experience and security. 

## What platform(s) does this occur on?
Web - Chrome, Firefox 

## Notes
- Wanted to merge on testnet but seems it is lagging several commits behind 

