### PR TITLE
fix: light mode styles in dark mode

### DIFF
--- a/src/components/Messages/MessagesList.tsx
+++ b/src/components/Messages/MessagesList.tsx
@@ -125,7 +125,7 @@ const MessagesList: FC<MessageListProps> = ({
 
   return (
     <div className="flex-grow flex h-[75%]">
-      <div className="relative w-full h-full bg-white pl-4 flex">
+      <div className="relative w-full h-full pl-4 flex">
         <div
           id="scrollableDiv"
           className="flex flex-col h-full overflow-y-auto w-full"

--- a/src/components/Messages/Preview.tsx
+++ b/src/components/Messages/Preview.tsx
@@ -26,7 +26,10 @@ const Preview: FC<Props> = ({ profile, message, conversationKey }) => {
   };
 
   return (
-    <div className="hover:bg-gray-100 py-3 cursor-pointer" onClick={() => onConversationSelected(profile.id)}>
+    <div
+      className="hover:bg-gray-100 dark:hover:bg-gray-800 py-3 cursor-pointer"
+      onClick={() => onConversationSelected(profile.id)}
+    >
       <div className="flex justify-between space-x-3 px-5">
         <img
           src={getAvatar(profile)}


### PR DESCRIPTION
## What does this PR do?

Fixes background in messages list and conversation preview hover state while in dark mode.

|Before|After|
|-|-|
|<img width="1242" alt="CleanShot 2022-10-29 at 18 14 18@2x" src="https://user-images.githubusercontent.com/510695/198858285-06146b5f-3ee2-497b-a5f2-c0a2b24beb47.png">|<img width="1261" alt="CleanShot 2022-10-29 at 18 14 02@2x" src="https://user-images.githubusercontent.com/510695/198858293-3355d248-9316-4ac1-a576-61ab6a3d735c.png">|

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Switch to dark mode
- [ ] Open a conversation and see that the messages list background is dark
- [ ] Hover mouse over the conversation preview card and see that the hover state is dark