### PR TITLE
fix: add auto pausing video when video player leaves viewport

### DIFF
--- a/src/components/Shared/Video.tsx
+++ b/src/components/Shared/Video.tsx
@@ -1,16 +1,38 @@
 import 'plyr-react/plyr.css';
 
-import Plyr from 'plyr-react';
-import React, { FC } from 'react';
+import Plyr, { APITypes } from 'plyr-react';
+import React, { FC, useEffect, useRef } from 'react';
 
 interface Props {
   src: string;
 }
 
 const Video: FC<Props> = ({ src }) => {
+  const videoRef = useRef<APITypes>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let handlePlay = (entries: any) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) {
+          (videoRef.current?.plyr as Plyr)?.pause();
+        }
+      }
+    };
+
+    let observer = new IntersectionObserver(handlePlay, {
+      threshold: [0.25, 0.75]
+    });
+
+    if (wrapperRef.current) {
+      observer.observe(wrapperRef?.current);
+    }
+  }, []);
+
   return (
-    <div className="rounded-lg">
+    <div ref={wrapperRef} className="rounded-lg">
       <Plyr
+        ref={videoRef}
         source={{
           type: 'video',
           sources: [{ src, provider: 'html5' }],


### PR DESCRIPTION
## What does this PR do?

This adds the functionality of auto pausing video when scrolling and video leaves viewport.
Due to refs not working well with the plyr object combined with the intersectionobserver, using a ref on the wrapper for detecting the location of the player in relation to viewport, then a ref on the player to control it.

https://user-images.githubusercontent.com/5845181/186959474-e5d19f50-5599-4a00-bee2-6439a07b241c.mov

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Enhancement (non-breaking small changes to existing functionality)

## How should this be tested?

This can be tested by running and scrolling home until you find a video. Play the video, then scroll away. The video should pause. No other functionality should change.
