### PR TITLE
feat: clickable links in messages

### DIFF
--- a/src/components/Messages/MessagesList.tsx
+++ b/src/components/Messages/MessagesList.tsx
@@ -51,7 +51,7 @@ const MessageTile: FC<MessageTileProps> = ({ message, profile, currentProfile })
           <span
             className={clsx(
               address === message.senderAddress ? 'text-white' : 'text-black',
-              'block text-md break-all linkify-message'
+              'block text-md break-words linkify-message'
             )}
           >
             {message.error

--- a/src/components/Messages/MessagesList.tsx
+++ b/src/components/Messages/MessagesList.tsx
@@ -1,3 +1,4 @@
+import Markup from '@components/Shared/Markup';
 import { Card } from '@components/UI/Card';
 import type { Profile } from '@generated/types';
 import { EmojiSadIcon } from '@heroicons/react/outline';
@@ -50,10 +51,12 @@ const MessageTile: FC<MessageTileProps> = ({ message, profile, currentProfile })
           <span
             className={clsx(
               address === message.senderAddress ? 'text-white' : 'text-black',
-              'block text-md break-all'
+              'block text-md break-all linkify-message'
             )}
           >
-            {message.error ? `Error: ${message.error?.message}` : message.content ?? ''}
+            {message.error
+              ? `Error: ${message.error?.message}`
+              : <Markup matchOnlyUrl>{message.content}</Markup> ?? ''}
           </span>
         </div>
       </div>

--- a/src/components/Shared/Markup.tsx
+++ b/src/components/Shared/Markup.tsx
@@ -14,26 +14,29 @@ import type { FC, MouseEvent } from 'react';
 interface Props {
   children: string;
   className?: string;
+  matchOnlyUrl?: boolean;
 }
 
-const Markup: FC<Props> = ({ children, className = '' }) => {
+const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
+  const defaultMatchers = [
+    new HashtagMatcher('hashtag'),
+    new MentionMatcher('mention'),
+    new MDBoldMatcher('mdBold'),
+    new MDLinkMatcher('mdLink'),
+    new MDStrikeMatcher('mdStrike'),
+    new MDQuoteMatcher('mdQuote'),
+    new MDCodeMatcher('mdCode'),
+    new SpoilerMatcher('spoiler'),
+    new UrlMatcher('url')
+  ];
+
   return (
     <Interweave
       className={className}
       content={trimify(children)}
       escapeHtml
       allowList={['b', 'i', 'a', 'br', 'code', 'span']}
-      matchers={[
-        new HashtagMatcher('hashtag'),
-        new MentionMatcher('mention'),
-        new MDBoldMatcher('mdBold'),
-        new MDLinkMatcher('mdLink'),
-        new MDStrikeMatcher('mdStrike'),
-        new MDQuoteMatcher('mdQuote'),
-        new MDCodeMatcher('mdCode'),
-        new SpoilerMatcher('spoiler'),
-        new UrlMatcher('url')
-      ]}
+      matchers={matchOnlyUrl ? [new UrlMatcher('url')] : defaultMatchers}
       onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
     />
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -33,6 +33,10 @@ body {
   @apply hover:text-brand-600 dark:hover:text-brand-500;
 }
 
+.linkify-message a {
+  @apply hover:text-brand-600 dark:hover:text-brand-500;
+}
+
 .identicon {
   width: 100% !important;
   height: 100% !important;


### PR DESCRIPTION
## What does this PR do?

- Uses the `Markup` shared component to make URLs clickable in messages
- Does not apply the other markdown styles (let's leave that for another day)

Fixes #948 

![CleanShot 2022-10-30 at 14 55 18](https://user-images.githubusercontent.com/510695/198903396-dedeed8a-b8c7-4de8-99d3-a4b2cb98356d.gif)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Send a message including a URL
- [ ] Hover over the URL to see that it is clickable
- [ ] Click the URL to see that it loads