### PR TITLE
Post action buttons improvements

### DIFF
--- a/src/components/Composer/Comment/New.tsx
+++ b/src/components/Composer/Comment/New.tsx
@@ -391,6 +391,7 @@ const NewComment: FC<Props> = ({ publication }) => {
         </div>
         <div className="ml-auto pt-2 sm:pt-0">
           <Button
+            className="post-action-button"
             disabled={isLoading}
             icon={isLoading ? <Spinner size="xs" /> : <ChatAlt2Icon className="w-4 h-4" />}
             onClick={createComment}

--- a/src/components/Composer/Post/Update/index.tsx
+++ b/src/components/Composer/Post/Update/index.tsx
@@ -379,6 +379,7 @@ const NewUpdate: FC = () => {
         </div>
         <div className="ml-auto pt-2 sm:pt-0">
           <Button
+            className="post-button"
             disabled={isLoading}
             icon={isLoading ? <Spinner size="xs" /> : <PencilAltIcon className="w-4 h-4" />}
             onClick={createPost}

--- a/src/components/Composer/Post/Update/index.tsx
+++ b/src/components/Composer/Post/Update/index.tsx
@@ -379,7 +379,7 @@ const NewUpdate: FC = () => {
         </div>
         <div className="ml-auto pt-2 sm:pt-0">
           <Button
-            className="post-button"
+            className="post-action-button"
             disabled={isLoading}
             icon={isLoading ? <Spinner size="xs" /> : <PencilAltIcon className="w-4 h-4" />}
             onClick={createPost}

--- a/src/styles.css
+++ b/src/styles.css
@@ -172,3 +172,11 @@ iframe {
 .plyr--audio.plyr--full-ui input[type='range'] {
   @apply !text-white;
 }
+
+.post-button {
+  border-radius: 25px;
+}
+
+.post-button:focus {
+  --tw-ring-inset: 0px;
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -173,10 +173,10 @@ iframe {
   @apply !text-white;
 }
 
-.post-button {
+.post-action-button {
   border-radius: 25px;
 }
 
-.post-button:focus {
+.post-action-button:focus {
   --tw-ring-inset: 0px;
 }


### PR DESCRIPTION
## What does this PR do?

"Post" action buttons are now round (25px) and without any outline when focused.

Fixes #60

![comment](https://user-images.githubusercontent.com/52707094/200134477-99ce17d0-3201-41f9-a45b-136309ea62a0.png)
![create_post](https://user-images.githubusercontent.com/52707094/200134478-6d524dac-1545-48a8-b32b-dea6a621b7ff.png)


## Type of change

- [X ] Enhancement

## Notes

Hopefully, I understood this issue correctly, if not, please let me know what else is needed and I will do it.
Also, if the way this PR was made is somehow wrong: 1) I'm sorry and 2) please let me know how to improve.