### PR TITLE
move dark mode toggle to navbar

### DIFF
--- a/apps/web/src/components/Messages/MessageIcon.tsx
+++ b/apps/web/src/components/Messages/MessageIcon.tsx
@@ -105,6 +105,7 @@ const MessageIcon: FC = () => {
       onClick={() => {
         currentProfile && clearMessagesBadge(currentProfile.id);
       }}
+      title="Messages"
     >
       <MailIcon className="w-5 h-5 sm:w-6 sm:h-6" />
       {showMessagesBadge.get(currentProfile?.id) ? (

--- a/apps/web/src/components/Notification/NotificationIcon.tsx
+++ b/apps/web/src/components/Notification/NotificationIcon.tsx
@@ -35,6 +35,7 @@ const NotificationIcon: FC = () => {
         setShowBadge(false);
         Leafwatch.track(NOTIFICATION.OPEN);
       }}
+      title="Notifications"
     >
       <LightningBoltIcon className="w-5 h-5 sm:w-6 sm:h-6" />
       {showBadge && <span className="w-2 h-2 bg-red-500 rounded-full" />}

--- a/apps/web/src/components/Shared/Navbar/SignedUser.tsx
+++ b/apps/web/src/components/Shared/Navbar/SignedUser.tsx
@@ -6,10 +6,8 @@ import {
   CogIcon,
   EmojiHappyIcon,
   LogoutIcon,
-  MoonIcon,
   ShieldCheckIcon,
   ShieldExclamationIcon,
-  SunIcon,
   SwitchHorizontalIcon,
   UserIcon
 } from '@heroicons/react/outline';
@@ -27,7 +25,7 @@ import type { FC } from 'react';
 import { Fragment } from 'react';
 import { useAppPersistStore, useAppStore } from 'src/store/app';
 import { useGlobalModalStateStore } from 'src/store/modals';
-import { PROFILE, STAFFTOOLS, SYSTEM } from 'src/tracking';
+import { PROFILE, STAFFTOOLS } from 'src/tracking';
 import { useDisconnect } from 'wagmi';
 
 import pkg from '../../../../package.json';
@@ -213,29 +211,6 @@ const SignedUser: FC = () => {
                   </div>
                 </>
               )}
-              <div className="divider" />
-              <Menu.Item
-                as="a"
-                onClick={() => {
-                  setTheme(theme === 'light' ? 'dark' : 'light');
-                  Leafwatch.track(theme === 'light' ? SYSTEM.SWITCH_DARK_THEME : SYSTEM.SWITCH_LIGHT_THEME);
-                }}
-                className={({ active }) => clsx({ 'dropdown-active': active }, 'menu-item')}
-              >
-                <div className="flex items-center space-x-1.5">
-                  {theme === 'light' ? (
-                    <>
-                      <MoonIcon className="w-4 h-4" />
-                      <div>Dark mode</div>
-                    </>
-                  ) : (
-                    <>
-                      <SunIcon className="w-4 h-4" />
-                      <div>Light mode</div>
-                    </>
-                  )}
-                </div>
-              </Menu.Item>
               {currentProfile && (
                 <>
                   <div className="divider" />

--- a/apps/web/src/components/Shared/Navbar/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/index.tsx
@@ -2,14 +2,17 @@ import MessageIcon from '@components/Messages/MessageIcon';
 import NotificationIcon from '@components/Notification/NotificationIcon';
 import useStaffMode from '@components/utils/hooks/useStaffMode';
 import { Disclosure } from '@headlessui/react';
-import { MenuIcon, XIcon } from '@heroicons/react/outline';
+import { MenuIcon, MoonIcon, SunIcon, XIcon } from '@heroicons/react/outline';
 import hasPrideLogo from '@lib/hasPrideLogo';
+import { Leafwatch } from '@lib/leafwatch';
 import clsx from 'clsx';
 import type { Profile } from 'lens';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useTheme } from 'next-themes';
 import type { FC } from 'react';
 import { useAppStore } from 'src/store/app';
+import { SYSTEM } from 'src/tracking';
 
 import MenuItems from './MenuItems';
 import MoreNavItems from './MoreNavItems';
@@ -20,6 +23,7 @@ const Navbar: FC = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const { allowed: staffMode } = useStaffMode();
   const router = useRouter();
+  const { theme, setTheme } = useTheme();
 
   const onProfileSelected = (profile: Profile) => {
     router.push(`/u/${profile?.handle}`);
@@ -100,6 +104,23 @@ const Navbar: FC = () => {
                 </div>
               </div>
               <div className="flex gap-4 items-center">
+                <button
+                  onClick={() => {
+                    setTheme(theme === 'light' ? 'dark' : 'light');
+                    Leafwatch.track(theme === 'light' ? SYSTEM.SWITCH_DARK_THEME : SYSTEM.SWITCH_LIGHT_THEME);
+                  }}
+                >
+                  <div
+                    className="flex items-center space-x-1.5 justify-center rounded-md hover:bg-gray-300 p-1 hover:bg-opacity-20 min-w-[40px]"
+                    title={theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
+                  >
+                    {theme === 'light' ? (
+                      <MoonIcon className="w-5 h-5 sm:w-6 sm:h-6" />
+                    ) : (
+                      <SunIcon className="w-5 h-5 sm:w-6 sm:h-6" />
+                    )}
+                  </div>
+                </button>
                 {currentProfile ? (
                   <>
                     <MessageIcon />


### PR DESCRIPTION
## What does this PR do?

Fixes #1268
This PR moves "Dark mode" toggle from profile menu to navbar, so that dark mode is accessible even if the user is logged out.

Request for comments on the design (e.g. where do we want the button?). Not sure if this is the desired layout, but the fix was easy so I created a PR as a proposal.


With the change, the navbar will look like this:
![Screenshot_2022-11-21_19-13-41](https://user-images.githubusercontent.com/667227/203130052-03820d2d-1551-4238-9a28-1729b62df2e4.png)
![Screenshot_2022-11-21_19-12-56](https://user-images.githubusercontent.com/667227/203130057-edd4456f-ff94-4482-b482-c312c7a994c9.png)
![Screenshot_2022-11-21_19-17-47](https://user-images.githubusercontent.com/667227/203130388-eccf3f46-736c-476c-999b-886dcd283b4d.png)

Bonus change:
Since I added a tooltip "Switch to dark mode", I also added tooltips for Messages and Notifications :)

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)


## Checklist

- I haven't read the [contributing guide](https://github.com/lensterxyz/lenster/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't added tests that prove my fix is effective or that my feature works
- I haven't checked if new and existing unit tests pass locally with my changes
