### PR TITLE
fix: hover state on disabled send button

### DIFF
--- a/src/components/Messages/Composer.tsx
+++ b/src/components/Messages/Composer.tsx
@@ -52,7 +52,13 @@ const Composer: FC<Props> = ({ sendMessage, conversationKey, disabledInput }) =>
         onKeyDown={handleKeyDown}
         onChange={(event) => setMessage(event.target.value)}
       />
-      <Button disabled={!canSendMessage} onClick={handleSend} variant="primary" aria-label="Send message">
+      <Button
+        disabled={!canSendMessage}
+        onClick={handleSend}
+        variant="primary"
+        className="disabled:bg-brand-500"
+        aria-label="Send message"
+      >
         <div className="flex items-center space-x-2">
           <span>Send</span>
           {!sending && <ArrowRightIcon className="h-5 w-5" />}


### PR DESCRIPTION
## What does this PR do?

When the "Send" button is disabled because the recipient has not enabled DMs, it should not have a hover state, because it cannot be activated.

### Before

![CleanShot 2022-10-30 at 21 14 48](https://user-images.githubusercontent.com/510695/198929712-1375bf3a-bfd9-4d77-ab25-49d841cc7b11.gif)

### After

![CleanShot 2022-10-30 at 21 12 23](https://user-images.githubusercontent.com/510695/198929562-af7bacb1-1c8d-491c-bffb-3e3ce703e312.gif)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Select a recipient who does not have DMs enabled
- [ ] See that the "Send" button is disabled
- [ ] Hover over the disabled "Send" button and see that it does not enter a hover state