### PR TITLE
feat: disambiguate sender in preview tile

### DIFF
--- a/src/components/Messages/Preview.tsx
+++ b/src/components/Messages/Preview.tsx
@@ -9,6 +9,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
 import React from 'react';
+import { useAppStore } from 'src/store/app';
 
 dayjs.extend(relativeTime);
 
@@ -20,6 +21,8 @@ interface Props {
 
 const Preview: FC<Props> = ({ profile, message, conversationKey }) => {
   const router = useRouter();
+  const currentProfile = useAppStore((state) => state.currentProfile);
+  const address = currentProfile?.ownedBy;
 
   const onConversationSelected = (profileId: string) => {
     router.push(profileId ? `/messages/${conversationKey}` : '/messages');
@@ -51,7 +54,9 @@ const Preview: FC<Props> = ({ profile, message, conversationKey }) => {
               </span>
             )}
           </div>
-          <span className="text-sm text-gray-500 line-clamp-1">{message.content}</span>
+          <span className="text-sm text-gray-500 line-clamp-1">
+            {address === message.senderAddress && 'You: '} {message.content}
+          </span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What does this PR do?

Disambiguates the message sender in the preview tile by prepending "You: " if the message was sent by the current user. This design pattern is used in Twitter DMs and Signal.

<img width="403" alt="CleanShot 2022-10-29 at 23 37 17@2x" src="https://user-images.githubusercontent.com/510695/198865874-beb6d3c4-877f-4c46-ad81-9a2208de4835.png">

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)

## How should this be tested?

- [ ] Send a message from Profile A to Profile B
- [ ] As Profile A, confirm "You: " **is seen** before the message content in the message preview tile
- [ ] Switch to Profile B
- [ ] As Profile B, confirm "You: " **is not seen** before the message content in the message preview tile