### PR TITLE
fix: xmtp env mismatch

### DIFF
--- a/src/components/utils/hooks/useXmtpClient.tsx
+++ b/src/components/utils/hooks/useXmtpClient.tsx
@@ -42,7 +42,7 @@ const useXmtpClient = () => {
         let keys = loadKeys(await signer.getAddress());
         if (!keys) {
           setAwaitingXmtpAuth(true);
-          keys = await Client.getKeys(signer);
+          keys = await Client.getKeys(signer, { env: XMTP_ENV });
           storeKeys(await signer.getAddress(), keys);
         }
 


### PR DESCRIPTION
## What does this PR do?

Include the `env` option with XMTP `Client.getKeys` call, so that it's using the correct network.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't read the [contributing guide](https://github.com/lensterxyz/lenster/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
