### PR TITLE
fix: remove "This is the beginning of the conversation" flicker

### DIFF
--- a/src/components/utils/hooks/useGetMessages.tsx
+++ b/src/components/utils/hooks/useGetMessages.tsx
@@ -15,8 +15,6 @@ const useGetMessages = (conversationKey: string, conversation?: Conversation, en
     }
 
     const loadMessages = async () => {
-      hasMore.set(conversationKey, true);
-      setHasMore(new Map(hasMore));
       const newMessages = await conversation.messages({
         direction: SortDirection.SORT_DIRECTION_DESCENDING,
         limit: MESSAGE_PAGE_LIMIT,
@@ -26,6 +24,9 @@ const useGetMessages = (conversationKey: string, conversation?: Conversation, en
         addMessages(conversationKey, newMessages);
         if (newMessages.length < MESSAGE_PAGE_LIMIT) {
           hasMore.set(conversationKey, false);
+          setHasMore(new Map(hasMore));
+        } else {
+          hasMore.set(conversationKey, true);
           setHasMore(new Map(hasMore));
         }
       } else {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- The "This is the beginning of the conversation" text would flicker when the page was loaded. This changes around the behaviour of the `hasMore` property so that it doesn't toggle between `true` and `false` while the first page is loading. 

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://user-images.githubusercontent.com/65710/199080609-30590d07-1405-4639-bcfb-4afc2273635c.mp4

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Go to a conversation with more than 15 messages. Reload the page and scroll to the top. All messages should be displayed
- [x] Go to a conversation with more than 30 messages. Reload the page and scroll to the top. All messages should be displayed
- [x] Go to a conversation with less than 15 messages. There should be no flicker on the "This is the beginning of the conversation" text when loading.
