### PR TITLE
chore: add `type` attribute in button

### DIFF
--- a/src/components/Composer/Post/New.tsx
+++ b/src/components/Composer/Post/New.tsx
@@ -54,6 +54,7 @@ const NewPost: FC = () => {
         />
         <button
           className="w-full flex items-center space-x-2 bg-gray-100 dark:bg-gray-900 px-4 py-2 rounded-xl border border-gray-200 dark:border-gray-700"
+          type="button"
           onClick={() => openModal('update')}
         >
           <PencilAltIcon className="h-5 w-5" />

--- a/src/components/Home/RecommendedProfiles.tsx
+++ b/src/components/Home/RecommendedProfiles.tsx
@@ -74,6 +74,7 @@ const RecommendedProfiles: FC = () => {
         </div>
         <button
           className="bg-gray-50 dark:bg-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 border-t dark:border-t-gray-700/80 text-sm w-full rounded-b-xl text-left px-5 py-3 flex items-center space-x-2 text-gray-600 dark:text-gray-300"
+          type="button"
           onClick={() => {
             setShowSuggestedModal(true);
             Mixpanel.track(MISCELLANEOUS.OPEN_RECOMMENDED_PROFILES);

--- a/src/components/Messages/index.tsx
+++ b/src/components/Messages/index.tsx
@@ -98,7 +98,9 @@ const Messages: FC = () => {
           <div className="flex justify-between">
             <div className="font-black text-lg">Messages</div>
             <div>
-              <button className="text-xs border border-p-100 p-1 rounded">New Message</button>
+              <button className="text-xs border border-p-100 p-1 rounded" type="button">
+                New Message
+              </button>
             </div>
           </div>
           <div className="flex justify-between p-4">

--- a/src/components/Publication/PublicationStats.tsx
+++ b/src/components/Publication/PublicationStats.tsx
@@ -36,6 +36,7 @@ const PublicationStats: FC<Props> = ({ publication }) => {
       {mirrorCount > 0 && (
         <>
           <button
+            type="button"
             onClick={() => {
               setShowMirrorsModal(true);
               Mixpanel.track(PUBLICATION.STATS.MIRRORED_BY);
@@ -56,6 +57,7 @@ const PublicationStats: FC<Props> = ({ publication }) => {
       {reactionCount > 0 && (
         <>
           <button
+            type="button"
             onClick={() => {
               setShowLikesModal(true);
               Mixpanel.track(PUBLICATION.STATS.LIKED_BY);
@@ -76,6 +78,7 @@ const PublicationStats: FC<Props> = ({ publication }) => {
       {collectCount > 0 && (
         <>
           <button
+            type="button"
             onClick={() => {
               setShowCollectorsModal(true);
               Mixpanel.track(PUBLICATION.STATS.COLLECTED_BY);


### PR DESCRIPTION
## What does this PR do?

Added `Missing type attribute in button elements
JS-0390`

Resolves [JS-0390](https://deepsource.io/gh/lensterxyz/lenster/issue/JS-0390/occurrences?listindex=0)

