### PR TITLE
chore: add appVersion to xmtp client config

### DIFF
--- a/src/components/utils/hooks/useXmtpClient.tsx
+++ b/src/components/utils/hooks/useXmtpClient.tsx
@@ -1,6 +1,6 @@
 import { Client } from '@xmtp/xmtp-js';
 import { useCallback, useEffect, useState } from 'react';
-import { LS_KEYS, XMTP_ENV } from 'src/constants';
+import { APP_NAME, APP_VERSION, LS_KEYS, XMTP_ENV } from 'src/constants';
 import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 import { useSigner } from 'wagmi';
@@ -47,7 +47,11 @@ const useXmtpClient = (cacheOnly = false) => {
           storeKeys(await signer.getAddress(), keys);
         }
 
-        const xmtp = await Client.create(null, { env: XMTP_ENV, privateKeyOverride: keys });
+        const xmtp = await Client.create(null, {
+          env: XMTP_ENV,
+          appVersion: APP_NAME + '/' + APP_VERSION,
+          privateKeyOverride: keys
+        });
         setClient(xmtp);
         setAwaitingXmtpAuth(false);
       } else {

--- a/src/components/utils/hooks/useXmtpClient.tsx
+++ b/src/components/utils/hooks/useXmtpClient.tsx
@@ -43,7 +43,10 @@ const useXmtpClient = (cacheOnly = false) => {
             return;
           }
           setAwaitingXmtpAuth(true);
-          keys = await Client.getKeys(signer, { env: XMTP_ENV });
+          keys = await Client.getKeys(signer, {
+            env: XMTP_ENV,
+            appVersion: APP_NAME + '/' + APP_VERSION
+          });
           storeKeys(await signer.getAddress(), keys);
         }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import getEnvConfig from '@lib/getEnvConfig';
+import packageJson from 'package.json';
 import { chain } from 'wagmi';
 
 // Environments
@@ -25,6 +26,7 @@ export const XMTP_PREFIX = 'lens.dev/dm';
 
 // Application
 export const APP_NAME = 'Lenster';
+export const APP_VERSION = packageJson.version;
 export const DESCRIPTION =
   'Lenster is a composable, decentralized, and permissionless social media web app built with Lens Protocol 🌿';
 export const DEFAULT_OG = 'https://assets.lenster.xyz/images/og/logo.jpeg';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 import getEnvConfig from '@lib/getEnvConfig';
-import packageJson from 'package.json';
 import { chain } from 'wagmi';
+
+import packageJson from '../package.json';
 
 // Environments
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production';


### PR DESCRIPTION
## What does this PR do?

Configures the XMTP client to include the app name and version in XMTP API headers.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

- [ ] Confirm that headers include `'X-App-Version': 'Lenster/1.0.3-beta'`
