### PR TITLE
chore: update copy around enabling dms

### DIFF
--- a/src/components/Home/EnableMessages.tsx
+++ b/src/components/Home/EnableMessages.tsx
@@ -43,7 +43,7 @@ const EnableMessages: FC = () => {
         <p>Direct messages are here!</p>
       </div>
       <p className="text-sm leading-[22px]">
-        Start sending DMs to your frens. Create your keys and enable your identity with XMTP to get started!
+        Create an XMTP account to start using Lenster to send DMs to frens.
       </p>
       <Button
         variant="success"

--- a/src/components/Messages/MessagesList.tsx
+++ b/src/components/Messages/MessagesList.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@components/UI/Card';
 import type { Profile } from '@generated/types';
-import { ExclamationIcon } from '@heroicons/react/solid';
+import { EmojiSadIcon } from '@heroicons/react/outline';
 import getAvatar from '@lib/getAvatar';
 import type { Message } from '@xmtp/xmtp-js';
 import clsx from 'clsx';
@@ -84,10 +84,10 @@ const DateDivider: FC<{ date?: Date }> = ({ date }) => (
 const MissingXmtpAuth: FC = () => (
   <Card as="aside" className="mb-4 border-gray-400 !bg-gray-300 !bg-opacity-20 space-y-2.5 p-5">
     <div className="flex items-center space-x-2 font-bold">
-      <ExclamationIcon className="w-5 h-5" />
-      <p>This profile has not enabled DMs yet</p>
+      <EmojiSadIcon className="w-5 h-5" />
+      <p>This fren hasn't enabled DMs yet</p>
     </div>
-    <p className="text-sm leading-[22px]">Messages can't be sent until they create their keys with XMTP.</p>
+    <p className="text-sm leading-[22px]">You can't send them a message until they enable DMs.</p>
   </Card>
 );
 


### PR DESCRIPTION
## What does this PR do?

Updates the copy in the two enable DMs panels.

| Home | Messaging |
|--|--|
| <img width="1497" alt="Screen Shot 2022-10-24 at 10 07 25 AM" src="https://user-images.githubusercontent.com/556051/197546809-fe9bfe61-bcaf-4958-9540-4a5500d68a18.png"> |  <img width="835" alt="Screen Shot 2022-10-24 at 10 08 30 AM" src="https://user-images.githubusercontent.com/556051/197546874-5823500e-a573-45ef-975c-a52d505a96df.png"> |

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)

## How should this be tested?

- [x] Create a new account and ensure enable DMs panel shows up on home
- [x] Tap enable dms, sign the message & ensure the panel disappears
- [x] Navigate to someone who has not enabled DMs yet and ensure the updated copy shows
