### PR TITLE
revert: redirect to first conversation

### DIFF
--- a/src/components/Messages/PreviewList.tsx
+++ b/src/components/Messages/PreviewList.tsx
@@ -7,7 +7,6 @@ import { GridItemFour } from '@components/UI/GridLayout';
 import { Modal } from '@components/UI/Modal';
 import { PageLoading } from '@components/UI/PageLoading';
 import useMessagePreviews from '@components/utils/hooks/useMessagePreviews';
-import useWindowSize from '@components/utils/hooks/useWindowSize';
 import type { Profile } from '@generated/types';
 import { MailIcon, PlusCircleIcon } from '@heroicons/react/outline';
 import buildConversationId from '@lib/buildConversationId';
@@ -17,7 +16,6 @@ import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
 import { useEffect, useState } from 'react';
-import { MIN_WIDTH_DESKTOP } from 'src/constants';
 import Custom404 from 'src/pages/404';
 import Custom500 from 'src/pages/500';
 import { useAppStore } from 'src/store/app';
@@ -35,7 +33,6 @@ const PreviewList: FC<Props> = ({ className, selectedConversationKey }) => {
   const setMessageProfiles = useMessageStore((state) => state.setMessageProfiles);
   const [showSearchModal, setShowSearchModal] = useState(false);
   const { authenticating, loading, messages, profiles, profilesError } = useMessagePreviews();
-  const { width } = useWindowSize();
   const clearMessagesBadge = useMessagePersistStore((state) => state.clearMessagesBadge);
   const isMessagesEnabled = isFeatureEnabled('messages', currentProfile?.id);
 
@@ -44,20 +41,6 @@ const PreviewList: FC<Props> = ({ className, selectedConversationKey }) => {
     const messageB = messages.get(keyB);
     return (messageA?.sent?.getTime() || 0) >= (messageB?.sent?.getTime() || 0) ? -1 : 1;
   });
-
-  useEffect(() => {
-    // Ignore this hook on mobile, since we use the /messages route to show the conversation list
-    if (!width || width < MIN_WIDTH_DESKTOP) {
-      return;
-    }
-    // If the user is on the /messages route and there are profiles, redirect to the top sorted one
-    // TODO: Move this to a higher component once we merge Message.tsx and index.tsx into a single view
-    if (router.pathname === '/messages' && sortedProfiles.length) {
-      const [conversationKey] = sortedProfiles[0];
-      router.push(`/messages/${conversationKey}`);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sortedProfiles, router.pathname, width]);
 
   useEffect(() => {
     if (!isMessagesEnabled || !currentProfile) {

--- a/src/components/Messages/index.tsx
+++ b/src/components/Messages/index.tsx
@@ -13,7 +13,7 @@ const NoConversationSelected = () => {
   return (
     <div className="text-center flex flex-col h-full">
       <div className="m-auto">
-        <span className="text-5xl text-center">👋🏻</span>
+        <span className="text-5xl text-center">👋</span>
         <h3 className="text-lg mt-3 mb-2">Select a conversation</h3>
         <p className="max-w-xs text-md text-gray-500">
           Choose an existing conversation or create a new one to start messaging

--- a/src/components/Messages/index.tsx
+++ b/src/components/Messages/index.tsx
@@ -9,6 +9,20 @@ import { useAppStore } from 'src/store/app';
 
 import PreviewList from './PreviewList';
 
+const NoConversationSelected = () => {
+  return (
+    <div className="text-center flex flex-col h-full">
+      <div className="m-auto">
+        <span className="text-5xl text-center">👋🏻</span>
+        <h3 className="text-lg mt-3 mb-2">Select a conversation</h3>
+        <p className="max-w-xs text-md text-gray-500">
+          Choose an existing conversation or create a new one to start messaging
+        </p>
+      </div>
+    </div>
+  );
+};
+
 const Messages: NextPage = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
 
@@ -22,7 +36,7 @@ const Messages: NextPage = () => {
       <PreviewList />
       <GridItemEight className="sm:h-[76vh] md:h-[80vh] xl:h-[84vh] mb-0 md:col-span-8 lg:block md:hidden sm:hidden xs:hidden sm:mx-2 xs:mx-2">
         <Card className="h-full">
-          <div />
+          <NoConversationSelected />
         </Card>
       </GridItemEight>
     </GridLayout>


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- No longer redirects to the first conversation in the list
- Adds an empty state for the Messages page

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://user-images.githubusercontent.com/65710/199570760-daa660a6-01d9-4644-85d8-50f710e5a548.mp4


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Navigate to `/messages` on desktop. The empty state should be displayed and no redirect should happen
