### PR TITLE
fix: margin in gif search

### DIFF
--- a/src/components/Shared/Giphy/GifSelector.tsx
+++ b/src/components/Shared/Giphy/GifSelector.tsx
@@ -54,13 +54,14 @@ const GifSelector: FC<Props> = ({ setShowModal, setGifAttachment }) => {
 
   return (
     <div>
-      <Input
-        className="m-3"
-        type="text"
-        placeholder="Search for GIFs"
-        value={debouncedGifInput}
-        onChange={handleSearch}
-      />
+      <div className="m-3">
+        <Input
+          type="text"
+          placeholder="Search for GIFs"
+          value={debouncedGifInput}
+          onChange={handleSearch}
+        />
+      </div>
       <div className="flex overflow-y-auto overflow-x-hidden h-[45vh]">
         {debouncedGifInput ? (
           <Grid


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/lensterxyz/lenster/264-fix-gif-search-input-padding?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=lensterxyz&repo=lenster&branch=264-fix-gif-search-input-padding">VS Code</a>

<!-- open-in-codesandbox:complete -->


