### PR TITLE
chore: fix .env syntax

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
-NEXT_PUBLIC_LENS_NETWORK="testnet" # mainnet, testnet, staging or sandbox
+# Configure which network to use. Valid values: "mainnet", "testnet", "staging" or "sandbox"
+NEXT_PUBLIC_LENS_NETWORK="testnet"
+
 NEXT_PUBLIC_RELAY_ON=false
 NEXT_PUBLIC_SENTRY_DSN=""
 NEXT_PUBLIC_ALCHEMY_KEY=""


### PR DESCRIPTION
## What does this PR do?

Fix the format of .env.example so that the server can be started in testnet from the instructions in README.md:
```
cp .env.example .env
yarn install
yarn dev
```
The parser for .env seems to parse the whole line, including the comment, as an invalid value, so that the server is started in *mainnet*, as a fallback, even if the .env says "testnet":
`NEXT_PUBLIC_LENS_NETWORK="testnet" # mainnet, testnet, staging or sandbox`

The comment in .env.example was added here: https://github.com/lensterxyz/lenster/commit/f2316b36554dffb487dfce2a4cb84ad3c2ed65dd


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
