### PR TITLE
chore: set XMTP environment consistently

### DIFF
--- a/src/components/Home/EnableMessages.tsx
+++ b/src/components/Home/EnableMessages.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
 import { useEffect, useState } from 'react';
+import { XMTP_ENV } from 'src/constants';
 import { useAppStore } from 'src/store/app';
 
 const EnableMessages: FC = () => {
@@ -21,7 +22,7 @@ const EnableMessages: FC = () => {
   useEffect(() => {
     const fetchCanMessage = async () => {
       setLoading(true);
-      const isMessagesEnabled = await Client.canMessage(currentProfile?.ownedBy);
+      const isMessagesEnabled = await Client.canMessage(currentProfile?.ownedBy, { env: XMTP_ENV });
       setCanMessage(isMessagesEnabled);
       setLoading(false);
     };

--- a/src/components/utils/hooks/useGetConversation.tsx
+++ b/src/components/utils/hooks/useGetConversation.tsx
@@ -2,6 +2,7 @@ import type { Profile } from '@generated/types';
 import { parseConversationKey } from '@lib/conversationKey';
 import { Client } from '@xmtp/xmtp-js';
 import { useEffect, useState } from 'react';
+import { XMTP_ENV } from 'src/constants';
 import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 
@@ -28,7 +29,7 @@ const useGetConversation = (conversationKey: string, profile?: Profile) => {
     }
     const createNewConversation = async () => {
       const conversationId = parseConversationKey(conversationKey)?.conversationId;
-      const canMessage = await Client.canMessage(profile.ownedBy);
+      const canMessage = await Client.canMessage(profile.ownedBy, { env: XMTP_ENV });
       setMissingXmtpAuth(!canMessage);
 
       if (!canMessage || !conversationId) {

--- a/src/components/utils/hooks/useXmtpClient.tsx
+++ b/src/components/utils/hooks/useXmtpClient.tsx
@@ -1,14 +1,12 @@
 import isFeatureEnabled from '@lib/isFeatureEnabled';
 import { Client } from '@xmtp/xmtp-js';
 import { useCallback, useEffect } from 'react';
-import { IS_MAINNET } from 'src/constants';
+import { XMTP_ENV } from 'src/constants';
 import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 import { useSigner } from 'wagmi';
 
 const ENCODING = 'binary';
-
-const XMTP_ENV = IS_MAINNET ? 'production' : 'dev';
 
 const buildLocalStorageKey = (walletAddress: string) => `xmtp:${XMTP_ENV}:keys:${walletAddress}`;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,9 @@ export const DEFAULT_COLLECT_TOKEN = getEnvConfig().defaultCollectToken;
 
 export const IS_MAINNET = API_URL === MAINNET_API_URL;
 
+// XMTP_NETWORK
+export const XMTP_ENV = IS_MAINNET ? 'production' : 'dev';
+
 // Application
 export const APP_NAME = 'Lenster';
 export const DESCRIPTION =


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I noticed that while the client SDK is set to the production network, some of the checks for whether a user is on the network were always set to the dev network. This is causing errors when trying to message a profile that is active on one network but not the other.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Attempt to message a Lens profile owned by a wallet that is using XMTP on the dev network but not the production network.
