### PR TITLE
fix: break up profiles into batches of 50

### DIFF
--- a/src/components/utils/hooks/useMessagePreviews.tsx
+++ b/src/components/utils/hooks/useMessagePreviews.tsx
@@ -76,7 +76,7 @@ const useMessagePreviews = () => {
         );
 
         for (const result of results) {
-          if (!result.data?.profiles.items) {
+          if (!result.data?.profiles.items.length) {
             continue;
           }
 

--- a/src/components/utils/hooks/useMessagePreviews.tsx
+++ b/src/components/utils/hooks/useMessagePreviews.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react';
 import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 
-const MAX_PROFILES_TO_LOAD_CONCURRENTLY = 50;
+const MAX_PROFILES_PER_REQUEST = 50;
 
 const useMessagePreviews = () => {
   const router = useRouter();
@@ -64,7 +64,7 @@ const useMessagePreviews = () => {
     const loadLatest = async () => {
       setProfilesLoading(true);
       const newMessageProfiles = new Map(messageProfiles);
-      const chunks = chunkArray(toQuery, MAX_PROFILES_TO_LOAD_CONCURRENTLY);
+      const chunks = chunkArray(toQuery, MAX_PROFILES_PER_REQUEST);
       try {
         const results = await Promise.all(
           chunks.map((profileIdChunk) =>

--- a/src/components/utils/hooks/useMessagePreviews.tsx
+++ b/src/components/utils/hooks/useMessagePreviews.tsx
@@ -13,7 +13,7 @@ import { useEffect, useState } from 'react';
 import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 
-const MAX_PREVIEWS_TO_LOAD = 50;
+const MAX_PROFILES_TO_LOAD_CONCURRENTLY = 3;
 
 const useMessagePreviews = () => {
   const router = useRouter();
@@ -66,7 +66,7 @@ const useMessagePreviews = () => {
       while (toQuery.length) {
         try {
           // Remove 50 items at a time from the list
-          const batch = toQuery.splice(0, MAX_PREVIEWS_TO_LOAD);
+          const batch = toQuery.splice(0, MAX_PROFILES_TO_LOAD_CONCURRENTLY);
           const result = await apolloClient.query({
             query: ProfilesDocument,
             variables: { request: { profileIds: batch } }
@@ -75,7 +75,6 @@ const useMessagePreviews = () => {
           if (!result.data?.profiles.items) {
             break;
           }
-
           const profiles = result.data.profiles.items as Profile[];
           for (const profile of profiles) {
             const peerAddress = profile.ownedBy as string;

--- a/src/components/utils/hooks/useMessagePreviews.tsx
+++ b/src/components/utils/hooks/useMessagePreviews.tsx
@@ -50,21 +50,20 @@ const useMessagePreviews = () => {
     if (profilesLoading) {
       return;
     }
-    const allProfileIds = new Set(profileIds);
+    const toQuery = new Set(profileIds);
     // Don't both querying for already seen profiles
     for (const profile of messageProfiles.values()) {
-      allProfileIds.delete(profile.id);
+      toQuery.delete(profile.id);
     }
 
-    const toQuery = Array.from(allProfileIds);
-    if (!toQuery.length) {
+    if (!toQuery.size) {
       return;
     }
 
     const loadLatest = async () => {
       setProfilesLoading(true);
       const newMessageProfiles = new Map(messageProfiles);
-      const chunks = chunkArray(toQuery, MAX_PROFILES_PER_REQUEST);
+      const chunks = chunkArray(Array.from(toQuery), MAX_PROFILES_PER_REQUEST);
       try {
         const results = await Promise.all(
           chunks.map((profileIdChunk) =>

--- a/src/lib/chunkArray.ts
+++ b/src/lib/chunkArray.ts
@@ -1,0 +1,11 @@
+const chunkArray = <T>(arr: T[], chunkSize: number): Array<T[]> => {
+  const out: Array<T[]> = [];
+  for (let i = 0; i < arr.length; i += chunkSize) {
+    const chunk = arr.slice(i, i + chunkSize);
+    out.push(chunk);
+  }
+
+  return out;
+};
+
+export default chunkArray;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
- We realized the Lens API doesn't allow you to query for more than 50 profiles at a time, but also doesn't offer pagination when querying by `profileIds`. So, we are breaking the request into smaller chunks.
- Bonus is that when a new conversation is added it will only query for the one new profile instead of the whole batch

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://user-images.githubusercontent.com/65710/199830468-ee5fe5e7-8ad9-4cd4-a9cb-c05c1c269ecb.mp4


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Have > 50 different conversations open. All should load. (More easily tested by lowering the `MAX_PROFILES_TO_LOAD_CONCURRENTLY` variable)