### PR TITLE
fix: url matching

### DIFF
--- a/src/components/Shared/Markup.tsx
+++ b/src/components/Shared/Markup.tsx
@@ -19,6 +19,7 @@ interface Props {
 
 const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
   const defaultMatchers = [
+    new UrlMatcher('url'),
     new HashtagMatcher('hashtag'),
     new MentionMatcher('mention'),
     new MDBoldMatcher('mdBold'),
@@ -26,8 +27,7 @@ const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
     new MDStrikeMatcher('mdStrike'),
     new MDQuoteMatcher('mdQuote'),
     new MDCodeMatcher('mdCode'),
-    new SpoilerMatcher('spoiler'),
-    new UrlMatcher('url')
+    new SpoilerMatcher('spoiler')
   ];
 
   return (

--- a/src/components/utils/matchers/UrlMatcher/index.tsx
+++ b/src/components/utils/matchers/UrlMatcher/index.tsx
@@ -37,14 +37,14 @@ export class UrlMatcher extends Matcher<UrlProps> {
   }
 
   match(string: string): MatchResponse<UrlMatch> | null {
-    const response = this.doMatch(string, URL_PATTERN, this.handleMatches);
+    const response = this.doMatch(string, URL_PATTERN, this.handleMatches, true);
 
     if (response?.valid) {
       const { host } = response;
       const tld = host.slice(host.lastIndexOf('.') + 1).toLowerCase();
 
       if (BLOCKED_TLDS.includes(tld)) {
-        return null;
+        response.valid = false;
       }
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #771

Details:
- Fixed ordering of matchers: URLMatcher now goes first to catch any URLs before the other matchers check for mention-tags, hashtags, etc.
- URLMatcher now marked as "void" (which means an URL cannot contain nested tags, see https://interweave.dev/docs/matchers/#creating-a-matcher )
- URLMatcher: when a blocked top-level-domain is found (i.e. ".lens"), set `response.valid = false;` This is the method in Interweave to filter out such false positives. (Before the fix, **null** was returned, which stopped the matcher from finding more matches, see https://interweave.dev/docs/matchers/#creating-a-matcher ) 

Before:
![before1](https://user-images.githubusercontent.com/667227/201416116-a39ad163-418b-46db-b01f-de146c4358dc.png)

After:
![after1](https://user-images.githubusercontent.com/667227/201416139-18a08d8a-4680-44c8-b2f7-553d7ce7a893.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Open  https://lenster.xyz/posts/0x24-0xc7 and check that URL is rendered correctly (whole URL clickable, and no mention-tag inside URL)

