### PR TITLE
feat: adding hover states to top navigation icons

### DIFF
--- a/src/components/Notification/Icon.tsx
+++ b/src/components/Notification/Icon.tsx
@@ -27,7 +27,7 @@ const NotificationIcon: FC = () => {
   return (
     <Link
       href="/notifications"
-      className="flex items-start"
+      className="flex items-start rounded-md hover:bg-gray-300 p-1 hover:bg-opacity-20"
       onClick={() => {
         setNotificationCount(data?.notifications?.pageInfo?.totalCount || 0);
         setShowBadge(false);

--- a/src/components/Shared/Navbar/index.tsx
+++ b/src/components/Shared/Navbar/index.tsx
@@ -99,11 +99,11 @@ const Navbar: FC = () => {
                   </div>
                 </div>
               </div>
-              <div className="flex gap-8 items-center">
+              <div className="flex gap-6 items-center">
                 {currentProfile ? (
                   <>
                     {isFeatureEnabled('messages', currentProfile?.id) && (
-                      <Link href="/messages">
+                      <Link href="/messages" className="rounded-md hover:bg-gray-300 p-1 hover:bg-opacity-20">
                         <MailIcon className="w-5 h-5 sm:w-6 sm:h-6" />
                       </Link>
                     )}


### PR DESCRIPTION
## What does this PR do?

Adds hover states for the notification and message icons in the top navigation bar using the current implementation for hover states on icons on desktop.

Fixes # (issue)

The current top navigation bar icons do not have a hover state on desktop.

Here is the current implementation of hover states on icon-only links/buttons:

<img width="224" alt="Screen Shot 2022-10-31 at 9 16 32 AM" src="https://user-images.githubusercontent.com/1136890/199074147-c5eea985-dc30-4686-87af-461ccce286a3.png">

Here's that same implementation added to the top navigation icons on desktop:

Notifications icon hovered:
<img width="134" alt="Screen Shot 2022-10-31 at 10 45 09 AM" src="https://user-images.githubusercontent.com/1136890/199074383-ff79bf8c-af87-47c2-9fdf-c152c48bb9ed.png">

Messages icon hovered:
<img width="110" alt="Screen Shot 2022-10-31 at 9 34 21 AM" src="https://user-images.githubusercontent.com/1136890/199074469-7f72467f-dd2c-4869-93ea-816b20bf4807.png">

Known issues:

- The notifications icon looks a bit odd when hovered with a badge but this would require a bit more planning to re-code/redesign how icons are treated on the app

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] Hover over the messages icon in the top navigation bar on a desktop browser
- [ ] Hover over the notifications icon in the top navigation bar on a desktop browser

## Checklist

- I haven't checked if new and existing unit tests pass locally with my changes