### PR TITLE
fix: crash on some posts containing markdown code formatting

### DIFF
--- a/apps/web/src/components/Shared/Markup.tsx
+++ b/apps/web/src/components/Shared/Markup.tsx
@@ -20,6 +20,7 @@ interface Props {
 
 const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
   const defaultMatchers = [
+    new MDCodeMatcher('mdCode'),
     new MDLinkMatcher('mdLink'),
     new UrlMatcher('url'),
     new HashtagMatcher('hashtag'),
@@ -28,7 +29,6 @@ const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
     new MDItalicMatcher('mdItalic'),
     new MDStrikeMatcher('mdStrike'),
     new MDQuoteMatcher('mdQuote'),
-    new MDCodeMatcher('mdCode'),
     new SpoilerMatcher('spoiler')
   ];
 

--- a/apps/web/src/components/utils/matchers/markdown/MDCodeMatcher.tsx
+++ b/apps/web/src/components/utils/matchers/markdown/MDCodeMatcher.tsx
@@ -13,8 +13,13 @@ export class MDCodeMatcher extends Matcher {
   }
 
   match(value: string) {
-    return this.doMatch(value, /`(.*?)`/u, (matches) => ({
-      match: matches[1]
-    }));
+    return this.doMatch(
+      value,
+      /`(.*?)`/u,
+      (matches) => ({
+        match: matches[1]
+      }),
+      true
+    );
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #1236
The problem was that MDCodeMatcher was not marked as "void" (see https://interweave.dev/docs/matchers ) so it allowed sub-tags, which caused the crash. Also, the MDCodeMatcher need to be executed first, since a code snippet can contain any syntax, that could otherwise be caught by other matchers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
Visit https://lenster.xyz/posts/0x101e-0x07
Confirm that the page doesn't crash, but shows some code snippets with asterisk inside:
![Screenshot_2022-11-18_13-06-17](https://user-images.githubusercontent.com/667227/202701564-a56e43e4-3ae7-4f2d-bfb6-f16c54988104.png)
