### PR TITLE
fix: insert date divider before date's messages

### DIFF
--- a/src/components/Messages/MessagesList.tsx
+++ b/src/components/Messages/MessagesList.tsx
@@ -141,13 +141,14 @@ const MessagesList: FC<MessageListProps> = ({
           >
             {messages?.map((msg: Message, index: number) => {
               const dateHasChanged = lastMessageDate ? !isOnSameDay(lastMessageDate, msg.sent) : false;
-              lastMessageDate = msg.sent;
-              return (
+              const messageDiv = (
                 <div key={`${msg.id}_${index}`}>
                   <MessageTile currentProfile={currentProfile} profile={profile} message={msg} />
-                  {dateHasChanged ? <DateDivider date={msg.sent} /> : null}
+                  {dateHasChanged ? <DateDivider date={lastMessageDate} /> : null}
                 </div>
               );
+              lastMessageDate = msg.sent;
+              return messageDiv;
             })}
           </InfiniteScroll>
         </div>


### PR DESCRIPTION
## What does this PR do?

This PR updates our UI to insert the date divider when the date changes so that it now shows the messages for the given date below the divider. This matches how other messaging platforms render their dividers like Signal and will likely feel more intuitive.

| Before | After |
|--|--|
| <img width="831" alt="before" src="https://user-images.githubusercontent.com/556051/197234544-c2a2a688-adfe-4943-b1f2-3c4e31877c98.png">| <img width="823" alt="after" src="https://user-images.githubusercontent.com/556051/197234594-52fe1d84-22c9-4630-b160-53fb0cefc9d8.png">|
