### PR TITLE
fix: remove fixed padding from top of message list

### DIFF
--- a/src/components/Messages/MessagesList.tsx
+++ b/src/components/Messages/MessagesList.tsx
@@ -92,13 +92,13 @@ const MissingXmtpAuth: FC = () => (
 );
 
 const ConversationBeginningNotice: FC = () => (
-  <div className="flex align-items-center justify-center pb-4">
+  <div className="flex align-items-center justify-center mt-6 pb-4">
     <span className="text-gray-300 text-sm font-bold">This is the beginning of the conversation</span>
   </div>
 );
 
 const LoadingMore: FC = () => (
-  <div className="p-1 text-center text-gray-300 font-bold text-sm">Loading...</div>
+  <div className="p-1 mt-6 text-center text-gray-300 font-bold text-sm">Loading...</div>
 );
 
 interface MessageListProps {
@@ -122,7 +122,7 @@ const MessagesList: FC<MessageListProps> = ({
 
   return (
     <div className="flex-grow flex h-[75%]">
-      <div className="relative w-full h-full bg-white pl-4 pt-6 flex">
+      <div className="relative w-full h-full bg-white pl-4 flex">
         <div
           id="scrollableDiv"
           className="flex flex-col h-full overflow-y-auto w-full"


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR removes the padding from the message list and instead adds top margin to the loading & end of list components. This allows the list to scroll under the header directly.

Fixes #911 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] Navigate to a conversation with >15 messages & notice the messages scroll under the header
- [x] Ensure there is still padding above the "The is the beginning of the conversation" & "Loading" items.
