### PR TITLE
chore: remove console

### DIFF
--- a/src/components/Shared/Attachments.tsx
+++ b/src/components/Shared/Attachments.tsx
@@ -15,7 +15,6 @@ const Video = dynamic(() => import('./Video'), {
 });
 
 const getClass = (attachments: number, isNew = false) => {
-  console.log(isNew);
   if (attachments === 1) {
     return {
       aspect: isNew ? 'aspect-w-16 aspect-h-12' : '',


### PR DESCRIPTION
## What does this PR do?

Removes console.log from `Attachments` component
![image](https://user-images.githubusercontent.com/42532987/194763056-739952b9-c72d-4936-a5be-9a0436b6e1f5.png)


