### PR TITLE
fix: verified badge in preview

### DIFF
--- a/src/components/Messages/Preview.tsx
+++ b/src/components/Messages/Preview.tsx
@@ -38,9 +38,9 @@ const Preview: FC<Props> = ({ profile, message, conversationKey }) => {
         />
         <div className="w-full">
           <div className="flex w-full justify-between space-x-1">
-            <div className="flex gap-1 items-center max-w-sm line-clamp-1">
-              <div className={clsx('text-md')}>{profile?.name ?? profile.handle}</div>
-              {isVerified(profile?.id) && <BadgeCheckIcon className="w-4 h-4 text-brand" />}
+            <div className="flex gap-1 items-center max-w-sm">
+              <div className={`line-clamp-1 ${clsx('text-md')}`}>{profile?.name ?? profile.handle}</div>
+              {isVerified(profile?.id) && <BadgeCheckIcon className="min-w-fit w-4 h-4 text-brand" />}
             </div>
             {message.sent && (
               <span className="min-w-fit pt-0.5 text-xs text-gray-500">


### PR DESCRIPTION
## What does this PR do?

This PR makes the verified badge appear on the same line as the profile name in the message preview list.

Fixes #973

<img width="387" alt="Screen Shot 2022-10-27 at 2 23 30 PM" src="https://user-images.githubusercontent.com/556051/198369614-43a85517-6260-4520-a8ba-74c2b174b057.png">
