### PR TITLE
chore: prefer let/const

### DIFF
--- a/src/lib/getTags.ts
+++ b/src/lib/getTags.ts
@@ -1,7 +1,7 @@
 const getTags = (inputText: string) => {
   const regex = /(?:^|\s)#([\dA-Za-z]+)/gm;
   const matches: any = [];
-  var match;
+  let match;
 
   while ((match = regex.exec(inputText))) {
     matches.push(match[1]);


### PR DESCRIPTION
## What does this PR do?
Fixed deepsource's `Consider using let or const instead of var
JS-0239` issue

Fixes # (issue)
Resolves [JS-0239](https://deepsource.io/gh/lensterxyz/lenster/issue/JS-0239/occurrences?listindex=0)
