### PR TITLE
feat: add prominent ENS badge to user profile and timeline

### DIFF
--- a/apps/web/src/components/Profile/Details.tsx
+++ b/apps/web/src/components/Profile/Details.tsx
@@ -1,4 +1,5 @@
 import Message from '@components/Profile/Message';
+import EnsCheckIcon from '@components/Shared/EnsCheckIcon';
 import Follow from '@components/Shared/Follow';
 import Markup from '@components/Shared/Markup';
 import Slug from '@components/Shared/Slug';
@@ -16,6 +17,7 @@ import { buildConversationKey } from '@lib/conversationKey';
 import formatAddress from '@lib/formatAddress';
 import getAttribute from '@lib/getAttribute';
 import getAvatar from '@lib/getAvatar';
+import isEnsVerified from '@lib/isEnsVerified';
 import isStaff from '@lib/isStaff';
 import isVerified from '@lib/isVerified';
 import { STATIC_IMAGES_URL } from 'data/constants';
@@ -82,6 +84,11 @@ const Details: FC<Props> = ({ profile }) => {
           {isVerified(profile?.id) && (
             <Tooltip content="Verified">
               <BadgeCheckIcon className="w-6 h-6 text-brand" />
+            </Tooltip>
+          )}
+          {isEnsVerified(profile) && (
+            <Tooltip content={`ENS: ${profile?.onChainIdentity?.ens?.name}`}>
+              <EnsCheckIcon className="w-6 h-6" alt={`ENS: ${profile?.onChainIdentity?.ens?.name}`} />
             </Tooltip>
           )}
         </div>

--- a/apps/web/src/components/Shared/EnsCheckIcon.tsx
+++ b/apps/web/src/components/Shared/EnsCheckIcon.tsx
@@ -1,0 +1,18 @@
+import { STATIC_IMAGES_URL } from 'data/constants';
+import * as React from 'react';
+
+interface Props {
+  alt?: string;
+  className?: string;
+}
+
+const EnsCheckIcon: React.FC<Props> = ({ className, alt }) => {
+  return <img src={`${STATIC_IMAGES_URL}/badges/ens.png`} className={className} alt={alt} />;
+};
+
+EnsCheckIcon.defaultProps = {
+  alt: '',
+  className: ''
+};
+
+export default EnsCheckIcon;

--- a/apps/web/src/components/Shared/UserProfile.tsx
+++ b/apps/web/src/components/Shared/UserProfile.tsx
@@ -1,6 +1,7 @@
 import { BadgeCheckIcon } from '@heroicons/react/solid';
 import getAttribute from '@lib/getAttribute';
 import getAvatar from '@lib/getAvatar';
+import isEnsVerified from '@lib/isEnsVerified';
 import isVerified from '@lib/isVerified';
 import clsx from 'clsx';
 import type { Profile } from 'lens';
@@ -8,6 +9,7 @@ import Link from 'next/link';
 import type { FC } from 'react';
 import { useState } from 'react';
 
+import EnsCheckIcon from './EnsCheckIcon';
 import Follow from './Follow';
 import Markup from './Markup';
 import Slug from './Slug';
@@ -60,6 +62,12 @@ const UserProfile: FC<Props> = ({
       <div className="flex items-center max-w-sm truncate">
         <div className={clsx(isBig ? 'font-bold' : 'text-md')}>{profile?.name ?? profile?.handle}</div>
         {isVerified(profile?.id) && <BadgeCheckIcon className="w-4 h-4 text-brand ml-1" />}
+        {isEnsVerified(profile) && (
+          <EnsCheckIcon
+            className="w-4 h-4 text-brand ml-1"
+            alt={`ENS: ${profile?.onChainIdentity?.ens?.name}`}
+          />
+        )}
         {showStatus && hasStatus ? (
           <div className="flex items-center text-gray-500">
             <span className="mx-1.5">·</span>

--- a/apps/web/src/lib/isEnsVerified.ts
+++ b/apps/web/src/lib/isEnsVerified.ts
@@ -1,0 +1,20 @@
+import type { Profile } from 'lens';
+
+/**
+ *
+ * @param profile - Profile id
+ * @returns `true` if handle is same as ENS name
+ *
+ * Examples for handle "vitalik.lens":
+ *  - ENS: "vitalik.eth" returns `true`
+ *  - ENS: "lens.vitalik.eth" returns `true`
+ *  - ENS "vitalik.eth.somebodyelse.eth" returns `false` (trying to impersonate)
+ */
+function isEnsVerified(profile: Profile): boolean {
+  const ensName = (profile?.onChainIdentity?.ens?.name || '') as string;
+  const handleWithEnsSuffix = profile?.handle.replace(/\.lens$/, '.eth');
+
+  return ensName.endsWith(handleWithEnsSuffix);
+}
+
+export default isEnsVerified;

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -16764,6 +16764,11 @@ export type TimelineQuery = {
               isFollowedByMe: boolean;
               stats: { __typename?: 'ProfileStats'; totalFollowers: number; totalFollowing: number };
               attributes?: Array<{ __typename?: 'Attribute'; key: string; value: string }> | null;
+              onChainIdentity: {
+                ens: {
+                  name: string;
+                };
+              };
               picture?:
                 | { __typename?: 'MediaSet'; original: { __typename?: 'Media'; url: any } }
                 | { __typename?: 'NftImage'; uri: any }
@@ -19619,6 +19624,11 @@ export const ProfileFieldsFragmentDoc = gql`
     attributes {
       key
       value
+    }
+    onChainIdentity {
+      ens {
+        name
+      }
     }
     picture {
       ... on MediaSet {


### PR DESCRIPTION
## What does this PR do?

**Community feature request**

- https://lenster.xyz/posts/0x017cc9-0x6a


If ENS name matches the lens handle, display ENS icon in Timeline and in Profile, next to "verified" badge.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Enhancement (non-breaking small changes to existing functionality)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A: Open Vitalik's profile
- Test B: Open Vitalik's post in the feed


<img width="522" alt="vitalik-profile" src="https://user-images.githubusercontent.com/988706/203041807-70f0f1c3-5204-49ef-a812-57746aed2164.png">
<img width="502" alt="vitalik-timeline-feed" src="https://user-images.githubusercontent.com/988706/203041816-8c8a0002-04f2-41c1-964b-756006567a57.png">
