### PR TITLE
fix: movement in nav icons on show badge true

### DIFF
--- a/src/components/Notification/Icon.tsx
+++ b/src/components/Notification/Icon.tsx
@@ -27,7 +27,7 @@ const NotificationIcon: FC = () => {
   return (
     <Link
       href="/notifications"
-      className="flex items-start rounded-md hover:bg-gray-300 p-1 hover:bg-opacity-20"
+      className="flex items-start justify-center rounded-md hover:bg-gray-300 p-1 hover:bg-opacity-20 min-w-[40px]"
       onClick={() => {
         setNotificationCount(data?.notifications?.pageInfo?.totalCount || 0);
         setShowBadge(false);


### PR DESCRIPTION
## What does this PR do?

Fixes the movement in the nav icons on the badge show, hide

Fixes # (issue)

Fixes this jitter

https://user-images.githubusercontent.com/510695/198705860-25b1d211-038f-451d-a064-9757c0d5e362.gif

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [ ] See if icons move when the badge is shown/hidden (The movement in the notification icon itself is expected as I am centering the content)
