### PR TITLE
changes to filter conversations as followed and requested

### DIFF
--- a/src/components/Messages/PreviewList.tsx
+++ b/src/components/Messages/PreviewList.tsx
@@ -9,7 +9,7 @@ import { Modal } from '@components/UI/Modal';
 import { PageLoading } from '@components/UI/PageLoading';
 import useMessagePreviews from '@components/utils/hooks/useMessagePreviews';
 import type { Profile } from '@generated/types';
-import { MailIcon, PlusCircleIcon } from '@heroicons/react/outline';
+import { MailIcon, PlusCircleIcon, UsersIcon } from '@heroicons/react/outline';
 import buildConversationId from '@lib/buildConversationId';
 import { buildConversationKey } from '@lib/conversationKey';
 import clsx from 'clsx';
@@ -111,6 +111,7 @@ const PreviewList: FC<Props> = ({ className, selectedConversationKey }) => {
               selectedTab === 'Following' ? 'bg-gray-100' : ''
             )}
           >
+            <UsersIcon className="mr-2 h-4 w-4" />
             Following
           </div>
           <div

--- a/src/components/Profile/Details.tsx
+++ b/src/components/Profile/Details.tsx
@@ -46,6 +46,7 @@ const Details: FC<Props> = ({ profile }) => {
   const router = useRouter();
   const messageProfiles = useMessageStore((state) => state.messageProfiles);
   const setMessageProfiles = useMessageStore((state) => state.setMessageProfiles);
+  const setSelectedTab = useMessageStore((state) => state.setSelectedTab);
 
   const onMessageClick = () => {
     if (!currentProfile) {
@@ -55,6 +56,11 @@ const Details: FC<Props> = ({ profile }) => {
     const conversationKey = buildConversationKey(profile.ownedBy, conversationId);
     messageProfiles.set(conversationKey, profile);
     setMessageProfiles(new Map(messageProfiles));
+    if (profile.isFollowedByMe) {
+      setSelectedTab('Following');
+    } else {
+      setSelectedTab('Requested');
+    }
     router.push(`/messages/${conversationKey}`);
   };
 

--- a/src/store/message.ts
+++ b/src/store/message.ts
@@ -6,6 +6,8 @@ import { LS_KEYS } from 'src/constants';
 import create from 'zustand';
 import { persist } from 'zustand/middleware';
 
+type tabValues = 'Following' | 'Requested';
+
 interface MessageState {
   client: Client | undefined;
   setClient: (client: Client | undefined) => void;
@@ -23,6 +25,8 @@ interface MessageState {
   reset: () => void;
   selectedProfileId: string;
   setSelectedProfileId: (selectedProfileId: string) => void;
+  selectedTab: tabValues;
+  setSelectedTab: (selectedTab: tabValues) => void;
 }
 
 export const useMessageStore = create<MessageState>((set) => ({
@@ -67,6 +71,8 @@ export const useMessageStore = create<MessageState>((set) => ({
   setPreviewMessages: (previewMessages) => set(() => ({ previewMessages })),
   selectedProfileId: '',
   setSelectedProfileId: (selectedProfileId) => set(() => ({ selectedProfileId })),
+  selectedTab: 'Following',
+  setSelectedTab: (selectedTab) => set(() => ({ selectedTab })),
   reset: () =>
     set((state) => {
       return {
@@ -74,7 +80,8 @@ export const useMessageStore = create<MessageState>((set) => ({
         conversations: new Map(),
         messages: new Map(),
         messageProfiles: new Map(),
-        previewMessages: new Map()
+        previewMessages: new Map(),
+        selectedTab: 'Following'
       };
     })
 }));

--- a/src/styles.css
+++ b/src/styles.css
@@ -38,6 +38,14 @@ body {
   @apply underline;
 }
 
+.tab-bg {
+  @apply hover:bg-gray-200
+}
+
+.tab-bg:hover > span {
+  @apply bg-gray-300
+}
+
 .identicon {
   width: 100% !important;
   height: 100% !important;


### PR DESCRIPTION
## What does this PR do?

Adds the following and requested tab in the conversations preview list to avoid spam.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (small non-breaking changes to existing functionality)

## How should this be tested?

- [ ] Check if the conversations from the profiles you follow and you don't are displayed in the correct tabs
- [ ] Try to switch between tabs
- [ ] Select a conversation and message them
- [ ] Search a profile and from the profiles, page click on the message button and see if routing is good

## Screenshots

![image](https://user-images.githubusercontent.com/28332178/200272747-665e6d43-f8bb-4ab6-a2b8-45b007249ca4.png)

![image](https://user-images.githubusercontent.com/28332178/200272832-394e66e9-53cb-4504-b47a-278d4a998219.png)
