### PR TITLE
fix: load profiles serially

### DIFF
--- a/src/components/utils/hooks/useMessagePreviews.tsx
+++ b/src/components/utils/hooks/useMessagePreviews.tsx
@@ -68,13 +68,9 @@ const useMessagePreviews = () => {
       const newMessageProfiles = new Map(messageProfiles);
       const chunks = chunkArray(Array.from(toQuery), MAX_PROFILES_PER_REQUEST);
       try {
-        const results = await Promise.all(
-          chunks.map((profileIdChunk) =>
-            loadProfiles({ variables: { request: { profileIds: profileIdChunk } } })
-          )
-        );
-
-        for (const result of results) {
+        for (const chunk of chunks) {
+          const result = await loadProfiles({ variables: { request: { profileIds: chunk } } });
+          console.log(result.data?.profiles.items.map((item) => item.id));
           if (!result.data?.profiles.items.length) {
             continue;
           }

--- a/src/components/utils/hooks/useMessagePreviews.tsx
+++ b/src/components/utils/hooks/useMessagePreviews.tsx
@@ -70,7 +70,6 @@ const useMessagePreviews = () => {
       try {
         for (const chunk of chunks) {
           const result = await loadProfiles({ variables: { request: { profileIds: chunk } } });
-          console.log(result.data?.profiles.items.map((item) => item.id));
           if (!result.data?.profiles.items.length) {
             continue;
           }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

There seems to be an issue loading the profiles in parallel, where it uses the same variables for each request. This works around that issue by loading them one at a time. Confirmed it works by lowering the number of concurrent profiles and testing in dev.

Will work on a subsequent fix that loads everything in parallel.

Fixes # (issue)

<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Change the `MAX_PROFILES_PER_REQUEST` to 2 and refresh with a profile that has > 2 ongoing conversations. It should return all the profiles
