### PR TITLE
fix: stop click propagation for open original (#1176)

### DIFF
--- a/src/components/UI/LightBox.tsx
+++ b/src/components/UI/LightBox.tsx
@@ -50,6 +50,7 @@ export const LightBox: FC<Props> = ({ show, url, onClose }) => {
                   href={url}
                   target="_blank"
                   rel="noopener noreferrer"
+                  onClick={(event) => event.stopPropagation()}
                 >
                   Open original
                 </a>


### PR DESCRIPTION
## What does this PR do?

Fixes #1176
Fix the previous behavior which was that "Open original" opened both the original media and the corresponding post.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

In the feed, find a post which has an image
Click the image. Image will show in full size, with a link "Open original"
Click "Open original"
Verify that the original is opened in a new tab, and that nothing happens in the original tab (should not open the post)
