### PR TITLE
fix: clear LocalStorage on other logout mechanisms

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -18,6 +18,7 @@ import Loading from './Loading';
 import GlobalModals from './Shared/GlobalModals';
 import Navbar from './Shared/Navbar';
 import useIsMounted from './utils/hooks/useIsMounted';
+import { useDisconnectXmtp } from './utils/hooks/useXmtpClient';
 
 interface Props {
   children: ReactNode;
@@ -37,6 +38,7 @@ const Layout: FC<Props> = ({ children }) => {
   const { address, isDisconnected } = useAccount();
   const { chain } = useNetwork();
   const { disconnect } = useDisconnect();
+  const disconnectXmtp = useDisconnectXmtp();
 
   const resetAuthState = () => {
     setProfileId(null);
@@ -79,6 +81,7 @@ const Layout: FC<Props> = ({ children }) => {
 
     // If there are no auth data, clear and logout
     if (shouldLogout && profileId) {
+      disconnectXmtp();
       resetAuthState();
       resetAuthData();
       disconnect?.();

--- a/src/components/Settings/Delete/index.tsx
+++ b/src/components/Settings/Delete/index.tsx
@@ -7,6 +7,7 @@ import { GridItemEight, GridItemFour, GridLayout } from '@components/UI/GridLayo
 import { Modal } from '@components/UI/Modal';
 import { Spinner } from '@components/UI/Spinner';
 import { WarningMessage } from '@components/UI/WarningMessage';
+import { useDisconnectXmtp } from '@components/utils/hooks/useXmtpClient';
 import MetaTags from '@components/utils/MetaTags';
 import type { Mutation } from '@generated/types';
 import { CreateBurnProfileTypedDataDocument } from '@generated/types';
@@ -32,6 +33,7 @@ const DeleteSettings: FC = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const setCurrentProfile = useAppStore((state) => state.setCurrentProfile);
   const setProfileId = useAppPersistStore((state) => state.setProfileId);
+  const disconnectXmtp = useDisconnectXmtp();
 
   const { disconnect } = useDisconnect();
   const { isLoading: signLoading, signTypedDataAsync } = useSignTypedData({ onError });
@@ -39,6 +41,7 @@ const DeleteSettings: FC = () => {
   const onCompleted = () => {
     setCurrentProfile(null);
     setProfileId(null);
+    disconnectXmtp();
     resetAuthData();
     disconnect?.();
     location.href = '/';


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Wipes keys from one of the locations recommended in https://github.com/lensterxyz/lenster/issues/912.

I'm not sure we need to wipe the keys in the other two locations. Our keys in localStorage are prefixed with both the environment and the wallet address, so if a user changes chains or changes wallets the old keys will not be used. In cases where the auth token is expired, we can keep the keys in storage and re-use them when the user logs back in. The client will be unset on any form of logout through [this line](https://github.com/lensterxyz/lenster/blob/clear-localstorage-on-all-logout-methods/src/components/utils/hooks/useXmtpClient.tsx#L61:L61)

Let me know what you think?

Fixes # (issue)
https://github.com/lensterxyz/lenster/issues/912.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Use the delete button on the settings page. Ensure no xmtp keys are present in LocalStorage after.

## Checklist

