### PR TITLE
doc: empty feed typo fix

### DIFF
--- a/src/components/Profile/Feed.tsx
+++ b/src/components/Profile/Feed.tsx
@@ -68,7 +68,7 @@ const Feed: FC<Props> = ({ profile, type }) => {
         message={
           <div>
             <span className="mr-1 font-bold">@{profile?.handle}</span>
-            <span>doesn’t {type.toLowerCase()}ed yet!</span>
+            <span>hasn’t {type.toLowerCase()}ed yet!</span>
           </div>
         }
         icon={<CollectionIcon className="w-8 h-8 text-brand" />}


### PR DESCRIPTION
## What does this PR do?

Updates empty state message to "Profile hasn't feeded yet" as opposed to "Profile doesn't feeded yet"

Fixes #1032  (issue)


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Visit a profile with no posts and take a look at the feed tab.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
