### PR TITLE
fix: useMessagePreviews loading state

### DIFF
--- a/src/components/utils/hooks/useMessagePreviews.tsx
+++ b/src/components/utils/hooks/useMessagePreviews.tsx
@@ -34,7 +34,7 @@ const useMessagePreviews = () => {
   const [conversationStream, setConversationStream] = useState<Stream<Conversation>>();
   // TODO: Remove this and replace with streamAllMessages. Just need to make some changes in xmtp-js first
   const [messageStreams, setMessageStreams] = useState<Map<string, Stream<DecodedMessage>>>(new Map());
-  const [messagesLoading, setMessagesLoading] = useState<boolean>();
+  const [messagesLoading, setMessagesLoading] = useState<boolean>(true);
 
   const getProfileFromKey = (key: string): string | null => {
     const parsed = parseConversationKey(key);


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- When the `useMessagePreviews` hook is initially loaded, the `loading` state is set to false until the effects are run. These leads to a brief period where the state is not loading but there are no messages. This causes the UI to show the empty inbox state, when it in fact should be loading.

Fixes https://github.com/lensterxyz/lenster/issues/971

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
### After
https://user-images.githubusercontent.com/65710/198720627-8a9c0909-696e-4859-ba29-e16f9a30d502.mp4


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to the messages page for a profile with some message history. The "Start messaging your Lens frens" message should never appear, and the left panel should be initialized in a loading state
- [ ] Go to the messages page for a profile with no message history. After loading, the "Start messaging your Lens frens" message should appear
