### PR TITLE
fix: hashtag matcher

### DIFF
--- a/src/components/utils/matchers/HashtagMatcher.tsx
+++ b/src/components/utils/matchers/HashtagMatcher.tsx
@@ -46,7 +46,7 @@ export class HashtagMatcher extends Matcher {
   }
 
   match(value: string) {
-    return this.doMatch(value, /\B(#[A-Za-z]+\b)(?!;)/, (matches) => {
+    return this.doMatch(value, /\B(#\w*[A-Za-z]+\w*\b)(?!;)/, (matches) => {
       return {
         display: matches[0]
       };


### PR DESCRIPTION
## What does this PR do?

- Detect hashtags with digits, for example `#web3`,
- Detect hashtags with underscore, for example `#foo_bar`
- **Ignore** hashtags with only digits and/or underscore, for example `#123`, `#12_34`, `#_`)

Before fix:
![before](https://user-images.githubusercontent.com/667227/201488080-693c5fad-2bbd-4544-bc64-c879d3bfe424.png)
After fix:
![after](https://user-images.githubusercontent.com/667227/201488092-7a353d33-258c-441a-9b8c-f29f9abec314.png)

Here is a live example post which contains `#Web3` hashtag: https://lenster.xyz/posts/0x73a4-0x029e

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Create and view a post with the text. `#lens #web3 #foo_bar #123 #_ #12_34 #foo! #bar? #test. dfg`
- Verify that only `#lens`, `#web3`, `#foo_bar`, `#foo` and `#bar` are detected as hashtags.
