### PR TITLE
Add manifest.json to support PWA mode for Lenster

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,26 @@
+{
+  "short_name": "Lenster",
+  "name": "Lenster.xyz",
+  "iconPath": "./favicon.svg",
+  "description": "Lenster is a decentralized, and permissionless social media app built with Lens Protocol",
+  "orientation": "portrait",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "https://assets.lenster.xyz/images/icons/apple-touch-icon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    },
+    {
+      "src": "https://assets.lenster.xyz/images/icons/192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "https://assets.lenster.xyz/images/icons/512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/"
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -114,6 +114,8 @@ const Layout: FC<Props> = ({ children }) => {
   return (
     <>
       <Head>
+        <link rel="manifest" href="/manifest.json" />
+        <link rel="shortcut icon" href="/favicon.ico" />
         <meta name="theme-color" content={resolvedTheme === 'dark' ? '#1b1b1d' : '#ffffff'} />
       </Head>
       <Toaster position="bottom-right" toastOptions={getToastOptions(resolvedTheme)} />


### PR DESCRIPTION
## What does this PR do?

Adds a `manifest.json` file, allowing Lenster to be added to home screen for a more app-like UI, this could serve as a bridge while a real mobile app is built. Adding a service worker as a future enhancement would be the next step for a fully fledged PWA. I took some guesses with the icons which need to checked.

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Enhancement (non-breaking small changes to existing functionality)

## How should this be tested?

- [ ] Run the app and attempt to add it to your home screen via chrome mobile

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't commented my code, particularly in hard-to-understand areas
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
