### PR TITLE
chore: add `no-unexpected-multiline` rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
     "prettier/prettier": "error",
     "react/prop-types": "off",
     "react/no-unescaped-entities": "off",
-    "react/jsx-no-useless-fragment": 2,
+    "react/jsx-no-useless-fragment": "error",
     "no-unused-vars": "warn",
     "unused-imports/no-unused-imports": "error",
     "@next/next/no-html-link-for-pages": "off",
@@ -25,7 +25,8 @@
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
     "jsx-a11y/role-supports-aria-props": "off",
-    "no-use-before-define" :"error"
+    "no-use-before-define": "error",
+    "no-unexpected-multiline": "error"
   },
   "ignorePatterns": ["/src/generated/types.ts"]
 }


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/lensterxyz/lenster/chore/no-unexpected-multiline?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=lensterxyz&repo=lenster&branch=chore/no-unexpected-multiline">VS Code</a>

<!-- open-in-codesandbox:complete -->


It is better to add [`no-unexpected-multiline`](https://eslint.org/docs/latest/rules/no-unexpected-multiline) rule, since we are not using semicolons.