### PR TITLE
chore: use production messaging env on mainnet

### DIFF
--- a/src/components/utils/hooks/useXmtpClient.tsx
+++ b/src/components/utils/hooks/useXmtpClient.tsx
@@ -8,7 +8,9 @@ import { useSigner } from 'wagmi';
 
 const ENCODING = 'binary';
 
-const buildLocalStorageKey = (walletAddress: string) => `xmtp:keys:${walletAddress}`;
+const xmtpEnv = IS_MAINNET ? 'production' : 'dev';
+
+const buildLocalStorageKey = (walletAddress: string) => `xmtp:${xmtpEnv}:keys:${walletAddress}`;
 
 const loadKeys = (walletAddress: string): Uint8Array | null => {
   const val = localStorage.getItem(buildLocalStorageKey(walletAddress));
@@ -44,8 +46,7 @@ const useXmtpClient = () => {
           storeKeys(await signer.getAddress(), keys);
         }
 
-        const env = IS_MAINNET ? 'production' : 'dev';
-        const xmtp = await Client.create(null, { env: env, privateKeyOverride: keys });
+        const xmtp = await Client.create(null, { env: xmtpEnv, privateKeyOverride: keys });
         setClient(xmtp);
       }
     };

--- a/src/components/utils/hooks/useXmtpClient.tsx
+++ b/src/components/utils/hooks/useXmtpClient.tsx
@@ -8,9 +8,9 @@ import { useSigner } from 'wagmi';
 
 const ENCODING = 'binary';
 
-const xmtpEnv = IS_MAINNET ? 'production' : 'dev';
+const XMTP_ENV = IS_MAINNET ? 'production' : 'dev';
 
-const buildLocalStorageKey = (walletAddress: string) => `xmtp:${xmtpEnv}:keys:${walletAddress}`;
+const buildLocalStorageKey = (walletAddress: string) => `xmtp:${XMTP_ENV}:keys:${walletAddress}`;
 
 const loadKeys = (walletAddress: string): Uint8Array | null => {
   const val = localStorage.getItem(buildLocalStorageKey(walletAddress));
@@ -46,7 +46,7 @@ const useXmtpClient = () => {
           storeKeys(await signer.getAddress(), keys);
         }
 
-        const xmtp = await Client.create(null, { env: xmtpEnv, privateKeyOverride: keys });
+        const xmtp = await Client.create(null, { env: XMTP_ENV, privateKeyOverride: keys });
         setClient(xmtp);
       }
     };

--- a/src/components/utils/hooks/useXmtpClient.tsx
+++ b/src/components/utils/hooks/useXmtpClient.tsx
@@ -1,6 +1,7 @@
 import isFeatureEnabled from '@lib/isFeatureEnabled';
 import { Client } from '@xmtp/xmtp-js';
 import { useCallback, useEffect } from 'react';
+import { IS_MAINNET } from 'src/constants';
 import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 import { useSigner } from 'wagmi';
@@ -43,7 +44,8 @@ const useXmtpClient = () => {
           storeKeys(await signer.getAddress(), keys);
         }
 
-        const xmtp = await Client.create(null, { privateKeyOverride: keys });
+        const env = IS_MAINNET ? 'production' : 'dev';
+        const xmtp = await Client.create(null, { env: env, privateKeyOverride: keys });
         setClient(xmtp);
       }
     };


### PR DESCRIPTION
## What does this PR do?
This PR uses XMTP's `production` environment on mainnet and `dev` on testnet. Note: you'll have to re-sign after this since we're now storing creds per env. Also, mainnet messages will be reset.

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)

## How should this be tested?

- Ensure messages are still visible on testnet after another sig.
