### PR TITLE
chore: update enable dm copy

### DIFF
--- a/data/feature-flags.ts
+++ b/data/feature-flags.ts
@@ -27,7 +27,8 @@ export const featureFlags = [
       '0x016b25', // adamalix.lens
       '0x016b24', // bhavyam.lens
       '0x016b0b', // xmtplabs.lens
-      '0xf5ff' // anoopr.lens
+      '0xf5ff', // anoopr.lens
+      '0x0122d4' // darick.lens
     ]
   },
   {

--- a/src/components/Home/EnableMessages.tsx
+++ b/src/components/Home/EnableMessages.tsx
@@ -43,7 +43,7 @@ const EnableMessages: FC = () => {
         <p>Direct messages are here!</p>
       </div>
       <p className="text-sm leading-[22px]">
-        Create an XMTP account to start using Lenster to send DMs to frens.
+        Activate XMTP to start using Lenster to send end-to-end encrypted DMs to frens.
       </p>
       <Button
         variant="success"

--- a/src/components/Home/EnableMessages.tsx
+++ b/src/components/Home/EnableMessages.tsx
@@ -42,7 +42,7 @@ const EnableMessages: FC = () => {
         <MailOpenIcon className="w-5 h-5" />
         <p>Direct messages are here!</p>
       </div>
-      <p className="text-sm leading-[22px]">
+      <p className="text-sm leading-[22px] mr-10">
         Activate XMTP to start using Lenster to send end-to-end encrypted DMs to frens.
       </p>
       <Button


### PR DESCRIPTION
## What does this PR do?

Updates Enable DMs panel with revised copy from XMTP.

<img width="409" alt="CleanShot 2022-10-29 at 22 51 52@2x" src="https://user-images.githubusercontent.com/510695/198864685-3e27d73e-4c50-4059-af8b-1e44b6f1fb3c.png">

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Log in with an account that has not enabled DMs.
- [ ] See that the Enable DMs panel copy says "Activate XMTP to start using Lenster to send end-to-end encrypted DMs to frens."