### PR TITLE
fix: text color and bg of explore tab in dark mode

### DIFF
--- a/src/components/Explore/FeedType.tsx
+++ b/src/components/Explore/FeedType.tsx
@@ -23,7 +23,7 @@ const FeedType: FC<Props> = ({ setFocus, focus }) => {
       }}
       className={clsx(
         { '!bg-brand-500 !text-white': focus === type },
-        'text-xs bg-brand-100 rounded-full px-3 sm:px-4 py-1.5 text-brand border border-brand-300'
+        'text-xs bg-brand-100 dark:bg-opacity-20 rounded-full px-3 sm:px-4 py-1.5 text-brand border border-brand-300 dark:border-brand-500'
       )}
       aria-label={name}
     >

--- a/src/components/Explore/index.tsx
+++ b/src/components/Explore/index.tsx
@@ -40,7 +40,7 @@ const Explore: NextPage = () => {
       />
       <GridItemEight className="space-y-5">
         <Tab.Group>
-          <Tab.List className="border-b space-x-8">
+          <Tab.List className="divider space-x-8">
             {tabs.map((tab, index) => (
               <Tab
                 key={index}
@@ -50,7 +50,7 @@ const Explore: NextPage = () => {
                 }}
                 className={({ selected }) =>
                   clsx(
-                    { 'border-b-2 border-brand-500 !text-black': selected },
+                    { 'border-b-2 border-brand-500 !text-black dark:!text-white': selected },
                     'px-4 pb-2 text-gray-500 outline-none font-medium text-sm'
                   )
                 }


### PR DESCRIPTION
<img width="794" alt="Screenshot 2022-10-14 at 8 05 41 PM" src="https://user-images.githubusercontent.com/69431456/195873060-a1de5642-9bce-4129-b36c-9ca54b0a78f3.png">
