### PR TITLE
Wipe out message when changing conversations

### DIFF
--- a/src/components/Messages/Composer.tsx
+++ b/src/components/Messages/Composer.tsx
@@ -3,14 +3,15 @@ import { Input } from '@components/UI/Input';
 import { Spinner } from '@components/UI/Spinner';
 import { ArrowRightIcon } from '@heroicons/react/outline';
 import type { FC } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 
 interface Props {
   sendMessage: (message: string) => Promise<boolean>;
+  conversationKey: string;
 }
 
-const Composer: FC<Props> = ({ sendMessage }) => {
+const Composer: FC<Props> = ({ sendMessage, conversationKey }) => {
   const [message, setMessage] = useState<string>('');
   const [sending, setSending] = useState<boolean>(false);
 
@@ -29,6 +30,10 @@ const Composer: FC<Props> = ({ sendMessage }) => {
     }
     setSending(false);
   };
+
+  useEffect(() => {
+    setMessage('');
+  }, [conversationKey]);
 
   const handleKeyDown = (event: { key: string }) => {
     if (event.key === 'Enter') {

--- a/src/components/Messages/Message.tsx
+++ b/src/components/Messages/Message.tsx
@@ -77,7 +77,7 @@ const Message: FC<MessageProps> = ({ conversationKey }) => {
                 hasMore={hasMore}
                 missingXmtpAuth={missingXmtpAuth ?? false}
               />
-              <Composer sendMessage={sendMessage} />
+              <Composer sendMessage={sendMessage} conversationKey={conversationKey} />
             </>
           )}
         </Card>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- When changing between conversations, the message composer box was being carried over. This fixes that to wipe the message composer box any time you change conversations.
- We may want to actually store this as state, so that the user can continue composing when they navigate back. I'm going to create a separate ticket for that and we can prioritize as necessary.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

### Before

https://user-images.githubusercontent.com/65710/198716769-e865a5f8-78eb-4ffb-bfd9-c414024506b6.mp4


### After

https://user-images.githubusercontent.com/65710/198716868-fcaa0757-21e5-4093-9094-ad0d36a798a3.mp4


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Start typing in one conversation, but don't send. Change to another conversation. The half-finished message should be cleared.
