### PR TITLE
fix: Pressing 'Shop Collects' button takes you to mirror

### DIFF
--- a/src/components/Publication/Actions/Collect/CollectModule.tsx
+++ b/src/components/Publication/Actions/Collect/CollectModule.tsx
@@ -252,7 +252,7 @@ const CollectModule: FC<Props> = ({ count, setCount, publication, electedMirror 
   };
 
   const shopCollects = () => {
-    const pubId = publication.id ?? publication.mirrorOf.id;
+    const pubId = publication.mirrorOf?.id ?? publication.id;
     const decimalProfileId = parseInt(pubId.split('-')[0], 16);
     const decimalPubId = parseInt(pubId.split('-')[1], 16);
     const marketplacePublicationId = decimalProfileId + '_' + decimalPubId;


### PR DESCRIPTION
Pressing 'Shop Collects' button takes you to mirror's page instead of pointed page

## What does this PR do?

Simple fix to move priority of publication.mirrorOf?.id in front of publication.id.
Without this, the button takes user's to the wrong page: the page of the mirror publication instead of the page of the publication being mirrored.

Fixes #1185 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
Press Shop Collects button on a publication's mirror