### PR TITLE
chore: allowlist more xmtp testers

### DIFF
--- a/data/feature-flags.ts
+++ b/data/feature-flags.ts
@@ -20,7 +20,14 @@ export const featureFlags = [
       '0x010e75', // shash256.lens
       '0x010f89', // alohajha.lens
       '0x21ad', // galligan.lens
-      '0x77bd' // filiptronicek.lens
+      '0x77bd', // filiptronicek.lens
+      '0x016b0f', // prashantbagga.lens
+      '0x016b21', // snormore.lens
+      '0x016b23', // martink.lens
+      '0x016b25', // adamalix.lens
+      '0x016b24', // bhavyam.lens
+      '0x016b0b', // xmtplabs.lens
+      '0xf5ff' // anoopr.lens
     ]
   },
   {


### PR DESCRIPTION
## What does this PR do?
This PR adds a few new XMTP testers as well as a few duplicates for existing testers so we can test switching between multiple profiles.
