### PR TITLE
fix: grammar in feed empty state

### DIFF
--- a/src/components/Profile/Feed.tsx
+++ b/src/components/Profile/Feed.tsx
@@ -74,12 +74,20 @@ const Feed: FC<Props> = ({ profile, type }) => {
   }
 
   if (publications?.length === 0) {
+    const emptyMessage =
+      type === 'FEED'
+        ? 'has nothing in their feed yet!'
+        : type === 'MEDIA'
+        ? 'has no media yet!'
+        : type === 'REPLIES'
+        ? "hasn't replied yet!"
+        : '';
     return (
       <EmptyState
         message={
           <div>
             <span className="mr-1 font-bold">@{profile?.handle}</span>
-            <span>hasn’t {type.toLowerCase()}ed yet!</span>
+            <span>{emptyMessage}</span>
           </div>
         }
         icon={<CollectionIcon className="w-8 h-8 text-brand" />}


### PR DESCRIPTION
## What does this PR do?

Fixes #1195

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Visit a profile that has empty feed/media/replies
- Check that the wording for the empty state under the feed tabs has correct grammar


**Before fix:**
![Screenshot_2022-11-15_19-08-51](https://user-images.githubusercontent.com/667227/201994186-648bb9b5-db57-4189-a093-8d8bd762c88b.png)
![Screenshot_2022-11-15_19-08-59](https://user-images.githubusercontent.com/667227/201994193-0d965521-2f34-42f0-8e42-f30f7aed7a99.png)
![Screenshot_2022-11-15_19-09-12](https://user-images.githubusercontent.com/667227/201994196-b2aa86e8-3492-446d-833c-32f351f3afe4.png)


**After fix:**
![Screenshot_2022-11-15_18-56-17](https://user-images.githubusercontent.com/667227/201992109-c61c50ae-2083-4285-99ca-77d85d770c1a.png)
![Screenshot_2022-11-15_18-56-26](https://user-images.githubusercontent.com/667227/201992114-b31fcf6d-740a-46be-88ad-3bd0168b93da.png)
![Screenshot_2022-11-15_18-56-35](https://user-images.githubusercontent.com/667227/201992117-9519525c-0ee3-4265-a062-1ee4f8d89da9.png)
