### PR TITLE
chore: remove == null check

### DIFF
--- a/src/components/utils/hooks/useSendMessage.tsx
+++ b/src/components/utils/hooks/useSendMessage.tsx
@@ -7,8 +7,12 @@ const useSendMessage = (conversation?: Conversation) => {
       if (!conversation) {
         return false;
       }
-      const sent = await conversation.send(message);
-      return sent != null;
+      try {
+        await conversation.send(message);
+      } catch (error) {
+        return false;
+      }
+      return true;
     },
     [conversation]
   );


### PR DESCRIPTION
## What does this PR do?

Use a try/catch to determine whether we want to toast a message failed to send error instead of a null check.

Fixes #886
