### PR TITLE
fix: reload the conversation previews after changing profiles

### DIFF
--- a/src/components/utils/hooks/useMessagePreviews.tsx
+++ b/src/components/utils/hooks/useMessagePreviews.tsx
@@ -51,7 +51,7 @@ const useMessagePreviews = () => {
     variables: {
       request: request
     },
-    skip: !currentProfile?.id || profileIds.size === 0,
+    skip: profileIds.size === 0 || currentProfile?.id !== selectedProfileId,
     onCompleted: (data) => {
       if (!data?.profiles?.items.length) {
         return;
@@ -186,10 +186,12 @@ const useMessagePreviews = () => {
   }, [client, currentProfile?.id, selectedProfileId]);
 
   useEffect(() => {
-    if (currentProfile?.id !== selectedProfileId) {
+    if (selectedProfileId && currentProfile?.id !== selectedProfileId) {
       reset();
       setSelectedProfileId(currentProfile?.id);
       router.push('/messages');
+    } else {
+      setSelectedProfileId(currentProfile?.id);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentProfile]);


### PR DESCRIPTION
## What does this PR do?
This PR fixes a small issue where the profile list wasn't refetching after changing profiles. It also makes it so we only re-route to /messages if there already was a selected profile.

https://user-images.githubusercontent.com/556051/198398584-48192701-49c3-49cc-81a3-793014f1db9a.mov

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)