### PR TITLE
chore: rename PostActions component to PublicationActions

### DIFF
--- a/src/components/Publication/Actions/index.tsx
+++ b/src/components/Publication/Actions/index.tsx
@@ -8,25 +8,26 @@ import PostMenu from './Menu'
 import Mirror from './Mirror'
 
 interface Props {
-  post: LensterPublication
+  publication: LensterPublication
 }
 
-const PostActions: FC<Props> = ({ post }) => {
-  const postType = post?.metadata?.attributes[0]?.value
+const PublicationActions: FC<Props> = ({ publication }) => {
+  const postType = publication?.metadata?.attributes[0]?.value
 
   return postType !== 'community' ? (
     <div
       className="flex gap-6 items-center pt-3 -ml-2 text-gray-500 sm:gap-8"
       onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
     >
-      <Comment post={post} />
-      <Mirror post={post} />
-      <Like post={post} />
-      {post?.collectModule?.__typename !== 'RevertCollectModuleSettings' &&
-        postType !== 'crowdfund' && <Collect post={post} />}
-      <PostMenu post={post} />
+      <Comment post={publication} />
+      <Mirror post={publication} />
+      <Like post={publication} />
+      {publication?.collectModule?.__typename !==
+        'RevertCollectModuleSettings' &&
+        postType !== 'crowdfund' && <Collect post={publication} />}
+      <PostMenu post={publication} />
     </div>
   ) : null
 }
 
-export default PostActions
+export default PublicationActions

--- a/src/components/Publication/FullPublication.tsx
+++ b/src/components/Publication/FullPublication.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import React, { FC } from 'react'
 
-import PostActions from './Actions'
+import PublicationActions from './Actions'
 import HiddenPublication from './HiddenPublication'
 import PublicationBody from './PublicationBody'
 import PostType from './Type'
@@ -46,7 +46,7 @@ const FullPublication: FC<Props> = ({ publication }) => {
           ) : (
             <>
               <PublicationBody publication={publication} />
-              <PostActions post={publication} />
+              <PublicationActions publication={publication} />
             </>
           )}
         </div>

--- a/src/components/Publication/SinglePublication.tsx
+++ b/src/components/Publication/SinglePublication.tsx
@@ -5,7 +5,7 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import Link from 'next/link'
 import React, { FC } from 'react'
 
-import PostActions from './Actions'
+import PublicationActions from './Actions'
 import HiddenPublication from './HiddenPublication'
 import PublicationBody from './PublicationBody'
 import PostType from './Type'
@@ -57,7 +57,9 @@ const SinglePublication: FC<Props> = ({
             ) : (
               <>
                 <PublicationBody publication={publication} />
-                {showActions && <PostActions post={publication} />}
+                {showActions && (
+                  <PublicationActions publication={publication} />
+                )}
               </>
             )}
           </div>

--- a/src/components/Publication/ThreadBody.tsx
+++ b/src/components/Publication/ThreadBody.tsx
@@ -5,7 +5,7 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 import Link from 'next/link'
 import React, { FC } from 'react'
 
-import PostActions from './Actions'
+import PublicationActions from './Actions'
 import HiddenPublication from './HiddenPublication'
 import PublicationBody from './PublicationBody'
 
@@ -45,7 +45,7 @@ const ThreadBody: FC<Props> = ({ post }) => {
           ) : (
             <>
               <PublicationBody publication={post} />
-              <PostActions post={post} />
+              <PublicationActions publication={post} />
             </>
           )}
         </div>


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/lensterxyz/lenster/225-rename-postactions-component-to-publicationactions?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=lensterxyz&repo=lenster&branch=225-rename-postactions-component-to-publicationactions">VS Code</a>

<!-- open-in-codesandbox:complete -->


