### PR TITLE
chore: rename PostMenu component to PublicationMenu

### DIFF
--- a/src/components/Publication/Actions/Menu/index.tsx
+++ b/src/components/Publication/Actions/Menu/index.tsx
@@ -14,10 +14,10 @@ import Embed from './Embed'
 import Permalink from './Permalink'
 
 interface Props {
-  post: LensterPublication
+  publication: LensterPublication
 }
 
-const PostMenu: FC<Props> = ({ post }) => {
+const PublicationMenu: FC<Props> = ({ publication }) => {
   const { currentUser } = useAppPersistStore()
 
   return (
@@ -45,12 +45,12 @@ const PostMenu: FC<Props> = ({ post }) => {
               static
               className="absolute py-1 w-max bg-white rounded-xl border shadow-sm dark:bg-gray-900 focus:outline-none z-[5] dark:border-gray-700/80"
             >
-              {currentUser?.id === post?.profile?.id ? (
-                <Delete post={post} />
+              {currentUser?.id === publication?.profile?.id ? (
+                <Delete post={publication} />
               ) : (
                 <Menu.Item
                   as={NextLink}
-                  href={`/report/${post?.id}`}
+                  href={`/report/${publication?.id}`}
                   className={({ active }: { active: boolean }) =>
                     clsx(
                       { 'dropdown-active': active },
@@ -64,8 +64,8 @@ const PostMenu: FC<Props> = ({ post }) => {
                   </div>
                 </Menu.Item>
               )}
-              <Embed post={post} />
-              <Permalink post={post} />
+              <Embed post={publication} />
+              <Permalink post={publication} />
             </Menu.Items>
           </Transition>
         </>
@@ -74,4 +74,4 @@ const PostMenu: FC<Props> = ({ post }) => {
   )
 }
 
-export default PostMenu
+export default PublicationMenu

--- a/src/components/Publication/Actions/index.tsx
+++ b/src/components/Publication/Actions/index.tsx
@@ -4,7 +4,7 @@ import React, { FC, MouseEvent } from 'react'
 import Collect from './Collect'
 import Comment from './Comment'
 import Like from './Like'
-import PostMenu from './Menu'
+import PublicationMenu from './Menu'
 import Mirror from './Mirror'
 
 interface Props {
@@ -25,7 +25,7 @@ const PublicationActions: FC<Props> = ({ publication }) => {
       {publication?.collectModule?.__typename !==
         'RevertCollectModuleSettings' &&
         postType !== 'crowdfund' && <Collect post={publication} />}
-      <PostMenu post={publication} />
+      <PublicationMenu publication={publication} />
     </div>
   ) : null
 }


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/lensterxyz/lenster/233-rename-postmenu-component-to-publicationmenu?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=lensterxyz&repo=lenster&branch=233-rename-postmenu-component-to-publicationmenu">VS Code</a>

<!-- open-in-codesandbox:complete -->


