### PR TITLE
fix: code scanner alert

### DIFF
--- a/src/components/Settings/Account/SuperFollow.tsx
+++ b/src/components/Settings/Account/SuperFollow.tsx
@@ -144,6 +144,11 @@ const SuperFollow: FC = () => {
 
   const followType = currencyData?.profile?.followModule?.__typename;
 
+  const symbolToUrl = (symbol: string) => {
+    const currency = currencyData?.enabledModuleCurrencies.find((c) => c.symbol === symbol);
+    return currency?.symbol ? getTokenImage(currency.symbol) : '';
+  };
+
   return (
     <Card>
       <Form
@@ -186,7 +191,7 @@ const SuperFollow: FC = () => {
               className="w-6 h-6"
               height={24}
               width={24}
-              src={getTokenImage(selectedCurrencySymbol)}
+              src={symbolToUrl(selectedCurrencySymbol)}
               alt={selectedCurrencySymbol}
             />
           }


### PR DESCRIPTION
## What does this PR do?

Fixes one of the alerts from the code scanner:
![Screenshot_2022-11-16_19-19-09](https://user-images.githubusercontent.com/667227/202263029-97a83b85-d8d9-4cb0-9f87-79fd607b5423.png)

@bigint I also looked at the other alert (for `src/components/Shared/Login/New/Pending.tsx:33`) but I'm not sure what the best solution for that one is. In the meanwhile, since the alerts could be security risks, this PR solves at least one of them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
