### PR TITLE
fix: remove duplicate profile link

### DIFF
--- a/apps/web/src/components/Shared/Navbar/SignedUser.tsx
+++ b/apps/web/src/components/Shared/Navbar/SignedUser.tsx
@@ -10,8 +10,7 @@ import {
   ShieldCheckIcon,
   ShieldExclamationIcon,
   SunIcon,
-  SwitchHorizontalIcon,
-  UserIcon
+  SwitchHorizontalIcon
 } from '@heroicons/react/outline';
 import { Analytics } from '@lib/analytics';
 import formatHandle from '@lib/formatHandle';
@@ -126,18 +125,6 @@ const SignedUser: FC = () => {
                 </div>
               </Menu.Item>
               <div className="divider" />
-              <Menu.Item
-                as={NextLink}
-                href={`/u/${formatHandle(currentProfile?.handle)}`}
-                className={({ active }: { active: boolean }) =>
-                  clsx({ 'dropdown-active': active }, 'menu-item')
-                }
-              >
-                <div className="flex items-center space-x-1.5">
-                  <UserIcon className="w-4 h-4" />
-                  <div>Your Profile</div>
-                </div>
-              </Menu.Item>
               <Menu.Item
                 as={NextLink}
                 href="/settings"


### PR DESCRIPTION
## What does this PR do?

Removes the second link to user's profile in the profile menu
Fixes #794

@bigint, I was considering whether the design of the remaining button needs to change, to make it more clear that it leads to the profile page, but I thought it felt pretty intuitive as it is, although any ideas are welcome.

**Before:**
![before](https://user-images.githubusercontent.com/667227/207922976-951f1303-945a-4bda-8754-dc6377fb7bdb.png)

**After:**
![after](https://user-images.githubusercontent.com/667227/207923005-8159fa30-1753-41ae-ae98-8ba90b6ee0ed.png)

## Type of change
- [x] Enhancement (non-breaking small changes to existing functionality)
