### PR TITLE
fix: code scanner alert

### DIFF
--- a/apps/web/src/components/Settings/Account/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Account/SuperFollow.tsx
@@ -141,6 +141,11 @@ const SuperFollow: FC = () => {
 
   const followType = currencyData?.profile?.followModule?.__typename;
 
+  const symbolToUrl = (symbol: string) => {
+    const currency = currencyData?.enabledModuleCurrencies.find((c) => c.symbol === symbol);
+    return currency?.symbol ? getTokenImage(currency.symbol) : '';
+  };
+
   return (
     <Card>
       <Form
@@ -183,7 +188,7 @@ const SuperFollow: FC = () => {
               className="w-6 h-6"
               height={24}
               width={24}
-              src={getTokenImage(selectedCurrencySymbol)}
+              src={symbolToUrl(selectedCurrencySymbol)}
               alt={selectedCurrencySymbol}
             />
           }


### PR DESCRIPTION
## What does this PR do?

Fixes code scanning alert: DOM text reinterpreted as HTML
Fixes #348
@bigint Seems like the code scanner is currently disabled for https://github.com/lensterxyz/lenster , but I see these errors on my side, and I assume that they still should be resolved. If not, just reject the PR :)

## How should this be tested?

Check that the warning is gone in code scanning results