### PR TITLE
fix: DM page title while loading

### DIFF
--- a/src/components/Messages/Message.tsx
+++ b/src/components/Messages/Message.tsx
@@ -57,8 +57,8 @@ const Message: FC<MessageProps> = ({ conversationKey }) => {
 
   const showLoading = !missingXmtpAuth && (!profile || !currentProfile || !selectedConversation);
 
-  const profileName = profile?.name ?? profile?.handle;
-  const title = profileName ? `${profileName} • ${APP_NAME}` : APP_NAME;
+  const userNameForTitle = profile?.name ?? profile?.handle;
+  const title = userNameForTitle ? `${userNameForTitle} • ${APP_NAME}` : APP_NAME;
 
   return (
     <GridLayout classNameChild="md:gap-8">

--- a/src/components/Messages/Message.tsx
+++ b/src/components/Messages/Message.tsx
@@ -57,9 +57,12 @@ const Message: FC<MessageProps> = ({ conversationKey }) => {
 
   const showLoading = !missingXmtpAuth && (!profile || !currentProfile || !selectedConversation);
 
+  const profileName = profile?.name ?? profile?.handle;
+  const title = profileName ? `${profileName} • ${APP_NAME}` : APP_NAME;
+
   return (
     <GridLayout classNameChild="md:gap-8">
-      <MetaTags title={`${profile?.name ?? profile?.handle} • ${APP_NAME}`} />
+      <MetaTags title={title} />
       <PreviewList className="md:block sm:hidden xs:hidden" />
       <GridItemEight className="xs:h-[85vh] sm:h-[76vh] md:h-[80vh] xl:h-[84vh] mb-0 md:col-span-8 sm:mx-2 xs:mx-2">
         <Card className="h-full flex justify-between flex-col">


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Previously the page title would show `undefined • Lenster` while the page was still in a loading state. This updates the logic to only show the profile name/title once the profile has fully loaded.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://user-images.githubusercontent.com/65710/199076560-a5e3c3dd-4abe-4c6e-83f0-bb664a455d2e.mp4


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Go to a messaging page with another user. Refresh the page. Title should not include the word `undefined` anywhere
