### PR TITLE
fix: ellipsize preview list content

### DIFF
--- a/src/components/Messages/Preview.tsx
+++ b/src/components/Messages/Preview.tsx
@@ -9,7 +9,6 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
 import React from 'react';
-import { MESSAGE_PREVIEW_LENGTH } from 'src/constants';
 
 dayjs.extend(relativeTime);
 
@@ -28,31 +27,29 @@ const Preview: FC<Props> = ({ profile, message, conversationKey }) => {
 
   return (
     <div className="hover:bg-gray-100 py-3 cursor-pointer" onClick={() => onConversationSelected(profile.id)}>
-      <div className="flex justify-between space-x-1.5 px-5 flex-wrap">
-        <div className="flex items-center space-x-3">
-          <img
-            src={getAvatar(profile)}
-            loading="lazy"
-            className="w-10 h-10 bg-gray-200 rounded-full border dark:border-gray-700/80"
-            height={40}
-            width={40}
-            alt={profile?.handle}
-          />
-          <div>
-            <div className="flex gap-1 items-center max-w-sm truncate">
+      <div className="flex justify-between space-x-3 px-5">
+        <img
+          src={getAvatar(profile)}
+          loading="lazy"
+          className="w-10 h-10 bg-gray-200 rounded-full border dark:border-gray-700/80"
+          height={40}
+          width={40}
+          alt={profile?.handle}
+        />
+        <div className="w-full">
+          <div className="flex w-full justify-between space-x-1">
+            <div className="flex gap-1 items-center max-w-sm line-clamp-1">
               <div className={clsx('text-md')}>{profile?.name ?? profile.handle}</div>
               {isVerified(profile?.id) && <BadgeCheckIcon className="w-4 h-4 text-brand" />}
             </div>
-            <span className="text-sm text-gray-500 line-clamp-1">
-              {message.content && message.content.length > MESSAGE_PREVIEW_LENGTH
-                ? message.content.substring(0, MESSAGE_PREVIEW_LENGTH)
-                : message.content}
-            </span>
+            {message.sent && (
+              <span className="min-w-fit pt-0.5 text-xs text-gray-500">
+                {dayjs(new Date(message.sent)).fromNow()}
+              </span>
+            )}
           </div>
+          <span className="text-sm text-gray-500 line-clamp-1">{message.content}</span>
         </div>
-        {message.sent && (
-          <span className="min-w-fit text-xs text-gray-500">{dayjs(new Date(message.sent)).fromNow()}</span>
-        )}
       </div>
     </div>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -106,7 +106,6 @@ export const BUNDLR_NODE_URL = 'https://node2.bundlr.network';
 // UI
 export const MESSAGE_PAGE_LIMIT = 15;
 export const SCROLL_THRESHOLD = 0.5;
-export const MESSAGE_PREVIEW_LENGTH = 20;
 
 // Named transforms
 export const AVATAR = '250:250';


### PR DESCRIPTION
## What does this PR do?

Adds an ellipsis if the name or message content is too long in the preview list.

| Before | After |
|--|--|
| <img width="374" alt="Screen Shot 2022-10-27 at 11 50 36 AM" src="https://user-images.githubusercontent.com/556051/198338676-ba57379a-68d6-45e3-9475-3797f45a8c12.png"> | <img width="374" alt="Screen Shot 2022-10-27 at 11 49 22 AM" src="https://user-images.githubusercontent.com/556051/198338625-03f30bed-47cd-4806-b2c5-fc66b748bb61.png">