### PR TITLE
chore: add missing type attribute in button elements

### DIFF
--- a/src/components/Composer/Post/New.tsx
+++ b/src/components/Composer/Post/New.tsx
@@ -27,7 +27,11 @@ interface ActionProps {
 
 const Action: FC<ActionProps> = ({ icon, text, onClick }) => (
   <Tooltip content={text} placement="top">
-    <button className="flex flex-col items-center text-gray-500 hover:text-brand-500" onClick={onClick}>
+    <button
+      className="flex flex-col items-center text-gray-500 hover:text-brand-500"
+      onClick={onClick}
+      type="button"
+    >
       {icon}
     </button>
   </Tooltip>

--- a/src/components/Messages/PreviewList.tsx
+++ b/src/components/Messages/PreviewList.tsx
@@ -41,7 +41,7 @@ const PreviewList: FC = () => {
       <Card className="h-[86vh]">
         <div className="flex justify-between items-center p-5 border-b">
           <div className="font-bold">Messages</div>
-          <button onClick={newMessageClick}>
+          <button onClick={newMessageClick} type="button">
             <PlusCircleIcon className="h-6 w-6" />
           </button>
         </div>


### PR DESCRIPTION
## What does this PR do?

Added missing `type` attribute in button elements

Fixes #887

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->


## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
