### PR TITLE
feat: i18n support

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,11 +1,14 @@
-name: Crowdin upload
+name: Crowdin download
 
 on:
-  push:
-    branches: [ i18n-support ]
+  schedule:
+    - cron: '0 0 * * *' # every day at 00:00
+
+  # start via Actions tab in Github UI
+  workflow_dispatch:
 
 jobs:
-  upload-translations:
+  download-translations:
     runs-on: ubuntu-latest
 
     steps:
@@ -13,11 +16,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Upload to Crowdin
+    - name: Download from Crowdin
       uses: crowdin/github-action@1.5.2
       with:
-        upload_translations: true
-        download_translations: false
+        upload_translations: false
+        download_translations: true
+        create_pull_request: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -2,7 +2,10 @@ name: Crowdin upload
 
 on:
   push:
-    branches: [ i18n-support ]
+    branches: [ main ]
+
+  # start via Actions tab in Github UI
+  workflow_dispatch:
 
 jobs:
   upload-translations:

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,24 @@
+name: Crowdin upload
+
+on:
+  push:
+    branches: [ i18n-support ]
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: crowdin action
+      uses: crowdin/github-action@1.5.2
+      with:
+        upload_translations: true
+        download_translations: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+        CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/I18N.md
+++ b/I18N.md
@@ -8,6 +8,8 @@ Lenster uses LinguiJS and Crowdin for internationalization
 
 ## Syncing with Crowdin project
 
+Environment variables `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN` needs to be set before running sync commands from command line.
+
 Uploading sources (English .po file) to Crowdin
 
     yarn sync:sources

--- a/I18N.md
+++ b/I18N.md
@@ -1,25 +1,31 @@
 ## Internationalization
 
-Lenster uses LinguiJS and Crowdin for internationalization
+Lenster uses LinguiJS and Crowdin for internationalization.
 
 ## Extracting strings from source code to .po files
 
     yarn extract
 
-## Syncing with Crowdin project
+## Automatic sync with Crowdin via Github
 
-Environment variables `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN` needs to be set before running sync commands from command line.
+Two Github workflows are used to sync translations with Crowdin.
+
+[Crowdin upload](https://github.com/lensterxyz/lenster/blob/main/.github/workflows/crowdin-upload.yml) is configured to upload any new strings to Crowdin when `main` branch is updated.
+
+[Crowdin download](https://github.com/lensterxyz/lenster/blob/main/.github/workflows/crowdin-download.yml) is configured to download translations from Crowdin and create a pull request. The workflow is scheduled to run nightly.
+
+The workflows provide environment variables from Github secrets to `crowdin.yml`. Both workflows can be run manually from Actions tab in Lenster repository on Github.
+
+## Syncing with Crowdin project via command line
+
+When syncing from command line, environment variables `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN`, which are used in `crowdin.yml`, need to be set.
 
 Uploading sources (English .po file) to Crowdin
 
-    yarn sync:sources
+    yarn crowdin push
 
 Downloading translations from Crowdin
 
-    yarn sync:translations
-
-Both of the above in one command
-
-    yarn sync
+    yarn crowdin pull
 
 See https://lingui.js.org/tools/crowdin.html for details

--- a/I18N.md
+++ b/I18N.md
@@ -1,0 +1,23 @@
+## Internationalization
+
+Lenster uses LinguiJS and Crowdin for internationalization
+
+## Extracting strings from source code to .po files
+
+    yarn extract
+
+## Syncing with Crowdin project
+
+Uploading sources (English .po file) to Crowdin
+
+    yarn sync:sources
+
+Downloading translations from Crowdin
+
+    yarn sync:translations
+
+Both of the above in one command
+
+    yarn sync
+
+See https://lingui.js.org/tools/crowdin.html for details

--- a/apps/web/.babelrc
+++ b/apps/web/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": ["macros"]
+}

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,1 @@
+src/locales/**/*.js

--- a/apps/web/.linguirc
+++ b/apps/web/.linguirc
@@ -1,0 +1,15 @@
+{
+  "locales": [
+    "en",
+    "cs"
+  ],
+  "catalogs": [
+    {
+      "path": "src/locales/{locale}/messages",
+      "include": [
+        "src"
+      ]
+    }
+  ],
+  "format": "po"
+}

--- a/apps/web/.linguirc
+++ b/apps/web/.linguirc
@@ -11,5 +11,10 @@
       ]
     }
   ],
-  "format": "po"
+  "format": "po",
+  "formatOptions": {
+    "origins": true,
+    "lineNumbers": false
+  },
+  "orderBy": "origin"
 }

--- a/apps/web/.linguirc
+++ b/apps/web/.linguirc
@@ -1,8 +1,12 @@
 {
   "locales": [
     "en",
-    "cs"
+    "qaa"
   ],
+  "pseudoLocale": "qaa",
+  "fallbackLocales": {
+    "qaa": "en"
+  },
   "catalogs": [
     {
       "path": "src/locales/{locale}/messages",

--- a/apps/web/crowdin.yml
+++ b/apps/web/crowdin.yml
@@ -1,0 +1,8 @@
+project_id: '556737'
+api_token: 'f412c35a318449726ab736218ecf26de4293a8b63f4987303960b7f463e8a3a1a64c8932142764ff'
+
+preserve_hierarchy: true
+
+files:
+  - source: /**/locales/en/*.po
+    translation: /**/locales/%two_letters_code%/%original_file_name%

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "@apollo/client": "^3.7.3",
     "@aws-sdk/client-s3": "^3.238.0",
-    "@crowdin/cli": "3",
     "@giphy/js-fetch-api": "^4.7.1",
     "@giphy/react-components": "^6.5.1",
     "@headlessui/react": "^1.7.7",
@@ -62,6 +61,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.7",
+    "@crowdin/cli": "^3.9.1",
     "@giphy/js-types": "^4.2.1",
     "@lingui/cli": "^3.15.0",
     "@lingui/macro": "^3.15.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.3",
     "@aws-sdk/client-s3": "^3.238.0",
+    "@crowdin/cli": "3",
     "@giphy/js-fetch-api": "^4.7.1",
     "@giphy/react-components": "^6.5.1",
     "@headlessui/react": "^1.7.7",
@@ -30,6 +31,7 @@
     "@lexical/link": "^0.7.5",
     "@lexical/markdown": "^0.7.5",
     "@lexical/react": "^0.7.5",
+    "@lingui/react": "^3.15.0",
     "@tanstack/react-query": "^4.20.4",
     "@tippyjs/react": "^4.2.6",
     "@xmtp/xmtp-js": "^7.7.2",
@@ -62,7 +64,10 @@
     "zustand": "^4.1.4"
   },
   "devDependencies": {
+    "@babel/core": "^7.20.7",
     "@giphy/js-types": "^4.2.1",
+    "@lingui/cli": "^3.15.0",
+    "@lingui/macro": "^3.15.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/line-clamp": "^0.4.2",
@@ -73,6 +78,7 @@
     "@types/websocket": "^1.0.5",
     "abis": "*",
     "autoprefixer": "^10.4.13",
+    "babel-plugin-macros": "^3.1.0",
     "cypress": "^12.2.0",
     "data": "*",
     "eslint-config-weblint": "*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,12 +3,18 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --port 4783",
+    "dev": "lingui compile && next dev --port 4783",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .js,.ts,.tsx",
-    "test": "cypress run --headless"
+    "test": "cypress run --headless",
+    "extract": "NODE_ENV=development lingui extract",
+    "compile": "lingui compile",
+    "crowdin": "crowdin",
+    "sync": "crowdin push && crowdin pull",
+    "sync:sources": "crowdin push",
+    "sync:translations": "crowdin pull"
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "lingui compile && next dev --port 4783",
+    "prebuild": "lingui compile",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,11 +11,7 @@
     "lint": "eslint . --ext .js,.ts,.tsx",
     "test": "cypress run --headless",
     "extract": "NODE_ENV=development lingui extract",
-    "compile": "lingui compile",
-    "crowdin": "crowdin",
-    "sync": "crowdin push && crowdin pull",
-    "sync:sources": "crowdin push",
-    "sync:translations": "crowdin pull"
+    "compile": "lingui compile"
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,15 +3,15 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "lingui compile && next dev --port 4783",
+    "predev": "lingui compile",
+    "dev": "next dev --port 4783",
     "prebuild": "lingui compile",
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .js,.ts,.tsx",
     "test": "cypress run --headless",
-    "extract": "NODE_ENV=development lingui extract",
-    "compile": "lingui compile"
+    "extract": "NODE_ENV=development lingui extract"
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",

--- a/apps/web/src/components/Common/Providers.tsx
+++ b/apps/web/src/components/Common/Providers.tsx
@@ -1,8 +1,12 @@
 import { ApolloProvider } from '@apollo/client';
+import { initLocale } from '@lib/i18n';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ALCHEMY_KEY, IS_MAINNET } from 'data/constants';
 import { ThemeProvider } from 'next-themes';
 import type { ReactNode } from 'react';
+import { useEffect } from 'react';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, polygonMumbai } from 'wagmi/chains';
 import { InjectedConnector } from 'wagmi/connectors/injected';
@@ -34,18 +38,24 @@ const wagmiClient = createClient({
 const queryClient = new QueryClient();
 
 const Providers = ({ children }: { children: ReactNode }) => {
+  useEffect(() => {
+    initLocale();
+  }, []);
+
   return (
-    <ErrorBoundary>
-      <WagmiConfig client={wagmiClient}>
-        <ApolloProvider client={client}>
-          <QueryClientProvider client={queryClient}>
-            <ThemeProvider defaultTheme="light" attribute="class">
-              <Layout>{children}</Layout>
-            </ThemeProvider>
-          </QueryClientProvider>
-        </ApolloProvider>
-      </WagmiConfig>
-    </ErrorBoundary>
+    <I18nProvider i18n={i18n}>
+      <ErrorBoundary>
+        <WagmiConfig client={wagmiClient}>
+          <ApolloProvider client={client}>
+            <QueryClientProvider client={queryClient}>
+              <ThemeProvider defaultTheme="light" attribute="class">
+                <Layout>{children}</Layout>
+              </ThemeProvider>
+            </QueryClientProvider>
+          </ApolloProvider>
+        </WagmiConfig>
+      </ErrorBoundary>
+    </I18nProvider>
   );
 };
 

--- a/apps/web/src/components/Composer/Editor/index.tsx
+++ b/apps/web/src/components/Composer/Editor/index.tsx
@@ -10,6 +10,7 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
 import { MarkdownShortcutPlugin } from '@lexical/react/LexicalMarkdownShortcutPlugin';
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
+import { Trans } from '@lingui/macro';
 import { ERROR_MESSAGE } from 'data/constants';
 import type { FC } from 'react';
 import { toast } from 'react-hot-toast';
@@ -40,7 +41,7 @@ const Editor: FC = () => {
         contentEditable={<ContentEditable className="px-5 block my-4 min-h-[65px] overflow-auto" />}
         placeholder={
           <div className="px-5 absolute top-[65px] text-gray-400 pointer-events-none whitespace-nowrap">
-            What's happening?
+            <Trans>What's happening?</Trans>
           </div>
         }
         ErrorBoundary={() => <div>{ERROR_MESSAGE}</div>}

--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -21,6 +21,7 @@ import getUserLocale from '@lib/getUserLocale';
 import onError from '@lib/onError';
 import splitSignature from '@lib/splitSignature';
 import uploadToArweave from '@lib/uploadToArweave';
+import { t } from '@lingui/macro';
 import { LensHubProxy } from 'abis';
 import clsx from 'clsx';
 import {
@@ -541,7 +542,9 @@ const NewPublication: FC<Props> = ({ publication }) => {
             }
             onClick={createPublication}
           >
-            {isComment ? 'Comment' : 'Post'}
+            {isComment
+              ? t({ id: '[cta]Comment', message: 'Comment' })
+              : t({ id: '[cta]Post', message: 'Post' })}
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/Composer/Post/New.tsx
+++ b/apps/web/src/components/Composer/Post/New.tsx
@@ -4,6 +4,7 @@ import { Tooltip } from '@components/UI/Tooltip';
 import { PencilAltIcon } from '@heroicons/react/outline';
 import formatHandle from '@lib/formatHandle';
 import getAvatar from '@lib/getAvatar';
+import { Trans } from '@lingui/macro';
 import { useRouter } from 'next/router';
 import type { FC, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
@@ -81,7 +82,9 @@ const NewPost: FC = () => {
           onClick={() => openModal('update')}
         >
           <PencilAltIcon className="h-5 w-5" />
-          <span>What's happening?</span>
+          <span>
+            <Trans>What's happening?</Trans>
+          </span>
         </button>
         <Modal
           title="Create post"

--- a/apps/web/src/components/Composer/Post/New.tsx
+++ b/apps/web/src/components/Composer/Post/New.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from '@components/UI/Tooltip';
 import { PencilAltIcon } from '@heroicons/react/outline';
 import formatHandle from '@lib/formatHandle';
 import getAvatar from '@lib/getAvatar';
-import { Trans } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import { useRouter } from 'next/router';
 import type { FC, ReactNode } from 'react';
 import { useEffect, useState } from 'react';
@@ -87,7 +87,7 @@ const NewPost: FC = () => {
           </span>
         </button>
         <Modal
-          title="Create post"
+          title={t`Create post`}
           size="md"
           show={showNewPostModal}
           onClose={() => setShowNewPostModal(false)}

--- a/apps/web/src/components/Explore/Feed.tsx
+++ b/apps/web/src/components/Explore/Feed.tsx
@@ -6,6 +6,7 @@ import { ErrorMessage } from '@components/UI/ErrorMessage';
 import InfiniteLoader from '@components/UI/InfiniteLoader';
 import type { LensterPublication } from '@generated/types';
 import { CollectionIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
 import { SCROLL_THRESHOLD } from 'data/constants';
 import { CustomFiltersTypes, PublicationSortCriteria, useExploreFeedQuery } from 'lens';
 import type { FC } from 'react';
@@ -52,7 +53,11 @@ const Feed: FC<Props> = ({ focus, feedType = PublicationSortCriteria.CuratedProf
   if (publications?.length === 0) {
     return (
       <EmptyState
-        message={<div>No posts yet!</div>}
+        message={
+          <div>
+            <Trans>No posts yet!</Trans>
+          </div>
+        }
         icon={<CollectionIcon className="w-8 h-8 text-brand" />}
       />
     );

--- a/apps/web/src/components/Explore/FeedType.tsx
+++ b/apps/web/src/components/Explore/FeedType.tsx
@@ -1,4 +1,5 @@
 import { Analytics } from '@lib/analytics';
+import { t } from '@lingui/macro';
 import clsx from 'clsx';
 import { PublicationMainFocus } from 'lens';
 import type { Dispatch, FC } from 'react';
@@ -33,11 +34,11 @@ const FeedType: FC<Props> = ({ setFocus, focus }) => {
 
   return (
     <div className="flex flex-wrap gap-3 px-5 mt-3 sm:px-0 sm:mt-0">
-      <FeedLink name="All posts" />
-      <FeedLink name="Text" type={PublicationMainFocus.TextOnly} />
-      <FeedLink name="Video" type={PublicationMainFocus.Video} />
-      <FeedLink name="Audio" type={PublicationMainFocus.Audio} />
-      <FeedLink name="Images" type={PublicationMainFocus.Image} />
+      <FeedLink name={t`All posts`} />
+      <FeedLink name={t`Text`} type={PublicationMainFocus.TextOnly} />
+      <FeedLink name={t`Video`} type={PublicationMainFocus.Video} />
+      <FeedLink name={t`Audio`} type={PublicationMainFocus.Audio} />
+      <FeedLink name={t`Images`} type={PublicationMainFocus.Image} />
     </div>
   );
 };

--- a/apps/web/src/components/Explore/index.tsx
+++ b/apps/web/src/components/Explore/index.tsx
@@ -6,6 +6,7 @@ import { GridItemEight, GridItemFour, GridLayout } from '@components/UI/GridLayo
 import { Tab } from '@headlessui/react';
 import { Analytics } from '@lib/analytics';
 import isFeatureEnabled from '@lib/isFeatureEnabled';
+import { t } from '@lingui/macro';
 import clsx from 'clsx';
 import { APP_NAME, STATIC_IMAGES_URL } from 'data/constants';
 import { PublicationSortCriteria } from 'lens';
@@ -21,10 +22,10 @@ const Explore: NextPage = () => {
   const [focus, setFocus] = useState<any>();
 
   const tabs = [
-    { name: 'For you', emoji: 'leaf-fluttering-in-wind.png', type: PublicationSortCriteria.CuratedProfiles },
-    { name: 'Popular', emoji: 'hundred-points.png', type: PublicationSortCriteria.TopCommented },
-    { name: 'Trending', emoji: 'heart-on-fire.png', type: PublicationSortCriteria.TopCollected },
-    { name: 'Interesting', emoji: 'hushed-face.png', type: PublicationSortCriteria.TopMirrored }
+    { name: t`For you`, emoji: 'leaf-fluttering-in-wind.png', type: PublicationSortCriteria.CuratedProfiles },
+    { name: t`Popular`, emoji: 'hundred-points.png', type: PublicationSortCriteria.TopCommented },
+    { name: t`Trending`, emoji: 'heart-on-fire.png', type: PublicationSortCriteria.TopCollected },
+    { name: t`Interesting`, emoji: 'hushed-face.png', type: PublicationSortCriteria.TopMirrored }
   ];
 
   return (

--- a/apps/web/src/components/Home/BetaWarning.tsx
+++ b/apps/web/src/components/Home/BetaWarning.tsx
@@ -1,5 +1,6 @@
 import { Card } from '@components/UI/Card';
 import { BeakerIcon, CurrencyDollarIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
 import { APP_NAME, IS_MAINNET } from 'data/constants';
 import type { FC } from 'react';
 
@@ -11,16 +12,18 @@ const BetaWarning: FC = () => {
     >
       <div className="flex items-center space-x-2 font-bold">
         <BeakerIcon className="w-5 h-5" />
-        <p>Beta warning!</p>
+        <p>
+          <Trans>Beta warning!</Trans>
+        </p>
       </div>
       <p className="text-sm leading-[22px]">
-        {APP_NAME} is still in the beta phase, things may break, please handle us with care.
+        <Trans>{APP_NAME} is still in the beta phase, things may break, please handle us with care.</Trans>
       </p>
       {!IS_MAINNET && (
         <div className="flex items-center space-x-1.5 text-sm font-bold">
           <CurrencyDollarIcon className="w-4 h-4" />
           <a href="https://faucet.polygon.technology/" target="_blank" rel="noreferrer noopener">
-            Get testnet tokens
+            <Trans>Get testnet tokens</Trans>
           </a>
         </div>
       )}

--- a/apps/web/src/components/Home/EnableDispatcher.tsx
+++ b/apps/web/src/components/Home/EnableDispatcher.tsx
@@ -1,6 +1,7 @@
 import ToggleDispatcher from '@components/Settings/Dispatcher/ToggleDispatcher';
 import { Card } from '@components/UI/Card';
 import { HandIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
 import { APP_NAME } from 'data/constants';
 import type { FC } from 'react';
 import { useAppStore } from 'src/store/app';
@@ -19,10 +20,14 @@ const EnableDispatcher: FC = () => {
     >
       <div className="flex items-center space-x-2 font-bold">
         <HandIcon className="w-5 h-5" />
-        <p>Action Required</p>
+        <p>
+          <Trans>Action Required</Trans>
+        </p>
       </div>
       <p className="text-sm leading-[22px]">
-        You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions.
+        <Trans>
+          You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions.
+        </Trans>
       </p>
       <ToggleDispatcher buttonSize="sm" />
     </Card>

--- a/apps/web/src/components/Home/FeedEventFilters.tsx
+++ b/apps/web/src/components/Home/FeedEventFilters.tsx
@@ -3,6 +3,7 @@ import { Checkbox } from '@components/UI/Checkbox';
 import { Tooltip } from '@components/UI/Tooltip';
 import { Menu } from '@headlessui/react';
 import { AdjustmentsIcon } from '@heroicons/react/outline';
+import { t } from '@lingui/macro';
 import clsx from 'clsx';
 import type { ChangeEvent, FC } from 'react';
 import { useTimelinePersistStore } from 'src/store/timeline';
@@ -18,7 +19,7 @@ const FeedEventFilters: FC = () => {
   return (
     <Menu as="div" className="relative">
       <Menu.Button className="rounded-md hover:bg-gray-300 p-1 hover:bg-opacity-20">
-        <Tooltip placement="top" content="Filter">
+        <Tooltip placement="top" content={t`Filter`}>
           <AdjustmentsIcon className="w-5 h-5 text-brand" />
         </Tooltip>
       </Menu.Button>

--- a/apps/web/src/components/Home/FeedType.tsx
+++ b/apps/web/src/components/Home/FeedType.tsx
@@ -1,6 +1,7 @@
 import TabButton from '@components/UI/TabButton';
 import { SparklesIcon, ViewListIcon } from '@heroicons/react/outline';
 import { Analytics } from '@lib/analytics';
+import { t } from '@lingui/macro';
 import type { Dispatch, FC } from 'react';
 import { MISCELLANEOUS } from 'src/tracking';
 
@@ -17,7 +18,7 @@ const FeedType: FC<Props> = ({ setFeedType, feedType }) => {
     <div className="flex flex-wrap items-center md:px-0 px-1 justify-between">
       <div className="flex overflow-x-auto gap-3 sm:px-0">
         <TabButton
-          name="Timeline"
+          name={t`Timeline`}
           icon={<ViewListIcon className="w-4 h-4" />}
           active={feedType === 'TIMELINE'}
           showOnSm={false}
@@ -27,7 +28,7 @@ const FeedType: FC<Props> = ({ setFeedType, feedType }) => {
           }}
         />
         <TabButton
-          name="Highlights"
+          name={t`Highlights`}
           icon={<SparklesIcon className="w-4 h-4" />}
           active={feedType === 'HIGHLIGHTS'}
           showOnSm={false}

--- a/apps/web/src/components/Home/Hero.tsx
+++ b/apps/web/src/components/Home/Hero.tsx
@@ -1,3 +1,4 @@
+import { Trans } from '@lingui/macro';
 import { APP_NAME } from 'data/constants';
 import type { FC } from 'react';
 
@@ -6,9 +7,13 @@ const Hero: FC = () => {
     <div className="py-12 border-b bg-hero dark:border-b-gray-700">
       <div className="px-5 mx-auto max-w-screen-xl flex items-stretch py-8 w-full text-center sm:py-12 sm:text-left">
         <div className="flex-1 space-y-3">
-          <div className="text-2xl font-extrabold sm:text-4xl font-serif">Welcome to {APP_NAME} 👋</div>
+          <div className="text-2xl font-extrabold sm:text-4xl font-serif">
+            <Trans>Welcome to {APP_NAME} 👋</Trans>
+          </div>
           <div className="leading-7 text-gray-700 dark:text-gray-300">
-            {APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿
+            <Trans>
+              {APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿
+            </Trans>
           </div>
         </div>
         <div className="hidden flex-1 flex-shrink-0 w-full sm:block" />

--- a/apps/web/src/components/Home/Highlights.tsx
+++ b/apps/web/src/components/Home/Highlights.tsx
@@ -7,6 +7,7 @@ import { ErrorMessage } from '@components/UI/ErrorMessage';
 import InfiniteLoader from '@components/UI/InfiniteLoader';
 import type { LensterPublication } from '@generated/types';
 import { CollectionIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
 import { SCROLL_THRESHOLD } from 'data/constants';
 import { useFeedHighlightsQuery } from 'lens';
 import type { FC } from 'react';
@@ -44,7 +45,11 @@ const Highlights: FC = () => {
   if (publications?.length === 0) {
     return (
       <EmptyState
-        message={<div>No posts yet!</div>}
+        message={
+          <div>
+            <Trans>No posts yet!</Trans>
+          </div>
+        }
         icon={<CollectionIcon className="w-8 h-8 text-brand" />}
       />
     );

--- a/apps/web/src/components/Home/RecommendedProfiles.tsx
+++ b/apps/web/src/components/Home/RecommendedProfiles.tsx
@@ -7,6 +7,7 @@ import { Modal } from '@components/UI/Modal';
 import { DotsCircleHorizontalIcon, UsersIcon } from '@heroicons/react/outline';
 import { SparklesIcon } from '@heroicons/react/solid';
 import { Analytics } from '@lib/analytics';
+import { Trans } from '@lingui/macro';
 import type { Profile } from 'lens';
 import { useRecommendedProfilesQuery } from 'lens';
 import type { FC } from 'react';
@@ -19,7 +20,9 @@ const Title = () => {
   return (
     <div className="flex gap-2 items-center px-5 mb-2 sm:px-0">
       <SparklesIcon className="w-4 h-4 text-yellow-500" />
-      <div>Who to follow</div>
+      <div>
+        <Trans>Who to follow</Trans>
+      </div>
     </div>
   );
 };
@@ -82,7 +85,9 @@ const RecommendedProfiles: FC = () => {
           }}
         >
           <DotsCircleHorizontalIcon className="h-4 w-4" />
-          <span>Show more</span>
+          <span>
+            <Trans>Show more</Trans>
+          </span>
         </button>
       </Card>
       <Modal

--- a/apps/web/src/components/Home/SeeThroughLens.tsx
+++ b/apps/web/src/components/Home/SeeThroughLens.tsx
@@ -8,6 +8,7 @@ import { ChevronDownIcon } from '@heroicons/react/solid';
 import { Analytics } from '@lib/analytics';
 import formatHandle from '@lib/formatHandle';
 import getAvatar from '@lib/getAvatar';
+import { t, Trans } from '@lingui/macro';
 import clsx from 'clsx';
 import type { FeedItem, Profile, ProfileSearchResult } from 'lens';
 import {
@@ -97,7 +98,7 @@ const SeeThroughLens: FC = () => {
             className="bg-gray-200 w-5 h-5 rounded-full border dark:border-gray-700"
             alt={formatHandle(profile?.handle)}
           />
-          <span>{seeThroughProfile ? `@${formatHandle(profile?.handle)}` : 'My Feed'}</span>
+          <span>{seeThroughProfile ? `@${formatHandle(profile?.handle)}` : t`My Feed`}</span>
           <ChevronDownIcon className="w-4 h-4" />
         </span>
       </Menu.Button>
@@ -106,12 +107,14 @@ const SeeThroughLens: FC = () => {
           static
           className="absolute w-64 right-0 z-[5] mt-1 bg-white rounded-xl border shadow-sm dark:bg-gray-900 focus:outline-none dark:border-gray-700"
         >
-          <div className="text-xs pt-2 px-3">👀 See the feed through...</div>
+          <div className="text-xs pt-2 px-3">
+            <Trans>👀 See the feed through...</Trans>
+          </div>
           <div className="p-2">
             <Input
               type="text"
               className="py-2 px-3 text-sm"
-              placeholder="Search"
+              placeholder={t`Search`}
               value={searchText}
               autoFocus
               autoComplete="off"

--- a/apps/web/src/components/Home/SetProfile.tsx
+++ b/apps/web/src/components/Home/SetProfile.tsx
@@ -3,6 +3,7 @@ import { Card } from '@components/UI/Card';
 import { MinusCircleIcon, PencilAltIcon, PhotographIcon } from '@heroicons/react/outline';
 import { CheckCircleIcon } from '@heroicons/react/solid';
 import { Analytics } from '@lib/analytics';
+import { t, Trans } from '@lingui/macro';
 import clsx from 'clsx';
 import { APP_NAME } from 'data/constants';
 import Link from 'next/link';
@@ -47,19 +48,24 @@ const SetProfile: FC = () => {
     >
       <div className="flex items-center space-x-2 font-bold">
         <PhotographIcon className="w-5 h-5" />
-        <p>Setup your {APP_NAME} profile</p>
+        <p>
+          <Trans>Setup your {APP_NAME} profile</Trans>
+        </p>
       </div>
       <div className="space-y-1 text-sm leading-[22px]">
-        <Status finished={Boolean(currentProfile?.name)} title="Set profile name" />
-        <Status finished={Boolean(currentProfile?.bio)} title="Set profile bio" />
-        <Status finished={Boolean(currentProfile?.picture)} title="Set your avatar" />
+        <Status finished={Boolean(currentProfile?.name)} title={t`Set profile name`} />
+        <Status finished={Boolean(currentProfile?.bio)} title={t`Set profile bio`} />
+        <Status finished={Boolean(currentProfile?.picture)} title={t`Set your avatar`} />
         <div>
           <Link
             className="flex items-center space-x-2"
             onClick={() => Analytics.track(MISCELLANEOUS.NAVIGATE_UPDATE_PROFILE_INTERESTS)}
             href="/settings/interests"
           >
-            <Status finished={Boolean(currentProfile?.interests?.length)} title="Select profile interests" />
+            <Status
+              finished={Boolean(currentProfile?.interests?.length)}
+              title={t`Select profile interests`}
+            />
             <New />
           </Link>
         </div>
@@ -67,7 +73,7 @@ const SetProfile: FC = () => {
       <div className="flex items-center space-x-1.5 text-sm font-bold">
         <PencilAltIcon className="w-4 h-4" />
         <Link onClick={() => Analytics.track(MISCELLANEOUS.NAVIGATE_UPDATE_PROFILE)} href="/settings">
-          Update profile now
+          <Trans>Update profile now</Trans>
         </Link>
       </div>
     </Card>

--- a/apps/web/src/components/Home/Timeline/index.tsx
+++ b/apps/web/src/components/Home/Timeline/index.tsx
@@ -7,6 +7,7 @@ import { ErrorMessage } from '@components/UI/ErrorMessage';
 import InfiniteLoader from '@components/UI/InfiniteLoader';
 import type { LensterPublication } from '@generated/types';
 import { CollectionIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
 import { SCROLL_THRESHOLD } from 'data/constants';
 import type { FeedItem } from 'lens';
 import { FeedEventItemType, useTimelineQuery } from 'lens';
@@ -65,7 +66,11 @@ const Timeline: FC = () => {
   if (publications?.length === 0) {
     return (
       <EmptyState
-        message={<div>No posts yet!</div>}
+        message={
+          <div>
+            <Trans>No posts yet!</Trans>
+          </div>
+        }
         icon={<CollectionIcon className="w-8 h-8 text-brand" />}
       />
     );

--- a/apps/web/src/components/Home/Trending.tsx
+++ b/apps/web/src/components/Home/Trending.tsx
@@ -56,7 +56,9 @@ const Trending: FC = () => {
                 onClick={() => Analytics.track(MISCELLANEOUS.OPEN_TRENDING_TAG)}
               >
                 <div className="font-bold">{tag?.tag}</div>
-                <div className="text-[12px] lt-text-gray-500">{nFormatter(tag?.total)} Publications</div>
+                <Trans>
+                  <div className="text-[12px] lt-text-gray-500">{nFormatter(tag?.total)} Publications</div>
+                </Trans>
               </Link>
             </div>
           ) : null

--- a/apps/web/src/components/Home/Trending.tsx
+++ b/apps/web/src/components/Home/Trending.tsx
@@ -4,6 +4,7 @@ import { ErrorMessage } from '@components/UI/ErrorMessage';
 import { TrendingUpIcon } from '@heroicons/react/solid';
 import { Analytics } from '@lib/analytics';
 import nFormatter from '@lib/nFormatter';
+import { Trans } from '@lingui/macro';
 import type { TagResult } from 'lens';
 import { TagSortCriteria, useTrendingQuery } from 'lens';
 import Link from 'next/link';
@@ -14,7 +15,9 @@ const Title = () => {
   return (
     <div className="flex gap-2 items-center px-5 mb-2 sm:px-0">
       <TrendingUpIcon className="w-4 h-4 text-green-500" />
-      <div>Trending</div>
+      <div>
+        <Trans>Trending</Trans>
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/Mod/Feed.tsx
+++ b/apps/web/src/components/Mod/Feed.tsx
@@ -6,6 +6,7 @@ import { ErrorMessage } from '@components/UI/ErrorMessage';
 import InfiniteLoader from '@components/UI/InfiniteLoader';
 import type { LensterPublication } from '@generated/types';
 import { CollectionIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
 import { SCROLL_THRESHOLD } from 'data/constants';
 import { PublicationSortCriteria, PublicationTypes, useExploreFeedQuery } from 'lens';
 import type { FC } from 'react';
@@ -46,7 +47,11 @@ const Feed: FC = () => {
   if (publications?.length === 0) {
     return (
       <EmptyState
-        message={<div>No posts yet!</div>}
+        message={
+          <div>
+            <Trans>No posts yet!</Trans>
+          </div>
+        }
         icon={<CollectionIcon className="w-8 h-8 text-brand" />}
       />
     );

--- a/apps/web/src/components/Notification/Type/CollectNotification/index.tsx
+++ b/apps/web/src/components/Notification/Type/CollectNotification/index.tsx
@@ -6,7 +6,9 @@ import {
 import UserPreview from '@components/Shared/UserPreview';
 import { CollectionIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
-import { Trans } from '@lingui/macro';
+import type { MessageDescriptor } from '@lingui/core/cjs/i18n';
+import { defineMessage } from '@lingui/macro';
+import { Trans } from '@lingui/react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewCollectNotification } from 'lens';
@@ -22,7 +24,24 @@ interface Props {
   notification: NewCollectNotification;
 }
 
+const messages: Record<string, MessageDescriptor> = {
+  comment: defineMessage({
+    id: '<0><1/> collected your <2>comment</2></0>'
+  }),
+  mirror: defineMessage({
+    id: '<0><1/> collected your <2>mirror</2></0>'
+  }),
+  post: defineMessage({
+    id: '<0><1/> collected your <2>post</2></0>'
+  })
+};
+
+const defaultMessage = (typeName: string): string => {
+  return '<0><1/> collected your <2>' + typeName + '</2></0>';
+};
+
 const CollectNotification: FC<Props> = ({ notification }) => {
+  const typeName = notification?.collectedPublication.__typename?.toLowerCase() || '';
   return (
     <div className="flex justify-between items-start">
       <div className="space-y-2 w-4/5">
@@ -37,17 +56,18 @@ const CollectNotification: FC<Props> = ({ notification }) => {
           )}
         </div>
         <div className="ml-9">
-          <Trans>
-            {notification?.wallet?.defaultProfile ? (
-              <NotificationProfileName profile={notification?.wallet?.defaultProfile} />
-            ) : (
-              <NotificationWalletProfileName wallet={notification?.wallet} />
-            )}{' '}
-            <span className="text-gray-600 dark:text-gray-400">collected your </span>
-            <Link href={`/posts/${notification?.collectedPublication?.id}`} className="font-bold">
-              {notification?.collectedPublication.__typename?.toLowerCase()}
-            </Link>
-          </Trans>
+          <Trans
+            id={messages[typeName]?.id || defaultMessage(typeName)}
+            components={[
+              <span className="text-gray-600 dark:text-gray-400" key="" />,
+              notification?.wallet?.defaultProfile ? (
+                <NotificationProfileName profile={notification?.wallet?.defaultProfile} />
+              ) : (
+                <NotificationWalletProfileName wallet={notification?.wallet} />
+              ),
+              <Link href={`/posts/${notification?.collectedPublication?.id}`} className="font-bold" key="" />
+            ]}
+          />
           <CollectedContent notification={notification} />
           <CollectedAmount notification={notification} />
         </div>

--- a/apps/web/src/components/Notification/Type/CollectNotification/index.tsx
+++ b/apps/web/src/components/Notification/Type/CollectNotification/index.tsx
@@ -6,6 +6,7 @@ import {
 import UserPreview from '@components/Shared/UserPreview';
 import { CollectionIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
+import { Trans } from '@lingui/macro';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewCollectNotification } from 'lens';
@@ -36,15 +37,17 @@ const CollectNotification: FC<Props> = ({ notification }) => {
           )}
         </div>
         <div className="ml-9">
-          {notification?.wallet?.defaultProfile ? (
-            <NotificationProfileName profile={notification?.wallet?.defaultProfile} />
-          ) : (
-            <NotificationWalletProfileName wallet={notification?.wallet} />
-          )}{' '}
-          <span className="text-gray-600 dark:text-gray-400">collected your </span>
-          <Link href={`/posts/${notification?.collectedPublication?.id}`} className="font-bold">
-            {notification?.collectedPublication.__typename?.toLowerCase()}
-          </Link>
+          <Trans>
+            {notification?.wallet?.defaultProfile ? (
+              <NotificationProfileName profile={notification?.wallet?.defaultProfile} />
+            ) : (
+              <NotificationWalletProfileName wallet={notification?.wallet} />
+            )}{' '}
+            <span className="text-gray-600 dark:text-gray-400">collected your </span>
+            <Link href={`/posts/${notification?.collectedPublication?.id}`} className="font-bold">
+              {notification?.collectedPublication.__typename?.toLowerCase()}
+            </Link>
+          </Trans>
           <CollectedContent notification={notification} />
           <CollectedAmount notification={notification} />
         </div>

--- a/apps/web/src/components/Notification/Type/CommentNotification.tsx
+++ b/apps/web/src/components/Notification/Type/CommentNotification.tsx
@@ -2,7 +2,9 @@ import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
 import { ChatAlt2Icon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
-import { Trans } from '@lingui/macro';
+import type { MessageDescriptor } from '@lingui/core/cjs/i18n';
+import { defineMessage } from '@lingui/macro';
+import { Trans } from '@lingui/react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewCommentNotification } from 'lens';
@@ -17,7 +19,24 @@ interface Props {
   notification: NewCommentNotification;
 }
 
+const messages: Record<string, MessageDescriptor> = {
+  comment: defineMessage({
+    id: '<0><1/> commented on your <2>comment</2></0>'
+  }),
+  mirror: defineMessage({
+    id: '<0><1/> commented on your <2>mirror</2></0>'
+  }),
+  post: defineMessage({
+    id: '<0><1/> commented on your <2>post</2></0>'
+  })
+};
+
+const defaultMessage = (typeName: string): string => {
+  return '<0><1/> commented on your <2>' + typeName + '</2></0>';
+};
+
 const CommentNotification: FC<Props> = ({ notification }) => {
+  const typeName = notification?.comment?.commentOn?.__typename?.toLowerCase() || '';
   return (
     <div className="flex justify-between items-start">
       <div className="space-y-2 w-4/5">
@@ -28,13 +47,14 @@ const CommentNotification: FC<Props> = ({ notification }) => {
           </UserPreview>
         </div>
         <div className="ml-9">
-          <Trans>
-            <NotificationProfileName profile={notification?.profile} />{' '}
-            <span className="text-gray-600 dark:text-gray-400">commented on your </span>
-            <Link href={`/posts/${notification?.comment?.commentOn?.id}`} className="font-bold">
-              {notification?.comment?.commentOn?.__typename?.toLowerCase()}
-            </Link>
-          </Trans>
+          <Trans
+            id={messages[typeName]?.id || defaultMessage(typeName)}
+            components={[
+              <span className="text-gray-600 dark:text-gray-400" key="" />,
+              <NotificationProfileName profile={notification?.profile} key="" />,
+              <Link href={`/posts/${notification?.comment?.commentOn?.id}`} className="font-bold" key="" />
+            ]}
+          />
           <Link
             href={`/posts/${notification?.comment.id}`}
             className="lt-text-gray-500 line-clamp-2 linkify mt-2"

--- a/apps/web/src/components/Notification/Type/CommentNotification.tsx
+++ b/apps/web/src/components/Notification/Type/CommentNotification.tsx
@@ -2,6 +2,7 @@ import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
 import { ChatAlt2Icon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
+import { Trans } from '@lingui/macro';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewCommentNotification } from 'lens';
@@ -27,11 +28,13 @@ const CommentNotification: FC<Props> = ({ notification }) => {
           </UserPreview>
         </div>
         <div className="ml-9">
-          <NotificationProfileName profile={notification?.profile} />{' '}
-          <span className="text-gray-600 dark:text-gray-400">commented on your </span>
-          <Link href={`/posts/${notification?.comment?.commentOn?.id}`} className="font-bold">
-            {notification?.comment?.commentOn?.__typename?.toLowerCase()}
-          </Link>
+          <Trans>
+            <NotificationProfileName profile={notification?.profile} />{' '}
+            <span className="text-gray-600 dark:text-gray-400">commented on your </span>
+            <Link href={`/posts/${notification?.comment?.commentOn?.id}`} className="font-bold">
+              {notification?.comment?.commentOn?.__typename?.toLowerCase()}
+            </Link>
+          </Trans>
           <Link
             href={`/posts/${notification?.comment.id}`}
             className="lt-text-gray-500 line-clamp-2 linkify mt-2"

--- a/apps/web/src/components/Notification/Type/FollowerNotification.tsx
+++ b/apps/web/src/components/Notification/Type/FollowerNotification.tsx
@@ -1,7 +1,8 @@
 import UserPreview from '@components/Shared/UserPreview';
 import { UserAddIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
-import { Trans } from '@lingui/macro';
+import { defineMessage } from '@lingui/macro';
+import { Trans } from '@lingui/react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewFollowerNotification } from 'lens';
@@ -16,6 +17,14 @@ dayjs.extend(relativeTime);
 interface Props {
   notification: NewFollowerNotification;
 }
+
+const messageFollow = defineMessage({
+  id: '<0><1/> followed you</0>'
+});
+
+const messageSuperFollow = defineMessage({
+  id: '<0><1/> super followed you</0>'
+});
 
 const FollowerNotification: FC<Props> = ({ notification }) => {
   const currentProfile = useAppStore((state) => state.currentProfile);
@@ -39,16 +48,17 @@ const FollowerNotification: FC<Props> = ({ notification }) => {
           )}
         </div>
         <div className="ml-9">
-          <Trans>
-            {notification?.wallet?.defaultProfile ? (
-              <NotificationProfileName profile={notification?.wallet?.defaultProfile} />
-            ) : (
-              <NotificationWalletProfileName wallet={notification?.wallet} />
-            )}{' '}
-            <span className="text-gray-600 dark:text-gray-400">
-              {isSuperFollow ? 'super' : ''} followed you
-            </span>
-          </Trans>
+          <Trans
+            id={(isSuperFollow ? messageSuperFollow.id : messageFollow.id) || ''}
+            components={[
+              <span className="text-gray-600 dark:text-gray-400" key="" />,
+              notification?.wallet?.defaultProfile ? (
+                <NotificationProfileName profile={notification?.wallet?.defaultProfile} />
+              ) : (
+                <NotificationWalletProfileName wallet={notification?.wallet} />
+              )
+            ]}
+          />
         </div>
       </div>
       <div className="text-gray-400 text-[12px]" title={formatTime(notification?.createdAt)}>

--- a/apps/web/src/components/Notification/Type/FollowerNotification.tsx
+++ b/apps/web/src/components/Notification/Type/FollowerNotification.tsx
@@ -1,6 +1,7 @@
 import UserPreview from '@components/Shared/UserPreview';
 import { UserAddIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
+import { Trans } from '@lingui/macro';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewFollowerNotification } from 'lens';
@@ -38,14 +39,16 @@ const FollowerNotification: FC<Props> = ({ notification }) => {
           )}
         </div>
         <div className="ml-9">
-          {notification?.wallet?.defaultProfile ? (
-            <NotificationProfileName profile={notification?.wallet?.defaultProfile} />
-          ) : (
-            <NotificationWalletProfileName wallet={notification?.wallet} />
-          )}{' '}
-          <span className="text-gray-600 dark:text-gray-400">
-            {isSuperFollow ? 'super' : ''} followed you
-          </span>
+          <Trans>
+            {notification?.wallet?.defaultProfile ? (
+              <NotificationProfileName profile={notification?.wallet?.defaultProfile} />
+            ) : (
+              <NotificationWalletProfileName wallet={notification?.wallet} />
+            )}{' '}
+            <span className="text-gray-600 dark:text-gray-400">
+              {isSuperFollow ? 'super' : ''} followed you
+            </span>
+          </Trans>
         </div>
       </div>
       <div className="text-gray-400 text-[12px]" title={formatTime(notification?.createdAt)}>

--- a/apps/web/src/components/Notification/Type/LikeNotification.tsx
+++ b/apps/web/src/components/Notification/Type/LikeNotification.tsx
@@ -2,6 +2,7 @@ import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
 import { HeartIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
+import { Trans } from '@lingui/macro';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewReactionNotification } from 'lens';
@@ -27,11 +28,13 @@ const LikeNotification: FC<Props> = ({ notification }) => {
           </UserPreview>
         </div>
         <div className="ml-9">
-          <NotificationProfileName profile={notification?.profile} />{' '}
-          <span className="pl-0.5 text-gray-600 dark:text-gray-400">liked your </span>
-          <Link href={`/posts/${notification?.publication?.id}`} className="font-bold">
-            {notification?.publication?.__typename?.toLowerCase()}
-          </Link>
+          <Trans>
+            <NotificationProfileName profile={notification?.profile} />{' '}
+            <span className="pl-0.5 text-gray-600 dark:text-gray-400">liked your </span>
+            <Link href={`/posts/${notification?.publication?.id}`} className="font-bold">
+              {notification?.publication?.__typename?.toLowerCase()}
+            </Link>
+          </Trans>
           <Link
             href={`/posts/${notification?.publication?.id}`}
             className="lt-text-gray-500 line-clamp-2 linkify mt-2"

--- a/apps/web/src/components/Notification/Type/LikeNotification.tsx
+++ b/apps/web/src/components/Notification/Type/LikeNotification.tsx
@@ -2,7 +2,9 @@ import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
 import { HeartIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
-import { Trans } from '@lingui/macro';
+import type { MessageDescriptor } from '@lingui/core/cjs/i18n';
+import { defineMessage } from '@lingui/macro';
+import { Trans } from '@lingui/react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewReactionNotification } from 'lens';
@@ -17,7 +19,24 @@ interface Props {
   notification: NewReactionNotification;
 }
 
+const messages: Record<string, MessageDescriptor> = {
+  comment: defineMessage({
+    id: '<0><1/> liked your <2>comment</2></0>'
+  }),
+  mirror: defineMessage({
+    id: '<0><1/> liked your <2>mirror</2></0>'
+  }),
+  post: defineMessage({
+    id: '<0><1/> liked your <2>post</2></0>'
+  })
+};
+
+const defaultMessage = (typeName: string): string => {
+  return '<0><1/> liked your <2>' + typeName + '</2></0>';
+};
+
 const LikeNotification: FC<Props> = ({ notification }) => {
+  const typeName = notification?.publication?.__typename?.toLowerCase() || '';
   return (
     <div className="flex justify-between items-start">
       <div className="space-y-2 w-4/5">
@@ -28,13 +47,14 @@ const LikeNotification: FC<Props> = ({ notification }) => {
           </UserPreview>
         </div>
         <div className="ml-9">
-          <Trans>
-            <NotificationProfileName profile={notification?.profile} />{' '}
-            <span className="pl-0.5 text-gray-600 dark:text-gray-400">liked your </span>
-            <Link href={`/posts/${notification?.publication?.id}`} className="font-bold">
-              {notification?.publication?.__typename?.toLowerCase()}
-            </Link>
-          </Trans>
+          <Trans
+            id={messages[typeName]?.id || defaultMessage(typeName)}
+            components={[
+              <span className="pl-0.5 text-gray-600 dark:text-gray-400" key="" />,
+              <NotificationProfileName profile={notification?.profile} key="" />,
+              <Link href={`/posts/${notification?.publication?.id}`} className="font-bold" key="" />
+            ]}
+          />
           <Link
             href={`/posts/${notification?.publication?.id}`}
             className="lt-text-gray-500 line-clamp-2 linkify mt-2"

--- a/apps/web/src/components/Notification/Type/MentionNotification.tsx
+++ b/apps/web/src/components/Notification/Type/MentionNotification.tsx
@@ -2,7 +2,9 @@ import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
 import { AtSymbolIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
-import { Trans } from '@lingui/macro';
+import type { MessageDescriptor } from '@lingui/core/cjs/i18n';
+import { defineMessage } from '@lingui/macro';
+import { Trans } from '@lingui/react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewMentionNotification } from 'lens';
@@ -17,9 +19,25 @@ interface Props {
   notification: NewMentionNotification;
 }
 
+const messages: Record<string, MessageDescriptor> = {
+  comment: defineMessage({
+    id: '<0><1/> mentioned you in a <2>comment</2></0>'
+  }),
+  mirror: defineMessage({
+    id: '<0><1/> mentioned you in a <2>mirror</2></0>'
+  }),
+  post: defineMessage({
+    id: '<0><1/> mentioned you in a <2>post</2></0>'
+  })
+};
+
+const defaultMessage = (typeName: string): string => {
+  return '<0><1/> mentioned you in a <2>' + typeName + '</2></0>';
+};
+
 const MentionNotification: FC<Props> = ({ notification }) => {
   const profile = notification?.mentionPublication?.profile;
-
+  const typeName = notification?.mentionPublication.__typename?.toLowerCase() || '';
   return (
     <div className="flex justify-between items-start">
       <div className="space-y-2 w-4/5">
@@ -30,13 +48,14 @@ const MentionNotification: FC<Props> = ({ notification }) => {
           </UserPreview>
         </div>
         <div className="ml-9">
-          <Trans>
-            <NotificationProfileName profile={profile} />{' '}
-            <span className="text-gray-600 dark:text-gray-400">mentioned you in a </span>
-            <Link href={`/posts/${notification?.mentionPublication?.id}`} className="font-bold">
-              {notification?.mentionPublication.__typename?.toLowerCase()}
-            </Link>
-          </Trans>
+          <Trans
+            id={messages[typeName]?.id || defaultMessage(typeName)}
+            components={[
+              <span className="text-gray-600 dark:text-gray-400" key="" />,
+              <NotificationProfileName profile={profile} key="" />,
+              <Link href={`/posts/${notification?.mentionPublication?.id}`} className="font-bold" key="" />
+            ]}
+          />
           <Link
             href={`/posts/${notification?.mentionPublication.id}`}
             className="lt-text-gray-500 line-clamp-2 linkify mt-2"

--- a/apps/web/src/components/Notification/Type/MentionNotification.tsx
+++ b/apps/web/src/components/Notification/Type/MentionNotification.tsx
@@ -2,6 +2,7 @@ import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
 import { AtSymbolIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
+import { Trans } from '@lingui/macro';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewMentionNotification } from 'lens';
@@ -29,11 +30,13 @@ const MentionNotification: FC<Props> = ({ notification }) => {
           </UserPreview>
         </div>
         <div className="ml-9">
-          <NotificationProfileName profile={profile} />{' '}
-          <span className="text-gray-600 dark:text-gray-400">mentioned you in a </span>
-          <Link href={`/posts/${notification?.mentionPublication?.id}`} className="font-bold">
-            {notification?.mentionPublication.__typename?.toLowerCase()}
-          </Link>
+          <Trans>
+            <NotificationProfileName profile={profile} />{' '}
+            <span className="text-gray-600 dark:text-gray-400">mentioned you in a </span>
+            <Link href={`/posts/${notification?.mentionPublication?.id}`} className="font-bold">
+              {notification?.mentionPublication.__typename?.toLowerCase()}
+            </Link>
+          </Trans>
           <Link
             href={`/posts/${notification?.mentionPublication.id}`}
             className="lt-text-gray-500 line-clamp-2 linkify mt-2"

--- a/apps/web/src/components/Notification/Type/MirrorNotification.tsx
+++ b/apps/web/src/components/Notification/Type/MirrorNotification.tsx
@@ -2,7 +2,9 @@ import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
 import { SwitchHorizontalIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
-import { Trans } from '@lingui/macro';
+import type { MessageDescriptor } from '@lingui/core/cjs/i18n';
+import { defineMessage } from '@lingui/macro';
+import { Trans } from '@lingui/react';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewMirrorNotification } from 'lens';
@@ -17,7 +19,24 @@ interface Props {
   notification: NewMirrorNotification;
 }
 
+const messages: Record<string, MessageDescriptor> = {
+  comment: defineMessage({
+    id: '<0><1/> commented on your <2>comment</2></0>'
+  }),
+  mirror: defineMessage({
+    id: '<0><1/> commented on your <2>mirror</2></0>'
+  }),
+  post: defineMessage({
+    id: '<0><1/> commented on your <2>post</2></0>'
+  })
+};
+
+const defaultMessage = (typeName: string): string => {
+  return '<0><1/> commented on your <2>' + typeName + '</2></0>';
+};
+
 const MirrorNotification: FC<Props> = ({ notification }) => {
+  const typeName = notification?.publication.__typename?.toLowerCase() || '';
   return (
     <div className="flex justify-between items-start">
       <div className="space-y-2 w-4/5">
@@ -28,13 +47,14 @@ const MirrorNotification: FC<Props> = ({ notification }) => {
           </UserPreview>
         </div>
         <div className="ml-9">
-          <Trans>
-            <NotificationProfileName profile={notification?.profile} />{' '}
-            <span className="pl-0.5 text-gray-600 dark:text-gray-400">mirrored your </span>
-            <Link href={`/posts/${notification?.publication?.id}`} className="font-bold">
-              {notification?.publication.__typename?.toLowerCase()}
-            </Link>
-          </Trans>
+          <Trans
+            id={messages[typeName]?.id || defaultMessage(typeName)}
+            components={[
+              <span className="pl-0.5 text-gray-600 dark:text-gray-400" key="" />,
+              <NotificationProfileName profile={notification?.profile} key="" />,
+              <Link href={`/posts/${notification?.publication?.id}`} className="font-bold" key="" />
+            ]}
+          />
           <Link
             href={`/posts/${notification?.publication?.id}`}
             className="lt-text-gray-500 line-clamp-2 linkify mt-2"

--- a/apps/web/src/components/Notification/Type/MirrorNotification.tsx
+++ b/apps/web/src/components/Notification/Type/MirrorNotification.tsx
@@ -2,6 +2,7 @@ import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
 import { SwitchHorizontalIcon } from '@heroicons/react/solid';
 import formatTime from '@lib/formatTime';
+import { Trans } from '@lingui/macro';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { NewMirrorNotification } from 'lens';
@@ -27,11 +28,13 @@ const MirrorNotification: FC<Props> = ({ notification }) => {
           </UserPreview>
         </div>
         <div className="ml-9">
-          <NotificationProfileName profile={notification?.profile} />{' '}
-          <span className="pl-0.5 text-gray-600 dark:text-gray-400">mirrored your </span>
-          <Link href={`/posts/${notification?.publication?.id}`} className="font-bold">
-            {notification?.publication.__typename?.toLowerCase()}
-          </Link>
+          <Trans>
+            <NotificationProfileName profile={notification?.profile} />{' '}
+            <span className="pl-0.5 text-gray-600 dark:text-gray-400">mirrored your </span>
+            <Link href={`/posts/${notification?.publication?.id}`} className="font-bold">
+              {notification?.publication.__typename?.toLowerCase()}
+            </Link>
+          </Trans>
           <Link
             href={`/posts/${notification?.publication?.id}`}
             className="lt-text-gray-500 line-clamp-2 linkify mt-2"

--- a/apps/web/src/components/Pages/Contact.tsx
+++ b/apps/web/src/components/Pages/Contact.tsx
@@ -9,6 +9,7 @@ import { Input } from '@components/UI/Input';
 import { TextArea } from '@components/UI/TextArea';
 import { PencilAltIcon } from '@heroicons/react/outline';
 import { CheckCircleIcon } from '@heroicons/react/solid';
+import { t, Trans } from '@lingui/macro';
 import { APP_NAME, CONTACT_EMAIL } from 'data/constants';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
@@ -32,18 +33,22 @@ const Contact: FC = () => {
 
   return (
     <GridLayout>
-      <MetaTags title={`Contact • ${APP_NAME}`} />
+      <MetaTags title={t`Contact • ${APP_NAME}`} />
       <GridItemFour>
         <SettingsHelper
-          heading={`Contact ${APP_NAME}`}
-          description="Contact us to help you get the issue resolved."
+          heading={t`Contact ${APP_NAME}`}
+          description={t`Contact us to help you get the issue resolved.`}
         />
       </GridItemFour>
       <GridItemEight>
         <Card>
           {false ? (
             <EmptyState
-              message={<span>Publication reported successfully!</span>}
+              message={
+                <span>
+                  <Trans>Publication reported successfully!</Trans>
+                </span>
+              }
               icon={<CheckCircleIcon className="w-14 h-14 text-green-500" />}
               hideCard
             />
@@ -58,11 +63,11 @@ const Contact: FC = () => {
                 push('/');
               }}
             >
-              <Input label="Subject" placeholder="What happened?" {...form.register('subject')} />
-              <TextArea label="Message" placeholder="How can we help?" {...form.register('message')} />
+              <Input label={t`Subject`} placeholder={t`What happened?`} {...form.register('subject')} />
+              <TextArea label={t`Message`} placeholder={t`How can we help?`} {...form.register('message')} />
               <div className="ml-auto">
                 <Button type="submit" icon={<PencilAltIcon className="w-4 h-4" />}>
-                  Submit
+                  <Trans>Submit</Trans>
                 </Button>
               </div>
             </Form>

--- a/apps/web/src/components/Publication/Type/Collected.tsx
+++ b/apps/web/src/components/Publication/Type/Collected.tsx
@@ -1,7 +1,7 @@
 import Slug from '@components/Shared/Slug';
+import UserName from '@components/Shared/Username';
 import { CollectionIcon } from '@heroicons/react/outline';
 import formatAddress from '@lib/formatAddress';
-import formatHandle from '@lib/formatHandle';
 import { POLYGONSCAN_URL } from 'data/constants';
 import type { Comment, Post } from 'lens';
 import Link from 'next/link';
@@ -16,13 +16,7 @@ const Collected: FC<Props> = ({ publication }) => {
     <div className="flex items-center pb-4 space-x-1 lt-text-gray-500 text-[13px]">
       <CollectionIcon className="w-4 h-4" />
       {publication?.collectedBy?.defaultProfile ? (
-        <Link href={`/u/${formatHandle(publication?.collectedBy?.defaultProfile?.handle)}`}>
-          {publication?.collectedBy?.defaultProfile?.name ? (
-            <b>{publication?.collectedBy?.defaultProfile?.name}</b>
-          ) : (
-            <Slug slug={formatHandle(publication?.collectedBy?.defaultProfile?.handle)} prefix="@" />
-          )}
-        </Link>
+        <UserName profile={publication.profile} className="max-w-xs truncate" />
       ) : (
         <a
           href={`${POLYGONSCAN_URL}/address/${publication?.collectedBy?.address}`}

--- a/apps/web/src/components/Publication/Type/Collected.tsx
+++ b/apps/web/src/components/Publication/Type/Collected.tsx
@@ -1,5 +1,5 @@
 import Slug from '@components/Shared/Slug';
-import UserName from '@components/Shared/Username';
+import Username from '@components/Shared/Username';
 import { CollectionIcon } from '@heroicons/react/outline';
 import formatAddress from '@lib/formatAddress';
 import { POLYGONSCAN_URL } from 'data/constants';
@@ -16,7 +16,7 @@ const Collected: FC<Props> = ({ publication }) => {
     <div className="flex items-center pb-4 space-x-1 lt-text-gray-500 text-[13px]">
       <CollectionIcon className="w-4 h-4" />
       {publication?.collectedBy?.defaultProfile ? (
-        <UserName profile={publication.profile} className="max-w-xs truncate" />
+        <Username profile={publication?.collectedBy?.defaultProfile} className="max-w-xs truncate" />
       ) : (
         <a
           href={`${POLYGONSCAN_URL}/address/${publication?.collectedBy?.address}`}

--- a/apps/web/src/components/Publication/Type/Mirrored.tsx
+++ b/apps/web/src/components/Publication/Type/Mirrored.tsx
@@ -1,4 +1,4 @@
-import UserName from '@components/Shared/Username';
+import Username from '@components/Shared/Username';
 import { SwitchHorizontalIcon } from '@heroicons/react/outline';
 import type { MessageDescriptor } from '@lingui/core/cjs/i18n';
 import { defineMessage } from '@lingui/macro';
@@ -33,7 +33,7 @@ const Mirrored: FC<Props> = ({ publication }) => {
         id={messages[typeName]?.id || defaultMessage(typeName)}
         components={[
           <span key="" />,
-          <UserName profile={publication.profile} className="max-w-xs truncate" key="" />,
+          <Username profile={publication.profile} className="max-w-xs truncate" key="" />,
           <Link href={`/posts/${publication?.mirrorOf?.id}`} className="font-bold" key="">
             {publication?.mirrorOf.__typename?.toLowerCase()}
           </Link>

--- a/apps/web/src/components/Publication/Type/Mirrored.tsx
+++ b/apps/web/src/components/Publication/Type/Mirrored.tsx
@@ -1,7 +1,8 @@
-import Slug from '@components/Shared/Slug';
+import UserName from '@components/Shared/Username';
 import { SwitchHorizontalIcon } from '@heroicons/react/outline';
-import formatHandle from '@lib/formatHandle';
-import { Trans } from '@lingui/macro';
+import type { MessageDescriptor } from '@lingui/core/cjs/i18n';
+import { defineMessage } from '@lingui/macro';
+import { Trans } from '@lingui/react';
 import type { Mirror } from 'lens';
 import Link from 'next/link';
 import type { FC } from 'react';
@@ -10,23 +11,34 @@ interface Props {
   publication: Mirror;
 }
 
+const messages: Record<string, MessageDescriptor> = {
+  comment: defineMessage({
+    id: '<0><1/> mirrored the <2>comment</2></0>'
+  }),
+  post: defineMessage({
+    id: '<0><1/> mirrored the <2>post</2></0>'
+  })
+};
+
+const defaultMessage = (typeName: string): string => {
+  return '<0><1/> mirrored the <2>' + typeName + '</2></0>';
+};
+
 const Mirrored: FC<Props> = ({ publication }) => {
+  const typeName = publication?.mirrorOf.__typename?.toLowerCase() || '';
   return (
     <div className="flex items-center pb-4 space-x-1 lt-text-gray-500 text-[13px]">
       <SwitchHorizontalIcon className="w-4 h-4" />
-      <Trans>
-        <Link href={`/u/${formatHandle(publication?.profile?.handle)}`} className="max-w-xs truncate">
-          {publication?.profile?.name ? (
-            <b>{publication?.profile?.name}</b>
-          ) : (
-            <Slug slug={formatHandle(publication?.profile?.handle)} prefix="@" />
-          )}
-        </Link>
-        <Link href={`/posts/${publication?.mirrorOf?.id}`}>
-          <span>mirrored the </span>
-          <b>{publication?.mirrorOf.__typename?.toLowerCase()}</b>
-        </Link>
-      </Trans>
+      <Trans
+        id={messages[typeName]?.id || defaultMessage(typeName)}
+        components={[
+          <span key="" />,
+          <UserName profile={publication.profile} className="max-w-xs truncate" key="" />,
+          <Link href={`/posts/${publication?.mirrorOf?.id}`} className="font-bold" key="">
+            {publication?.mirrorOf.__typename?.toLowerCase()}
+          </Link>
+        ]}
+      />
     </div>
   );
 };

--- a/apps/web/src/components/Publication/Type/Mirrored.tsx
+++ b/apps/web/src/components/Publication/Type/Mirrored.tsx
@@ -1,6 +1,7 @@
 import Slug from '@components/Shared/Slug';
 import { SwitchHorizontalIcon } from '@heroicons/react/outline';
 import formatHandle from '@lib/formatHandle';
+import { Trans } from '@lingui/macro';
 import type { Mirror } from 'lens';
 import Link from 'next/link';
 import type { FC } from 'react';
@@ -13,17 +14,19 @@ const Mirrored: FC<Props> = ({ publication }) => {
   return (
     <div className="flex items-center pb-4 space-x-1 lt-text-gray-500 text-[13px]">
       <SwitchHorizontalIcon className="w-4 h-4" />
-      <Link href={`/u/${formatHandle(publication?.profile?.handle)}`} className="max-w-xs truncate">
-        {publication?.profile?.name ? (
-          <b>{publication?.profile?.name}</b>
-        ) : (
-          <Slug slug={formatHandle(publication?.profile?.handle)} prefix="@" />
-        )}
-      </Link>
-      <Link href={`/posts/${publication?.mirrorOf?.id}`}>
-        <span>mirrored the </span>
-        <b>{publication?.mirrorOf.__typename?.toLowerCase()}</b>
-      </Link>
+      <Trans>
+        <Link href={`/u/${formatHandle(publication?.profile?.handle)}`} className="max-w-xs truncate">
+          {publication?.profile?.name ? (
+            <b>{publication?.profile?.name}</b>
+          ) : (
+            <Slug slug={formatHandle(publication?.profile?.handle)} prefix="@" />
+          )}
+        </Link>
+        <Link href={`/posts/${publication?.mirrorOf?.id}`}>
+          <span>mirrored the </span>
+          <b>{publication?.mirrorOf.__typename?.toLowerCase()}</b>
+        </Link>
+      </Trans>
     </div>
   );
 };

--- a/apps/web/src/components/Settings/Account/Language.tsx
+++ b/apps/web/src/components/Settings/Account/Language.tsx
@@ -1,0 +1,43 @@
+import { Card } from '@components/UI/Card';
+import { setLocale, supportedLocales } from '@lib/i18n';
+import { Trans } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import type { FC } from 'react';
+
+dayjs.extend(relativeTime);
+
+const Language: FC = () => {
+  const { i18n } = useLingui();
+
+  return (
+    <Card className="space-y-5 p-5">
+      <div className="text-lg font-bold">
+        <Trans>Locale settings</Trans>
+      </div>
+      <div className="pt-2">
+        <div className="label">
+          <Trans>Select display language</Trans>
+        </div>
+        <select
+          value={i18n.locale}
+          className="w-full bg-white rounded-xl border border-gray-300 outline-none dark:bg-gray-800 disabled:bg-gray-500 disabled:bg-opacity-20 disabled:opacity-60 dark:border-gray-700 focus:border-brand-500 focus:ring-brand-400"
+          onChange={(e) => {
+            console.log('select language onChange', e.target.value);
+            const langCode = e.target.value;
+            setLocale(langCode);
+          }}
+        >
+          {Object.entries(supportedLocales).map(([localeCode, localeName]) => (
+            <option key={localeCode} value={localeCode}>
+              {localeName}
+            </option>
+          ))}
+        </select>
+      </div>
+    </Card>
+  );
+};
+
+export default Language;

--- a/apps/web/src/components/Settings/Account/SetProfile.tsx
+++ b/apps/web/src/components/Settings/Account/SetProfile.tsx
@@ -10,6 +10,7 @@ import formatHandle from '@lib/formatHandle';
 import getSignature from '@lib/getSignature';
 import onError from '@lib/onError';
 import splitSignature from '@lib/splitSignature';
+import { Trans } from '@lingui/macro';
 import { LensHubProxy } from 'abis';
 import { APP_NAME, LENSHUB_PROXY, SIGN_WALLET } from 'data/constants';
 import type { Profile } from 'lens';
@@ -115,29 +116,45 @@ const SetProfile: FC = () => {
       {error && <ErrorMessage title="Transaction failed!" error={error} />}
       {hasDefaultProfile ? (
         <>
-          <div className="text-lg font-bold">Your default profile</div>
+          <div className="text-lg font-bold">
+            <Trans>Your default profile</Trans>
+          </div>
           <UserProfile profile={sortedProfiles[0]} />
         </>
       ) : (
         <div className="flex items-center space-x-1.5 font-bold text-yellow-500">
           <ExclamationIcon className="w-5 h-5" />
-          <div>You don&rsquo;t have any default profile set!</div>
+          <div>
+            <Trans>You don&rsquo;t have any default profile set!</Trans>
+          </div>
         </div>
       )}
-      <div className="text-lg font-bold">Select default profile</div>
+      <div className="text-lg font-bold">
+        <Trans>Select default profile</Trans>
+      </div>
       <p>
-        Selecting your default account helps to display the selected profile across {APP_NAME}, you can change
-        your default profile anytime.
+        <Trans>
+          Selecting your default account helps to display the selected profile across {APP_NAME}, you can
+          change your default profile anytime.
+        </Trans>
       </p>
-      <div className="text-lg font-bold">What else you should know</div>
+      <div className="text-lg font-bold">
+        <Trans>What else you should know</Trans>
+      </div>
       <div className="text-sm lt-text-gray-500 divide-y dark:divide-gray-700">
         <p className="pb-3">
-          Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc.
+          <Trans>
+            Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc.
+          </Trans>
         </p>
-        <p className="py-3">You can change default profile anytime here.</p>
+        <p className="py-3">
+          <Trans>You can change default profile anytime here.</Trans>
+        </p>
       </div>
       <div>
-        <div className="label">Select profile</div>
+        <div className="label">
+          <Trans>Select profile</Trans>
+        </div>
         <select
           className="w-full bg-white rounded-xl border border-gray-300 outline-none dark:bg-gray-800 disabled:bg-gray-500 disabled:bg-opacity-20 disabled:opacity-60 dark:border-gray-700 focus:border-brand-500 focus:ring-brand-400"
           onChange={(e) => setSelectedUser(e.target.value)}

--- a/apps/web/src/components/Settings/Account/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Account/SuperFollow.tsx
@@ -10,6 +10,7 @@ import getSignature from '@lib/getSignature';
 import getTokenImage from '@lib/getTokenImage';
 import onError from '@lib/onError';
 import splitSignature from '@lib/splitSignature';
+import { t, Trans } from '@lingui/macro';
 import { LensHubProxy } from 'abis';
 import { ADDRESS_REGEX, DEFAULT_COLLECT_TOKEN, LENSHUB_PROXY, SIGN_WALLET } from 'data/constants';
 import type { Erc20 } from 'lens';
@@ -149,13 +150,19 @@ const SuperFollow: FC = () => {
           setSuperFollow(amount, recipient);
         }}
       >
-        <div className="text-lg font-bold">Set super follow</div>
+        <div className="text-lg font-bold">
+          <Trans>Set super follow</Trans>
+        </div>
         <p>
-          Setting super follow makes users spend crypto to follow you, and it&rsquo;s a good way to earn it,
-          you can change the amount and currency or disable/enable it anytime.
+          <Trans>
+            Setting super follow makes users spend crypto to follow you, and it&rsquo;s a good way to earn it,
+            you can change the amount and currency or disable/enable it anytime.
+          </Trans>
         </p>
         <div className="pt-2">
-          <div className="label">Select Currency</div>
+          <div className="label">
+            <Trans>Select Currency</Trans>
+          </div>
           <select
             className="w-full bg-white rounded-xl border border-gray-300 outline-none dark:bg-gray-800 disabled:bg-gray-500 disabled:bg-opacity-20 disabled:opacity-60 dark:border-gray-700 focus:border-brand-500 focus:ring-brand-400"
             onChange={(e) => {
@@ -172,7 +179,7 @@ const SuperFollow: FC = () => {
           </select>
         </div>
         <Input
-          label="Follow amount"
+          label={t`Follow amount`}
           type="number"
           step="0.0001"
           min="0"
@@ -190,7 +197,7 @@ const SuperFollow: FC = () => {
           {...form.register('amount')}
         />
         <Input
-          label="Funds recipient"
+          label={t`Funds recipient`}
           type="text"
           placeholder="0x3A5bd...5e3"
           {...form.register('recipient')}
@@ -206,7 +213,7 @@ const SuperFollow: FC = () => {
                 disabled={typedDataLoading || signLoading || writeLoading || broadcastLoading}
                 icon={<XIcon className="w-4 h-4" />}
               >
-                Disable Super follow
+                <Trans>Disable Super follow</Trans>
               </Button>
             )}
             <Button
@@ -214,7 +221,7 @@ const SuperFollow: FC = () => {
               disabled={typedDataLoading || signLoading || writeLoading || broadcastLoading}
               icon={<StarIcon className="w-4 h-4" />}
             >
-              {followType === 'FeeFollowModuleSettings' ? 'Update Super follow' : 'Set Super follow'}
+              {followType === 'FeeFollowModuleSettings' ? t`Update Super follow` : t`Set Super follow`}
             </Button>
           </div>
           {writeData?.hash ?? broadcastTxHash ? (

--- a/apps/web/src/components/Settings/Account/Verification.tsx
+++ b/apps/web/src/components/Settings/Account/Verification.tsx
@@ -2,6 +2,7 @@ import { Card } from '@components/UI/Card';
 import { BadgeCheckIcon } from '@heroicons/react/solid';
 import { Analytics } from '@lib/analytics';
 import isVerified from '@lib/isVerified';
+import { Trans } from '@lingui/macro';
 import type { FC } from 'react';
 import { useAppStore } from 'src/store/app';
 import { SETTINGS } from 'src/tracking';
@@ -11,7 +12,9 @@ const Verification: FC = () => {
 
   return (
     <Card className="space-y-2 linkify p-5">
-      <div className="text-lg font-bold">Verified</div>
+      <div className="text-lg font-bold">
+        <Trans>Verified</Trans>
+      </div>
       {isVerified(currentProfile?.id) ? (
         <div className="flex items-center space-x-1.5">
           <span>Believe it. Yes, you're really verified.</span>
@@ -19,7 +22,7 @@ const Verification: FC = () => {
         </div>
       ) : (
         <div>
-          No.{' '}
+          <Trans>No.</Trans>{' '}
           <a
             href="https://tally.so/r/wgDajK"
             onClick={() => {
@@ -28,7 +31,7 @@ const Verification: FC = () => {
             target="_blank"
             rel="noreferrer noopener"
           >
-            Request Verification
+            <Trans>Request Verification</Trans>
           </a>
         </div>
       )}

--- a/apps/web/src/components/Settings/Account/index.tsx
+++ b/apps/web/src/components/Settings/Account/index.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from 'src/store/app';
 
 import SettingsSidebar from '../Sidebar';
 import CrossPost from './CrossPost';
+import Language from './Language';
 import SetProfile from './SetProfile';
 import Verification from './Verification';
 
@@ -25,6 +26,7 @@ const AccountSettings: NextPage = () => {
         <SettingsSidebar />
       </GridItemFour>
       <GridItemEight className="space-y-5">
+        <Language />
         <SetProfile />
         <SuperFollow />
         <Verification />

--- a/apps/web/src/components/Settings/Dispatcher/ToggleDispatcher.tsx
+++ b/apps/web/src/components/Settings/Dispatcher/ToggleDispatcher.tsx
@@ -6,6 +6,7 @@ import { Analytics } from '@lib/analytics';
 import getSignature from '@lib/getSignature';
 import onError from '@lib/onError';
 import splitSignature from '@lib/splitSignature';
+import { t } from '@lingui/macro';
 import { LensHubProxy } from 'abis';
 import clsx from 'clsx';
 import { LENSHUB_PROXY } from 'data/constants';
@@ -108,7 +109,7 @@ const ToggleDispatcher: FC<Props> = ({ buttonSize = 'md' }) => {
       }
       onClick={toggleDispatcher}
     >
-      {canUseRelay ? 'Disable' : 'Enable'} dispatcher
+      {canUseRelay ? t`Disable dispatcher` : t`Enable dispatcher`}
     </Button>
   );
 };

--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -21,9 +21,8 @@ import uploadToArweave from '@lib/uploadToArweave';
 import uploadToIPFS from '@lib/uploadToIPFS';
 import { LensPeriphery } from 'abis';
 import { APP_NAME, COVER, LENS_PERIPHERY, SIGN_WALLET, URL_REGEX } from 'data/constants';
-import type { CreatePublicSetProfileMetadataUriRequest, MediaSet } from 'lens';
+import type { CreatePublicSetProfileMetadataUriRequest, MediaSet, Profile } from 'lens';
 import {
-  Profile,
   useBroadcastMutation,
   useCreateSetProfileMetadataTypedDataMutation,
   useCreateSetProfileMetadataViaDispatcherMutation
@@ -53,7 +52,7 @@ interface Props {
   profile: Profile & { coverPicture: MediaSet };
 }
 
-const Profile: FC<Props> = ({ profile }) => {
+const ProfileSettingsForm: FC<Props> = ({ profile }) => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [pride, setPride] = useState(hasPrideLogo(profile));
   const [cover, setCover] = useState('');
@@ -297,4 +296,4 @@ const Profile: FC<Props> = ({ profile }) => {
   );
 };
 
-export default Profile;
+export default ProfileSettingsForm;

--- a/apps/web/src/components/Settings/Profile/index.tsx
+++ b/apps/web/src/components/Settings/Profile/index.tsx
@@ -16,7 +16,7 @@ import { useAppStore } from 'src/store/app';
 import SettingsSidebar from '../Sidebar';
 import NFTPicture from './NFTPicture';
 import Picture from './Picture';
-import Profile from './Profile';
+import ProfileSettingsForm from './Profile';
 
 const ProfileSettings: NextPage = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
@@ -74,7 +74,7 @@ const ProfileSettings: NextPage = () => {
         <SettingsSidebar />
       </GridItemFour>
       <GridItemEight className="space-y-5">
-        <Profile profile={profile as any} />
+        <ProfileSettingsForm profile={profile as any} />
         <Card className="space-y-5 p-5">
           <div className="flex items-center space-x-2">
             <TypeButton icon={<PhotographIcon className="w-5 h-5" />} type="AVATAR" name="Upload avatar" />

--- a/apps/web/src/components/Settings/Sidebar.tsx
+++ b/apps/web/src/components/Settings/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   SparklesIcon,
   UserIcon
 } from '@heroicons/react/outline';
+import { t, Trans } from '@lingui/macro';
 import type { Profile } from 'lens';
 import type { FC } from 'react';
 import { useAppStore } from 'src/store/app';
@@ -24,37 +25,41 @@ const SettingsSidebar: FC = () => {
       <Sidebar
         items={[
           {
-            title: 'Profile',
+            title: t`Profile`,
             icon: <UserIcon className="w-4 h-4" />,
             url: '/settings'
           },
           {
-            title: 'Account',
+            title: t`Account`,
             icon: <ChipIcon className="w-4 h-4" />,
             url: '/settings/account'
           },
           {
-            title: 'Interests',
+            title: t`Interests`,
             icon: <BookmarkIcon className="w-4 h-4" />,
             url: '/settings/interests'
           },
           {
-            title: 'Dispatcher',
+            title: t`Dispatcher`,
             icon: <FingerPrintIcon className="w-4 h-4" />,
             url: '/settings/dispatcher'
           },
           {
-            title: 'Allowance',
+            title: t`Allowance`,
             icon: <ShareIcon className="w-4 h-4" />,
             url: '/settings/allowance'
           },
           {
-            title: 'Cleanup',
+            title: t`Cleanup`,
             icon: <SparklesIcon className="w-4 h-4" />,
             url: '/settings/cleanup'
           },
           {
-            title: <div className="text-red-500">Danger Zone</div>,
+            title: (
+              <div className="text-red-500">
+                <Trans>Danger Zone</Trans>
+              </div>
+            ),
             icon: <ExclamationIcon className="w-4 h-4 text-red-500" />,
             url: '/settings/delete'
           }

--- a/apps/web/src/components/Shared/Footer.tsx
+++ b/apps/web/src/components/Shared/Footer.tsx
@@ -1,5 +1,6 @@
 import useStaffMode from '@components/utils/hooks/useStaffMode';
 import { Analytics } from '@lib/analytics';
+import { Trans } from '@lingui/macro';
 import { APP_NAME } from 'data/constants';
 import Link from 'next/link';
 import type { FC } from 'react';
@@ -18,15 +19,19 @@ const Footer: FC = () => {
       <span className="font-bold lt-text-gray-500">
         &copy; {new Date().getFullYear()} {APP_NAME}
       </span>
-      <Link href="/privacy">Terms</Link>
-      <Link href="/privacy">Privacy</Link>
+      <Link href="/privacy">
+        <Trans>Terms</Trans>
+      </Link>
+      <Link href="/privacy">
+        <Trans>Privacy</Trans>
+      </Link>
       <a
         href="https://lenster.xyz/discord"
         target="_blank"
         rel="noreferrer noopener"
         onClick={() => Analytics.track(FOOTER.DISCORD)}
       >
-        Discord
+        <Trans>Discord</Trans>
       </a>
       <a
         href="https://lenster.xyz/donate"
@@ -34,7 +39,7 @@ const Footer: FC = () => {
         rel="noreferrer noopener"
         onClick={() => Analytics.track(FOOTER.DONATE)}
       >
-        Donate
+        <Trans>Donate</Trans>
       </a>
       <a
         href="https://status.lenster.xyz"
@@ -42,7 +47,7 @@ const Footer: FC = () => {
         rel="noreferrer noopener"
         onClick={() => Analytics.track(FOOTER.STATUS)}
       >
-        Status
+        <Trans>Status</Trans>
       </a>
       <a
         href="https://feedback.lenster.xyz"
@@ -50,16 +55,18 @@ const Footer: FC = () => {
         rel="noreferrer noopener"
         onClick={() => Analytics.track(FOOTER.FEEDBACK)}
       >
-        Feedback
+        <Trans>Feedback</Trans>
       </a>
-      <Link href="/thanks">Thanks</Link>
+      <Link href="/thanks">
+        <Trans>Thanks</Trans>
+      </Link>
       <a
         href="https://github.com/lensterxyz/lenster"
         target="_blank"
         rel="noreferrer noopener"
         onClick={() => Analytics.track(FOOTER.GITHUB)}
       >
-        GitHub
+        <Trans>GitHub</Trans>
       </a>
       <a
         className="pr-3 hover:font-bold"
@@ -68,7 +75,7 @@ const Footer: FC = () => {
         rel="noreferrer noopener"
         onClick={() => Analytics.track(FOOTER.VERCEL)}
       >
-        ▲ Powered by Vercel
+        <Trans>▲ Powered by Vercel</Trans>
       </a>
     </footer>
   );

--- a/apps/web/src/components/Shared/GlobalModals.tsx
+++ b/apps/web/src/components/Shared/GlobalModals.tsx
@@ -2,6 +2,7 @@ import Report from '@components/Shared/Modal/Report';
 import { Modal } from '@components/UI/Modal';
 import type { LensterPublication } from '@generated/types';
 import { ArrowCircleRightIcon, EmojiHappyIcon, ShieldCheckIcon } from '@heroicons/react/outline';
+import { t } from '@lingui/macro';
 import type { FC } from 'react';
 import { useAuthStore } from 'src/store/auth';
 import { useGlobalModalStateStore } from 'src/store/modals';
@@ -38,7 +39,7 @@ const GlobalModals: FC = () => {
         <Status />
       </Modal>
       <Modal
-        title="Login"
+        title={t`Login`}
         icon={<ArrowCircleRightIcon className="w-5 h-5 text-brand" />}
         show={showAuthModal}
         onClose={() => setShowAuthModal(false)}

--- a/apps/web/src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
+++ b/apps/web/src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
@@ -1,5 +1,6 @@
 import Beta from '@components/Shared/Badges/Beta';
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { t } from '@lingui/macro';
 import {
   $getSelection,
   $isRangeSelection,
@@ -43,7 +44,7 @@ const ToolbarPlugin: FC = () => {
       <div className="w-full flex toolbar-icons space-x-1">
         <button
           className={isBold ? 'bg-brand-100' : ''}
-          title="Bold"
+          title={t`Bold`}
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
           }}
@@ -52,7 +53,7 @@ const ToolbarPlugin: FC = () => {
         </button>
         <button
           className={isItalic ? 'bg-brand-100' : ''}
-          title="Italic"
+          title={t`Italic`}
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic');
           }}
@@ -61,7 +62,7 @@ const ToolbarPlugin: FC = () => {
         </button>
         <button
           className={isCode ? 'bg-brand-100' : ''}
-          title="Code"
+          title={t`Code`}
           onClick={() => {
             activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code');
           }}

--- a/apps/web/src/components/Shared/Login/WalletSelector.tsx
+++ b/apps/web/src/components/Shared/Login/WalletSelector.tsx
@@ -7,6 +7,7 @@ import { Analytics } from '@lib/analytics';
 import getWalletLogo from '@lib/getWalletLogo';
 import onError from '@lib/onError';
 import toSnakeCase from '@lib/toSnakeCase';
+import { t, Trans } from '@lingui/macro';
 import clsx from 'clsx';
 import { ERROR_MESSAGE } from 'data/constants';
 import { useAuthenticateMutation, useChallengeLazyQuery, useUserProfilesLazyQuery } from 'lens';
@@ -119,7 +120,7 @@ const WalletSelector: FC<Props> = ({ setHasConnected, setHasProfile }) => {
           }
           onClick={handleSign}
         >
-          Sign-In with Lens
+          <Trans>Sign-In with Lens</Trans>
         </Button>
       ) : (
         <SwitchNetwork />
@@ -146,7 +147,7 @@ const WalletSelector: FC<Props> = ({ setHasConnected, setHasProfile }) => {
             disabled={mounted ? !connector.ready || connector.id === activeConnector?.id : false}
           >
             <span>
-              {mounted ? (connector.id === 'injected' ? 'Browser Wallet' : connector.name) : connector.name}
+              {mounted ? (connector.id === 'injected' ? t`Browser Wallet` : connector.name) : connector.name}
               {mounted ? !connector.ready && ' (unsupported)' : ''}
             </span>
             <img

--- a/apps/web/src/components/Shared/Login/index.tsx
+++ b/apps/web/src/components/Shared/Login/index.tsx
@@ -1,4 +1,5 @@
 import WalletSelector from '@components/Shared/Login/WalletSelector';
+import { Trans } from '@lingui/macro';
 import { APP_NAME, IS_MAINNET, STATIC_IMAGES_URL } from 'data/constants';
 import type { FC } from 'react';
 import { useState } from 'react';
@@ -15,16 +16,22 @@ const Login: FC = () => {
         <div className="space-y-5">
           {hasConnected ? (
             <div className="space-y-1">
-              <div className="text-xl font-bold">Please sign the message.</div>
+              <div className="text-xl font-bold">
+                <Trans>Please sign the message</Trans>.
+              </div>
               <div className="text-sm lt-text-gray-500">
-                {APP_NAME} uses this signature to verify that you&rsquo;re the owner of this address.
+                <Trans>
+                  {APP_NAME} uses this signature to verify that you&rsquo;re the owner of this address.
+                </Trans>
               </div>
             </div>
           ) : (
             <div className="space-y-1">
-              <div className="text-xl font-bold">Connect your wallet.</div>
+              <div className="text-xl font-bold">
+                <Trans>Connect your wallet</Trans>.
+              </div>
               <div className="text-sm lt-text-gray-500">
-                Connect with one of our available wallet providers or create a new one.
+                <Trans>Connect with one of our available wallet providers or create a new one.</Trans>
               </div>
             </div>
           )}

--- a/apps/web/src/components/Shared/Navbar/LoginButton.tsx
+++ b/apps/web/src/components/Shared/Navbar/LoginButton.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@components/UI/Button';
 import { Analytics } from '@lib/analytics';
+import { Trans } from '@lingui/macro';
 import type { FC } from 'react';
 import { useAuthStore } from 'src/store/auth';
 import { USER } from 'src/tracking';
@@ -15,7 +16,7 @@ const LoginButton: FC = () => {
         Analytics.track(USER.LOGIN);
       }}
     >
-      Login
+      <Trans>Login</Trans>
     </Button>
   );
 };

--- a/apps/web/src/components/Shared/Navbar/MoreNavItems.tsx
+++ b/apps/web/src/components/Shared/Navbar/MoreNavItems.tsx
@@ -1,5 +1,6 @@
 import { Menu } from '@headlessui/react';
 import { HandIcon, SupportIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
 import clsx from 'clsx';
 import type { FC } from 'react';
 import { Fragment } from 'react';
@@ -22,7 +23,7 @@ const MoreNavItems: FC = () => {
               }
             )}
           >
-            More
+            <Trans>More</Trans>
           </Menu.Button>
           <MenuTransition>
             <Menu.Items
@@ -38,7 +39,9 @@ const MoreNavItems: FC = () => {
               >
                 <div className="flex items-center space-x-1.5">
                   <SupportIcon className="w-4 h-4" />
-                  <div>Contact</div>
+                  <div>
+                    <Trans>Contact</Trans>
+                  </div>
                 </div>
               </Menu.Item>
               <Menu.Item
@@ -51,7 +54,9 @@ const MoreNavItems: FC = () => {
               >
                 <div className="flex items-center space-x-1.5">
                   <HandIcon className="w-4 h-4" />
-                  <div>Report a bug</div>
+                  <div>
+                    <Trans>Report a bug</Trans>
+                  </div>
                 </div>
               </Menu.Item>
             </Menu.Items>

--- a/apps/web/src/components/Shared/Navbar/Search.tsx
+++ b/apps/web/src/components/Shared/Navbar/Search.tsx
@@ -4,6 +4,7 @@ import { Spinner } from '@components/UI/Spinner';
 import useOnClickOutside from '@components/utils/hooks/useOnClickOutside';
 import { SearchIcon, XIcon } from '@heroicons/react/outline';
 import { Analytics } from '@lib/analytics';
+import { t } from '@lingui/macro';
 import clsx from 'clsx';
 import type { Profile, ProfileSearchResult } from 'lens';
 import { CustomFiltersTypes, SearchRequestTypes, useSearchProfilesLazyQuery } from 'lens';
@@ -24,7 +25,7 @@ interface Props {
 const Search: FC<Props> = ({
   hideDropdown = false,
   onProfileSelected,
-  placeholder = 'Search...',
+  placeholder = t`Search…`,
   modalWidthClassName = 'max-w-md'
 }) => {
   const { push, pathname, query } = useRouter();

--- a/apps/web/src/components/Shared/Navbar/SignedUser.tsx
+++ b/apps/web/src/components/Shared/Navbar/SignedUser.tsx
@@ -20,6 +20,7 @@ import getAvatar from '@lib/getAvatar';
 import isGardener from '@lib/isGardener';
 import isStaff from '@lib/isStaff';
 import resetAuthData from '@lib/resetAuthData';
+import { Trans } from '@lingui/macro';
 import clsx from 'clsx';
 import { APP_VERSION } from 'data/constants';
 import type { Profile } from 'lens';
@@ -86,7 +87,9 @@ const SignedUser: FC = () => {
             href={`/u/${formatHandle(currentProfile?.handle)}`}
             className={({ active }: { active: boolean }) => clsx({ 'dropdown-active': active }, 'menu-item')}
           >
-            <div>Logged in as</div>
+            <div>
+              <Trans>Logged in as</Trans>
+            </div>
             <div className="truncate">
               <Slug className="font-bold" slug={formatHandle(currentProfile?.handle)} prefix="@" />
             </div>
@@ -108,7 +111,9 @@ const SignedUser: FC = () => {
               ) : (
                 <>
                   <EmojiHappyIcon className="w-4 h-4" />
-                  <span>Set status</span>
+                  <span>
+                    <Trans>Set status</Trans>
+                  </span>
                 </>
               )}
             </div>
@@ -121,7 +126,9 @@ const SignedUser: FC = () => {
           >
             <div className="flex items-center space-x-1.5">
               <UserIcon className="w-4 h-4" />
-              <div>Your Profile</div>
+              <div>
+                <Trans>Your Profile</Trans>
+              </div>
             </div>
           </Menu.Item>
           <Menu.Item
@@ -131,7 +138,9 @@ const SignedUser: FC = () => {
           >
             <div className="flex items-center space-x-1.5">
               <CogIcon className="w-4 h-4" />
-              <div>Settings</div>
+              <div>
+                <Trans>Settings</Trans>
+              </div>
             </div>
           </Menu.Item>
           {isGardener(currentProfile?.id) && (
@@ -144,7 +153,9 @@ const SignedUser: FC = () => {
             >
               <div className="flex items-center space-x-1.5">
                 <ShieldCheckIcon className="w-4 h-4" />
-                <div>Moderation</div>
+                <div>
+                  <Trans>Moderation</Trans>
+                </div>
               </div>
             </Menu.Item>
           )}
@@ -155,7 +166,9 @@ const SignedUser: FC = () => {
           >
             <div className="flex items-center space-x-1.5">
               <LogoutIcon className="w-4 h-4" />
-              <div>Logout</div>
+              <div>
+                <Trans>Logout</Trans>
+              </div>
             </div>
           </Menu.Item>
           {profiles?.length > 1 && (
@@ -164,7 +177,9 @@ const SignedUser: FC = () => {
               <div className="overflow-auto m-2 max-h-36 no-scrollbar">
                 <div className="flex items-center px-4 pt-1 pb-2 space-x-1.5 text-sm font-bold lt-text-gray-500">
                   <SwitchHorizontalIcon className="w-4 h-4" />
-                  <div>Switch to</div>
+                  <div>
+                    <Trans>Switch to</Trans>
+                  </div>
                 </div>
                 {profiles.map((profile: Profile, index) => (
                   <div
@@ -211,12 +226,16 @@ const SignedUser: FC = () => {
               {theme === 'light' ? (
                 <>
                   <MoonIcon className="w-4 h-4" />
-                  <div>Dark mode</div>
+                  <div>
+                    <Trans>Dark mode</Trans>
+                  </div>
                 </>
               ) : (
                 <>
                   <SunIcon className="w-4 h-4" />
-                  <div>Light mode</div>
+                  <div>
+                    <Trans>Light mode</Trans>
+                  </div>
                 </>
               )}
             </div>
@@ -246,12 +265,16 @@ const SignedUser: FC = () => {
               >
                 {staffMode ? (
                   <div className="flex items-center space-x-1.5">
-                    <div>Disable staff mode</div>
+                    <div>
+                      <Trans>Disable staff mode</Trans>
+                    </div>
                     <ShieldExclamationIcon className="w-4 h-4 text-green-600" />
                   </div>
                 ) : (
                   <div className="flex items-center space-x-1.5">
-                    <div>Enable staff mode</div>
+                    <div>
+                      <Trans>Enable staff mode</Trans>
+                    </div>
                     <ShieldCheckIcon className="w-4 h-4 text-red-500" />
                   </div>
                 )}

--- a/apps/web/src/components/Shared/Navbar/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/index.tsx
@@ -5,6 +5,7 @@ import { Disclosure } from '@headlessui/react';
 import { MenuIcon, XIcon } from '@heroicons/react/outline';
 import formatHandle from '@lib/formatHandle';
 import hasPrideLogo from '@lib/hasPrideLogo';
+import { t } from '@lingui/macro';
 import clsx from 'clsx';
 import type { Profile } from 'lens';
 import Link from 'next/link';
@@ -56,8 +57,8 @@ const Navbar: FC = () => {
 
     return (
       <>
-        <NavItem url="/" name="Home" current={pathname == '/'} />
-        <NavItem url="/explore" name="Explore" current={pathname == '/explore'} />
+        <NavItem url="/" name={t`Home`} current={pathname == '/'} />
+        <NavItem url="/explore" name={t`Explore`} current={pathname == '/explore'} />
         <MoreNavItems />
       </>
     );

--- a/apps/web/src/components/Shared/Status.tsx
+++ b/apps/web/src/components/Shared/Status.tsx
@@ -10,6 +10,7 @@ import getSignature from '@lib/getSignature';
 import onError from '@lib/onError';
 import splitSignature from '@lib/splitSignature';
 import uploadToArweave from '@lib/uploadToArweave';
+import { t } from '@lingui/macro';
 import { LensPeriphery } from 'abis';
 import { APP_NAME, LENS_PERIPHERY, SIGN_WALLET } from 'data/constants';
 import type { CreatePublicSetProfileMetadataUriRequest } from 'lens';
@@ -202,7 +203,7 @@ const Status: FC = () => {
       >
         <Input
           prefix={<EmojiPicker emoji={emoji} setEmoji={setEmoji} />}
-          placeholder="What's happening?"
+          placeholder={t`What's happening?`}
           {...form.register('status')}
         />
         <div className="flex flex-col space-y-2">

--- a/apps/web/src/components/Shared/Username.tsx
+++ b/apps/web/src/components/Shared/Username.tsx
@@ -1,0 +1,21 @@
+import formatHandle from '@lib/formatHandle';
+import type { Profile } from 'lens';
+import Link from 'next/link';
+import type { FC } from 'react';
+
+import Slug from './Slug';
+
+interface Props {
+  profile: Profile;
+  className?: string;
+}
+
+const UserName: FC<Props> = ({ profile, className }) => {
+  return (
+    <Link href={`/u/${formatHandle(profile?.handle)}`} className={className}>
+      {profile?.name ? <b>{profile?.name}</b> : <Slug slug={formatHandle(profile?.handle)} prefix="@" />}
+    </Link>
+  );
+};
+
+export default UserName;

--- a/apps/web/src/components/Shared/Username.tsx
+++ b/apps/web/src/components/Shared/Username.tsx
@@ -10,7 +10,7 @@ interface Props {
   className?: string;
 }
 
-const UserName: FC<Props> = ({ profile, className }) => {
+const Username: FC<Props> = ({ profile, className }) => {
   return (
     <Link href={`/u/${formatHandle(profile?.handle)}`} className={className}>
       {profile?.name ? <b>{profile?.name}</b> : <Slug slug={formatHandle(profile?.handle)} prefix="@" />}
@@ -18,4 +18,4 @@ const UserName: FC<Props> = ({ profile, className }) => {
   );
 };
 
-export default UserName;
+export default Username;

--- a/apps/web/src/lib/formatTime.ts
+++ b/apps/web/src/lib/formatTime.ts
@@ -1,7 +1,7 @@
-import dayjs from 'dayjs';
+import { i18n } from '@lingui/core';
 
 const formatTime = (date: Date | undefined): string => {
-  return date ? dayjs(date).format('h:mm A · MMM D, YYYY') : '';
+  return date ? i18n.date(date, { dateStyle: 'medium', timeStyle: 'medium' }) : '';
 };
 
 export default formatTime;

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { i18n } from '@lingui/core';
-import { IS_PREVIEW, IS_PRODUCTION } from 'data/constants';
+import { IS_PREVIEW, IS_PRODUCTION, LS_KEYS } from 'data/constants';
 import dayjs from 'dayjs';
 import { en } from 'make-plural/plurals';
 
@@ -18,8 +18,6 @@ i18n.loadLocaleData({
   qaa: { plurals: en }
 });
 
-const localStorageKey = 'selectedLocale';
-
 /**
  * set locale and dynamically import catalog
  * @param locale a supported locale string
@@ -29,7 +27,7 @@ export async function setLocale(locale: string) {
     console.error('warning: unknown locale', locale);
     locale = defaultLocale;
   }
-  localStorage.setItem(localStorageKey, JSON.stringify(locale));
+  localStorage.setItem(LS_KEYS.SELECTED_LOCALE, JSON.stringify(locale));
   const { messages } = await import(`src/locales/${locale}/messages`);
   i18n.load(locale, messages);
   i18n.activate(locale);
@@ -37,7 +35,7 @@ export async function setLocale(locale: string) {
 }
 
 export const initLocale = () => {
-  const storedValue = localStorage.getItem(localStorageKey);
+  const storedValue = localStorage.getItem(LS_KEYS.SELECTED_LOCALE);
   const locale = storedValue ? JSON.parse(storedValue) : defaultLocale;
   setLocale(locale);
 };

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -1,17 +1,21 @@
 import { i18n } from '@lingui/core';
+import { IS_PRODUCTION } from 'data/constants';
 import dayjs from 'dayjs';
-import { cs, en } from 'make-plural/plurals';
+import { en } from 'make-plural/plurals';
 
-export const supportedLocales = {
-  en: 'English',
-  cs: 'Česky'
+export const supportedLocales: Record<string, string> = {
+  en: 'English'
 };
+
+if (!IS_PRODUCTION) {
+  supportedLocales.qaa = 'PseudoLanguage';
+}
 
 const defaultLocale = 'en';
 
 i18n.loadLocaleData({
   en: { plurals: en },
-  cs: { plurals: cs }
+  qaa: { plurals: en }
 });
 
 import('dayjs/locale/cs');

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -18,8 +18,6 @@ i18n.loadLocaleData({
   qaa: { plurals: en }
 });
 
-import('dayjs/locale/cs');
-
 const localStorageKey = 'selectedLocale';
 
 /**

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -1,5 +1,5 @@
 import { i18n } from '@lingui/core';
-import { IS_PRODUCTION } from 'data/constants';
+import { IS_PREVIEW, IS_PRODUCTION } from 'data/constants';
 import dayjs from 'dayjs';
 import { en } from 'make-plural/plurals';
 
@@ -7,7 +7,7 @@ export const supportedLocales: Record<string, string> = {
   en: 'English'
 };
 
-if (!IS_PRODUCTION) {
+if (!IS_PRODUCTION || IS_PREVIEW) {
   supportedLocales.qaa = 'PseudoLanguage';
 }
 

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -1,0 +1,41 @@
+import { i18n } from '@lingui/core';
+import dayjs from 'dayjs';
+import { cs, en } from 'make-plural/plurals';
+
+export const supportedLocales = {
+  en: 'English',
+  cs: 'Česky'
+};
+
+const defaultLocale = 'en';
+
+i18n.loadLocaleData({
+  en: { plurals: en },
+  cs: { plurals: cs }
+});
+
+import('dayjs/locale/cs');
+
+const localStorageKey = 'selectedLocale';
+
+/**
+ * set locale and dynamically import catalog
+ * @param locale a supported locale string
+ */
+export async function setLocale(locale: string) {
+  if (!supportedLocales.hasOwnProperty(locale)) {
+    console.error('warning: unknown locale', locale);
+    locale = defaultLocale;
+  }
+  localStorage.setItem(localStorageKey, JSON.stringify(locale));
+  const { messages } = await import(`src/locales/${locale}/messages`);
+  i18n.load(locale, messages);
+  i18n.activate(locale);
+  dayjs.locale(locale);
+}
+
+export const initLocale = () => {
+  const storedValue = localStorage.getItem(localStorageKey);
+  const locale = storedValue ? JSON.parse(storedValue) : defaultLocale;
+  setLocale(locale);
+};

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -13,408 +13,408 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Notification/Type/CommentNotification.tsx:31
-msgid "<0/> <1>commented on your </1><2>{0}</2>"
-msgstr "<0/> <1>přidal komentář k vašemu </1><2>{0}</2>"
-
-#: src/components/Notification/Type/LikeNotification.tsx:31
-msgid "<0/> <1>liked your </1><2>{0}</2>"
-msgstr "<0/> <1>olajkovalo vaše </1><2>{0}</2>"
-
-#: src/components/Notification/Type/MentionNotification.tsx:33
-msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
-msgstr "<0/> <1>se o vás zmínil v </1><2>{0}</2>"
-
-#: src/components/Notification/Type/MirrorNotification.tsx:31
-msgid "<0/> <1>mirrored your </1><2>{0}</2>"
-msgstr "<0/> <1>zrcadlil vaše </1><2>{0}</2>"
-
-#: src/components/Publication/Type/Mirrored.tsx:17
-msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
-msgstr "<0>{0}</0><1><2>zrcadlil </2><3>{1}</3></1>"
-
-#: src/components/Settings/Sidebar.tsx:55
-msgid "Account"
-msgstr "Účet"
-
-#: src/components/Home/EnableDispatcher.tsx:24
-msgid "Action Required"
-msgstr "Je vyžadována akce"
-
-#: src/components/Explore/FeedType.tsx:37
-msgid "All posts"
-msgstr "Všechny příspěvky"
-
-#: src/components/Settings/Sidebar.tsx:73
-msgid "Allowance"
-msgstr "Příspěvek"
-
-#: src/components/Explore/FeedType.tsx:40
-msgid "Audio"
-msgstr "Zvuk"
-
-#: src/components/Home/BetaWarning.tsx:16
-msgid "Beta warning!"
-msgstr "Upozornění beta!"
-
-#: src/components/Shared/Login/WalletSelector.tsx:150
-msgid "Browser Wallet"
-msgstr "Peněženka prohlížeče"
-
-#: src/components/Settings/Sidebar.tsx:79
-msgid "Cleanup"
-msgstr "Čištění"
-
-#: src/components/Shared/Login/index.tsx:34
-msgid "Connect with one of our available wallet providers or create a new one."
-msgstr "Spojte se s jedním z našich dostupných poskytovatelů peněženek nebo vytvořte nového."
-
-#: src/components/Shared/Login/index.tsx:31
-msgid "Connect your wallet"
-msgstr "Připojte svou peněženku"
-
-#: src/components/Shared/Navbar/MoreNavItems.tsx:51
-msgid "Contact"
-msgstr "Kontakt"
-
-#: src/components/Settings/Sidebar.tsx:85
-msgid "Danger Zone"
-msgstr "Nebezpečná zóna"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:246
-msgid "Dark mode"
-msgstr "Tmavý režim"
-
-#: src/components/Settings/Account/SuperFollow.tsx:217
-msgid "Disable Super follow"
-msgstr "Zakázat Super sledování"
-
-#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx:115
-msgid "Disable dispatcher"
-msgstr "Zakázat dispečera"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:287
-msgid "Disable staff mode"
-msgstr "Zakázat režim pro zaměstnance"
-
-#: src/components/Shared/Footer.tsx:29
-msgid "Discord"
-msgstr "Discord"
-
-#: src/components/Settings/Sidebar.tsx:67
-msgid "Dispatcher"
-msgstr "Odesílatel"
-
-#: src/components/Shared/Footer.tsx:37
-msgid "Donate"
-msgstr "Darovat"
-
-#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx:115
-msgid "Enable dispatcher"
-msgstr "Povolit dispečera"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:294
-msgid "Enable staff mode"
-msgstr "Povolit režim zaměstnanců"
-
-#: src/components/Shared/Navbar/index.tsx:61
-msgid "Explore"
-msgstr "Prozkoumat"
-
-#: src/components/Shared/Footer.tsx:53
-msgid "Feedback"
-msgstr "Zpětná vazba"
-
-#: src/components/Home/FeedEventFilters.tsx:22
-msgid "Filter"
-msgstr "Filtr"
-
-#: src/components/Settings/Account/SuperFollow.tsx:183
-msgid "Follow amount"
-msgstr "Sledujte množství"
-
-#: src/components/Explore/index.tsx:25
-msgid "For you"
-msgstr "Pro tebe"
-
-#: src/components/Settings/Account/SuperFollow.tsx:201
-msgid "Funds recipient"
-msgstr "Příjemce prostředků"
-
-#: src/components/Home/BetaWarning.tsx:26
-msgid "Get testnet tokens"
-msgstr "Získejte tokeny testnet"
-
-#: src/components/Shared/Footer.tsx:62
-msgid "GitHub"
-msgstr "GitHub"
-
-#: src/components/Home/FeedType.tsx:31
-msgid "Highlights"
-msgstr "Zvýraznění"
-
-#: src/components/Shared/Navbar/index.tsx:60
-msgid "Home"
-msgstr "Domov"
-
-#: src/components/Explore/FeedType.tsx:41
-msgid "Images"
-msgstr "Snímky"
-
-#: src/components/Explore/index.tsx:28
-msgid "Interesting"
-msgstr "Zajímavý"
-
-#: src/components/Settings/Sidebar.tsx:61
-msgid "Interests"
-msgstr "Zájmy"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:253
-msgid "Light mode"
-msgstr "Světelný režim"
-
-#: src/components/Settings/Account/Language.tsx:17
-msgid "Locale settings"
-msgstr "Nastavení národního prostředí"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:103
-msgid "Logged in as"
-msgstr "Přihlášen jako"
-
-#: src/components/Shared/GlobalModals.tsx:42
-#: src/components/Shared/Navbar/LoginButton.tsx:19
-msgid "Login"
-msgstr "Přihlásit se"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:186
-msgid "Logout"
-msgstr "Odhlásit se"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:173
-msgid "Moderation"
-msgstr "Umírněnost"
-
-#: src/components/Shared/Navbar/MoreNavItems.tsx:25
-msgid "More"
-msgstr "Více"
-
-#: src/components/Home/SeeThroughLens.tsx:100
-msgid "My Feed"
-msgstr "Můj příspěvek"
-
-#: src/components/Settings/Account/Verification.tsx:25
-msgid "No."
-msgstr "Ne."
-
-#: src/components/Settings/Account/SetProfile.tsx:151
-msgid "Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc."
-msgstr "V aplikaci {APP_NAME}, příkladech oznámení, sledování atd. bude viditelný pouze výchozí profil."
-
-#: src/components/Shared/Login/index.tsx:20
-msgid "Please sign the message"
-msgstr "Podepište prosím zprávu"
-
-#: src/components/Explore/index.tsx:26
-msgid "Popular"
-msgstr "Oblíbený"
-
-#: src/components/Shared/Footer.tsx:22
-msgid "Privacy"
-msgstr "Soukromí"
-
-#: src/components/Settings/Sidebar.tsx:49
-msgid "Profile"
-msgstr "Profil"
-
-#: src/components/Shared/Navbar/MoreNavItems.tsx:66
-msgid "Report a bug"
-msgstr "Nahlásit chybu"
-
-#: src/components/Settings/Account/Verification.tsx:34
-msgid "Request Verification"
-msgstr "Požádat o ověření"
-
-#: src/components/Home/SeeThroughLens.tsx:124
-msgid "Search"
-msgstr "Vyhledávání"
-
-#: src/components/Shared/Navbar/Search.tsx:28
-msgid "Search…"
-msgstr "Vyhledávání…"
-
-#: src/components/Settings/Account/SuperFollow.tsx:165
-msgid "Select Currency"
-msgstr "Vyberte možnost Měna"
-
-#: src/components/Settings/Account/SetProfile.tsx:138
-msgid "Select default profile"
-msgstr "Vyberte výchozí profil"
-
-#: src/components/Settings/Account/Language.tsx:21
-msgid "Select display language"
-msgstr "Vyberte jazyk zobrazení"
-
-#: src/components/Settings/Account/SetProfile.tsx:161
-msgid "Select profile"
-msgstr "Vyberte profil"
-
-#: src/components/Home/SetProfile.tsx:67
-msgid "Select profile interests"
-msgstr "Vyberte zájmy profilu"
-
-#: src/components/Settings/Account/SetProfile.tsx:141
-msgid "Selecting your default account helps to display the selected profile across {APP_NAME}, you can change your default profile anytime."
-msgstr "Výběr výchozího účtu pomůže zobrazit vybraný profil v aplikaci {APP_NAME}. Výchozí profil můžete kdykoli změnit."
-
-#: src/components/Settings/Account/SuperFollow.tsx:225
-msgid "Set Super follow"
-msgstr "Nastavte Super sledování"
-
-#: src/components/Home/SetProfile.tsx:57
-msgid "Set profile bio"
-msgstr "Nastavit bio profilu"
-
-#: src/components/Home/SetProfile.tsx:56
-msgid "Set profile name"
-msgstr "Nastavte název profilu"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:127
-msgid "Set status"
-msgstr "Nastavit stav"
-
-#: src/components/Settings/Account/SuperFollow.tsx:155
-msgid "Set super follow"
-msgstr "Nastavit super sledování"
-
-#: src/components/Home/SetProfile.tsx:58
-msgid "Set your avatar"
-msgstr "Nastavte si avatara"
-
-#: src/components/Settings/Account/SuperFollow.tsx:158
-msgid "Setting super follow makes users spend crypto to follow you, and it’s a good way to earn it, you can change the amount and currency or disable/enable it anytime."
-msgstr "Nastavení supersledování způsobí, že uživatelé utrácejí kryptoměny, aby vás sledovali, a je to dobrý způsob, jak je vydělat, můžete změnit částku a měnu nebo je kdykoli zakázat/povolit."
-
-#: src/components/Shared/Navbar/SignedUser.tsx:158
-msgid "Settings"
-msgstr "Nastavení"
-
-#: src/components/Home/SetProfile.tsx:52
-msgid "Setup your {APP_NAME} profile"
-msgstr "Nastavte si svůj profil {APP_NAME}"
-
-#: src/components/Home/RecommendedProfiles.tsx:89
-msgid "Show more"
-msgstr "Zobrazit více"
-
-#: src/components/Shared/Login/WalletSelector.tsx:123
-msgid "Sign-In with Lens"
-msgstr "Přihlaste se pomocí Lens"
-
-#: src/components/Shared/Footer.tsx:45
-msgid "Status"
-msgstr "Postavení"
-
-#: src/components/Shared/Navbar/SignedUser.tsx:197
-msgid "Switch to"
-msgstr "Přepnout na"
-
-#: src/components/Shared/Footer.tsx:21
-msgid "Terms"
-msgstr "Podmínky"
-
-#: src/components/Explore/FeedType.tsx:38
-msgid "Text"
-msgstr "Text"
-
-#: src/components/Shared/Footer.tsx:55
-msgid "Thanks"
-msgstr "Dík"
-
-#: src/components/Home/FeedType.tsx:21
-msgid "Timeline"
-msgstr "Časová osa"
-
-#: src/components/Explore/index.tsx:27
-#: src/components/Home/Trending.tsx:19
-msgid "Trending"
-msgstr "Trendy"
-
-#: src/components/Settings/Account/SuperFollow.tsx:225
-msgid "Update Super follow"
-msgstr "Aktualizovat Super sledování"
-
-#: src/components/Home/SetProfile.tsx:76
-msgid "Update profile now"
-msgstr "Aktualizujte profil nyní"
-
-#: src/components/Settings/Account/Verification.tsx:16
-msgid "Verified"
-msgstr "Ověřeno"
-
-#: src/components/Explore/FeedType.tsx:39
-msgid "Video"
-msgstr "Video"
-
-#: src/components/Home/Hero.tsx:11
-msgid "Welcome to {APP_NAME} 👋"
-msgstr "Vítejte v {APP_NAME} 👋"
-
-#: src/components/Settings/Account/SetProfile.tsx:147
-msgid "What else you should know"
-msgstr "Co byste ještě měli vědět"
-
-#: src/components/Composer/Post/New.tsx:86
+#: src/components/Composer/Post/New.tsx
 msgid "What's happening?"
 msgstr "Co se děje?"
 
-#: src/components/Home/RecommendedProfiles.tsx:24
-msgid "Who to follow"
-msgstr "Koho následovat"
+#: src/components/Explore/FeedType.tsx
+msgid "All posts"
+msgstr "Všechny příspěvky"
 
-#: src/components/Settings/Account/SetProfile.tsx:156
-msgid "You can change default profile anytime here."
-msgstr "Zde můžete kdykoli změnit výchozí profil."
+#: src/components/Explore/FeedType.tsx
+msgid "Text"
+msgstr "Text"
 
-#: src/components/Home/EnableDispatcher.tsx:28
-msgid "You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions."
-msgstr "Dispečerovi můžete povolit interakci s aplikací {APP_NAME}, aniž byste museli podepisovat jakoukoli z vašich transakcí."
+#: src/components/Explore/FeedType.tsx
+msgid "Video"
+msgstr "Video"
 
-#: src/components/Settings/Account/SetProfile.tsx:133
-msgid "You don’t have any default profile set!"
-msgstr "Nemáte nastaven žádný výchozí profil!"
+#: src/components/Explore/FeedType.tsx
+msgid "Audio"
+msgstr "Zvuk"
 
-#: src/components/Shared/Navbar/SignedUser.tsx:144
-msgid "Your Profile"
-msgstr "Tvůj profil"
+#: src/components/Explore/FeedType.tsx
+msgid "Images"
+msgstr "Snímky"
 
-#: src/components/Settings/Account/SetProfile.tsx:125
-msgid "Your default profile"
-msgstr "Váš výchozí profil"
+#: src/components/Explore/index.tsx
+msgid "For you"
+msgstr "Pro tebe"
 
-#: src/components/Notification/Type/CollectNotification/index.tsx:40
-msgid "{0} <0>collected your </0><1>{1}</1>"
-msgstr "{0} <0>shromáždil vaše </0><1>{1}</1>"
+#: src/components/Explore/index.tsx
+msgid "Popular"
+msgstr "Oblíbený"
 
-#: src/components/Notification/Type/FollowerNotification.tsx:42
-msgid "{0} <0>{1} followed you</0>"
-msgstr "{0} <0>{1} vás sleduje</0>"
+#: src/components/Explore/index.tsx
+#: src/components/Home/Trending.tsx
+msgid "Trending"
+msgstr "Trendy"
 
-#: src/components/Home/Hero.tsx:14
-msgid "{APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿"
-msgstr "{APP_NAME} je decentralizovaná aplikace sociálních médií bez povolení vytvořená pomocí protokolu Lens 🌿"
+#: src/components/Explore/index.tsx
+msgid "Interesting"
+msgstr "Zajímavý"
 
-#: src/components/Home/BetaWarning.tsx:20
+#: src/components/Home/BetaWarning.tsx
+msgid "Beta warning!"
+msgstr "Upozornění beta!"
+
+#: src/components/Home/BetaWarning.tsx
 msgid "{APP_NAME} is still in the beta phase, things may break, please handle us with care."
 msgstr "Aplikace {APP_NAME} je stále ve fázi beta, může se něco pokazit, zacházejte s námi prosím opatrně."
 
-#: src/components/Shared/Login/index.tsx:23
-msgid "{APP_NAME} uses this signature to verify that you’re the owner of this address."
-msgstr "Aplikace {APP_NAME} používá tento podpis k ověření, že jste vlastníkem této adresy."
+#: src/components/Home/BetaWarning.tsx
+msgid "Get testnet tokens"
+msgstr "Získejte tokeny testnet"
 
-#: src/components/Shared/Footer.tsx:71
+#: src/components/Home/EnableDispatcher.tsx
+msgid "Action Required"
+msgstr "Je vyžadována akce"
+
+#: src/components/Home/EnableDispatcher.tsx
+msgid "You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions."
+msgstr "Dispečerovi můžete povolit interakci s aplikací {APP_NAME}, aniž byste museli podepisovat jakoukoli z vašich transakcí."
+
+#: src/components/Home/FeedEventFilters.tsx
+msgid "Filter"
+msgstr "Filtr"
+
+#: src/components/Home/FeedType.tsx
+msgid "Timeline"
+msgstr "Časová osa"
+
+#: src/components/Home/FeedType.tsx
+msgid "Highlights"
+msgstr "Zvýraznění"
+
+#: src/components/Home/Hero.tsx
+msgid "Welcome to {APP_NAME} 👋"
+msgstr "Vítejte v {APP_NAME} 👋"
+
+#: src/components/Home/Hero.tsx
+msgid "{APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿"
+msgstr "{APP_NAME} je decentralizovaná aplikace sociálních médií bez povolení vytvořená pomocí protokolu Lens 🌿"
+
+#: src/components/Home/RecommendedProfiles.tsx
+msgid "Who to follow"
+msgstr "Koho následovat"
+
+#: src/components/Home/RecommendedProfiles.tsx
+msgid "Show more"
+msgstr "Zobrazit více"
+
+#: src/components/Home/SeeThroughLens.tsx
+msgid "My Feed"
+msgstr "Můj příspěvek"
+
+#: src/components/Home/SeeThroughLens.tsx
+msgid "👀 See the feed through..."
+msgstr "👀 Podívejte se na feed přes..."
+
+#: src/components/Home/SeeThroughLens.tsx
+msgid "Search"
+msgstr "Vyhledávání"
+
+#: src/components/Home/SetProfile.tsx
+msgid "Setup your {APP_NAME} profile"
+msgstr "Nastavte si svůj profil {APP_NAME}"
+
+#: src/components/Home/SetProfile.tsx
+msgid "Set profile name"
+msgstr "Nastavte název profilu"
+
+#: src/components/Home/SetProfile.tsx
+msgid "Set profile bio"
+msgstr "Nastavit bio profilu"
+
+#: src/components/Home/SetProfile.tsx
+msgid "Set your avatar"
+msgstr "Nastavte si avatara"
+
+#: src/components/Home/SetProfile.tsx
+msgid "Select profile interests"
+msgstr "Vyberte zájmy profilu"
+
+#: src/components/Home/SetProfile.tsx
+msgid "Update profile now"
+msgstr "Aktualizujte profil nyní"
+
+#: src/components/Notification/Type/CollectNotification/index.tsx
+msgid "{0} <0>collected your </0><1>{1}</1>"
+msgstr "{0} <0>shromáždil vaše </0><1>{1}</1>"
+
+#: src/components/Notification/Type/CommentNotification.tsx
+msgid "<0/> <1>commented on your </1><2>{0}</2>"
+msgstr "<0/> <1>přidal komentář k vašemu </1><2>{0}</2>"
+
+#: src/components/Notification/Type/FollowerNotification.tsx
+msgid "{0} <0>{1} followed you</0>"
+msgstr "{0} <0>{1} vás sleduje</0>"
+
+#: src/components/Notification/Type/LikeNotification.tsx
+msgid "<0/> <1>liked your </1><2>{0}</2>"
+msgstr "<0/> <1>olajkovalo vaše </1><2>{0}</2>"
+
+#: src/components/Notification/Type/MentionNotification.tsx
+msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
+msgstr "<0/> <1>se o vás zmínil v </1><2>{0}</2>"
+
+#: src/components/Notification/Type/MirrorNotification.tsx
+msgid "<0/> <1>mirrored your </1><2>{0}</2>"
+msgstr "<0/> <1>zrcadlil vaše </1><2>{0}</2>"
+
+#: src/components/Publication/Type/Mirrored.tsx
+msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
+msgstr "<0>{0}</0><1><2>zrcadlil </2><3>{1}</3></1>"
+
+#: src/components/Settings/Account/Language.tsx
+msgid "Locale settings"
+msgstr "Nastavení národního prostředí"
+
+#: src/components/Settings/Account/Language.tsx
+msgid "Select display language"
+msgstr "Vyberte jazyk zobrazení"
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Your default profile"
+msgstr "Váš výchozí profil"
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "You don’t have any default profile set!"
+msgstr "Nemáte nastaven žádný výchozí profil!"
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Select default profile"
+msgstr "Vyberte výchozí profil"
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Selecting your default account helps to display the selected profile across {APP_NAME}, you can change your default profile anytime."
+msgstr "Výběr výchozího účtu pomůže zobrazit vybraný profil v aplikaci {APP_NAME}. Výchozí profil můžete kdykoli změnit."
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "What else you should know"
+msgstr "Co byste ještě měli vědět"
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc."
+msgstr "V aplikaci {APP_NAME}, příkladech oznámení, sledování atd. bude viditelný pouze výchozí profil."
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "You can change default profile anytime here."
+msgstr "Zde můžete kdykoli změnit výchozí profil."
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Select profile"
+msgstr "Vyberte profil"
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Set super follow"
+msgstr "Nastavit super sledování"
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Setting super follow makes users spend crypto to follow you, and it’s a good way to earn it, you can change the amount and currency or disable/enable it anytime."
+msgstr "Nastavení supersledování způsobí, že uživatelé utrácejí kryptoměny, aby vás sledovali, a je to dobrý způsob, jak je vydělat, můžete změnit částku a měnu nebo je kdykoli zakázat/povolit."
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Select Currency"
+msgstr "Vyberte možnost Měna"
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Follow amount"
+msgstr "Sledujte množství"
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Funds recipient"
+msgstr "Příjemce prostředků"
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Disable Super follow"
+msgstr "Zakázat Super sledování"
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Update Super follow"
+msgstr "Aktualizovat Super sledování"
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Set Super follow"
+msgstr "Nastavte Super sledování"
+
+#: src/components/Settings/Account/Verification.tsx
+msgid "Verified"
+msgstr "Ověřeno"
+
+#: src/components/Settings/Account/Verification.tsx
+msgid "No."
+msgstr "Ne."
+
+#: src/components/Settings/Account/Verification.tsx
+msgid "Request Verification"
+msgstr "Požádat o ověření"
+
+#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx
+msgid "Disable dispatcher"
+msgstr "Zakázat dispečera"
+
+#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx
+msgid "Enable dispatcher"
+msgstr "Povolit dispečera"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Profile"
+msgstr "Profil"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Account"
+msgstr "Účet"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Interests"
+msgstr "Zájmy"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Dispatcher"
+msgstr "Odesílatel"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Allowance"
+msgstr "Příspěvek"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Cleanup"
+msgstr "Čištění"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Danger Zone"
+msgstr "Nebezpečná zóna"
+
+#: src/components/Shared/Footer.tsx
+msgid "Terms"
+msgstr "Podmínky"
+
+#: src/components/Shared/Footer.tsx
+msgid "Privacy"
+msgstr "Soukromí"
+
+#: src/components/Shared/Footer.tsx
+msgid "Discord"
+msgstr "Discord"
+
+#: src/components/Shared/Footer.tsx
+msgid "Donate"
+msgstr "Darovat"
+
+#: src/components/Shared/Footer.tsx
+msgid "Status"
+msgstr "Postavení"
+
+#: src/components/Shared/Footer.tsx
+msgid "Feedback"
+msgstr "Zpětná vazba"
+
+#: src/components/Shared/Footer.tsx
+msgid "Thanks"
+msgstr "Dík"
+
+#: src/components/Shared/Footer.tsx
+msgid "GitHub"
+msgstr "GitHub"
+
+#: src/components/Shared/Footer.tsx
 msgid "▲ Powered by Vercel"
 msgstr "▲ Používá technologii Vercel"
 
-#: src/components/Home/SeeThroughLens.tsx:118
-msgid "👀 See the feed through..."
-msgstr "👀 Podívejte se na feed přes..."
+#: src/components/Shared/GlobalModals.tsx
+#: src/components/Shared/Navbar/LoginButton.tsx
+msgid "Login"
+msgstr "Přihlásit se"
+
+#: src/components/Shared/Login/WalletSelector.tsx
+msgid "Sign-In with Lens"
+msgstr "Přihlaste se pomocí Lens"
+
+#: src/components/Shared/Login/WalletSelector.tsx
+msgid "Browser Wallet"
+msgstr "Peněženka prohlížeče"
+
+#: src/components/Shared/Login/index.tsx
+msgid "Please sign the message"
+msgstr "Podepište prosím zprávu"
+
+#: src/components/Shared/Login/index.tsx
+msgid "{APP_NAME} uses this signature to verify that you’re the owner of this address."
+msgstr "Aplikace {APP_NAME} používá tento podpis k ověření, že jste vlastníkem této adresy."
+
+#: src/components/Shared/Login/index.tsx
+msgid "Connect your wallet"
+msgstr "Připojte svou peněženku"
+
+#: src/components/Shared/Login/index.tsx
+msgid "Connect with one of our available wallet providers or create a new one."
+msgstr "Spojte se s jedním z našich dostupných poskytovatelů peněženek nebo vytvořte nového."
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx
+msgid "More"
+msgstr "Více"
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx
+msgid "Contact"
+msgstr "Kontakt"
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx
+msgid "Report a bug"
+msgstr "Nahlásit chybu"
+
+#: src/components/Shared/Navbar/Search.tsx
+msgid "Search…"
+msgstr "Vyhledávání…"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Logged in as"
+msgstr "Přihlášen jako"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Set status"
+msgstr "Nastavit stav"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Your Profile"
+msgstr "Tvůj profil"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Settings"
+msgstr "Nastavení"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Moderation"
+msgstr "Umírněnost"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Logout"
+msgstr "Odhlásit se"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Switch to"
+msgstr "Přepnout na"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Dark mode"
+msgstr "Tmavý režim"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Light mode"
+msgstr "Světelný režim"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Disable staff mode"
+msgstr "Zakázat režim pro zaměstnance"
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Enable staff mode"
+msgstr "Povolit režim zaměstnanců"
+
+#: src/components/Shared/Navbar/index.tsx
+msgid "Home"
+msgstr "Domov"
+
+#: src/components/Shared/Navbar/index.tsx
+msgid "Explore"
+msgstr "Prozkoumat"

--- a/apps/web/src/locales/cs/messages.po
+++ b/apps/web/src/locales/cs/messages.po
@@ -1,0 +1,420 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2022-12-16 21:10+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: cs\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/components/Notification/Type/CommentNotification.tsx:31
+msgid "<0/> <1>commented on your </1><2>{0}</2>"
+msgstr "<0/> <1>přidal komentář k vašemu </1><2>{0}</2>"
+
+#: src/components/Notification/Type/LikeNotification.tsx:31
+msgid "<0/> <1>liked your </1><2>{0}</2>"
+msgstr "<0/> <1>olajkovalo vaše </1><2>{0}</2>"
+
+#: src/components/Notification/Type/MentionNotification.tsx:33
+msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
+msgstr "<0/> <1>se o vás zmínil v </1><2>{0}</2>"
+
+#: src/components/Notification/Type/MirrorNotification.tsx:31
+msgid "<0/> <1>mirrored your </1><2>{0}</2>"
+msgstr "<0/> <1>zrcadlil vaše </1><2>{0}</2>"
+
+#: src/components/Publication/Type/Mirrored.tsx:17
+msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
+msgstr "<0>{0}</0><1><2>zrcadlil </2><3>{1}</3></1>"
+
+#: src/components/Settings/Sidebar.tsx:55
+msgid "Account"
+msgstr "Účet"
+
+#: src/components/Home/EnableDispatcher.tsx:24
+msgid "Action Required"
+msgstr "Je vyžadována akce"
+
+#: src/components/Explore/FeedType.tsx:37
+msgid "All posts"
+msgstr "Všechny příspěvky"
+
+#: src/components/Settings/Sidebar.tsx:73
+msgid "Allowance"
+msgstr "Příspěvek"
+
+#: src/components/Explore/FeedType.tsx:40
+msgid "Audio"
+msgstr "Zvuk"
+
+#: src/components/Home/BetaWarning.tsx:16
+msgid "Beta warning!"
+msgstr "Upozornění beta!"
+
+#: src/components/Shared/Login/WalletSelector.tsx:150
+msgid "Browser Wallet"
+msgstr "Peněženka prohlížeče"
+
+#: src/components/Settings/Sidebar.tsx:79
+msgid "Cleanup"
+msgstr "Čištění"
+
+#: src/components/Shared/Login/index.tsx:34
+msgid "Connect with one of our available wallet providers or create a new one."
+msgstr "Spojte se s jedním z našich dostupných poskytovatelů peněženek nebo vytvořte nového."
+
+#: src/components/Shared/Login/index.tsx:31
+msgid "Connect your wallet"
+msgstr "Připojte svou peněženku"
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx:51
+msgid "Contact"
+msgstr "Kontakt"
+
+#: src/components/Settings/Sidebar.tsx:85
+msgid "Danger Zone"
+msgstr "Nebezpečná zóna"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:246
+msgid "Dark mode"
+msgstr "Tmavý režim"
+
+#: src/components/Settings/Account/SuperFollow.tsx:217
+msgid "Disable Super follow"
+msgstr "Zakázat Super sledování"
+
+#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx:115
+msgid "Disable dispatcher"
+msgstr "Zakázat dispečera"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:287
+msgid "Disable staff mode"
+msgstr "Zakázat režim pro zaměstnance"
+
+#: src/components/Shared/Footer.tsx:29
+msgid "Discord"
+msgstr "Discord"
+
+#: src/components/Settings/Sidebar.tsx:67
+msgid "Dispatcher"
+msgstr "Odesílatel"
+
+#: src/components/Shared/Footer.tsx:37
+msgid "Donate"
+msgstr "Darovat"
+
+#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx:115
+msgid "Enable dispatcher"
+msgstr "Povolit dispečera"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:294
+msgid "Enable staff mode"
+msgstr "Povolit režim zaměstnanců"
+
+#: src/components/Shared/Navbar/index.tsx:61
+msgid "Explore"
+msgstr "Prozkoumat"
+
+#: src/components/Shared/Footer.tsx:53
+msgid "Feedback"
+msgstr "Zpětná vazba"
+
+#: src/components/Home/FeedEventFilters.tsx:22
+msgid "Filter"
+msgstr "Filtr"
+
+#: src/components/Settings/Account/SuperFollow.tsx:183
+msgid "Follow amount"
+msgstr "Sledujte množství"
+
+#: src/components/Explore/index.tsx:25
+msgid "For you"
+msgstr "Pro tebe"
+
+#: src/components/Settings/Account/SuperFollow.tsx:201
+msgid "Funds recipient"
+msgstr "Příjemce prostředků"
+
+#: src/components/Home/BetaWarning.tsx:26
+msgid "Get testnet tokens"
+msgstr "Získejte tokeny testnet"
+
+#: src/components/Shared/Footer.tsx:62
+msgid "GitHub"
+msgstr "GitHub"
+
+#: src/components/Home/FeedType.tsx:31
+msgid "Highlights"
+msgstr "Zvýraznění"
+
+#: src/components/Shared/Navbar/index.tsx:60
+msgid "Home"
+msgstr "Domov"
+
+#: src/components/Explore/FeedType.tsx:41
+msgid "Images"
+msgstr "Snímky"
+
+#: src/components/Explore/index.tsx:28
+msgid "Interesting"
+msgstr "Zajímavý"
+
+#: src/components/Settings/Sidebar.tsx:61
+msgid "Interests"
+msgstr "Zájmy"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:253
+msgid "Light mode"
+msgstr "Světelný režim"
+
+#: src/components/Settings/Account/Language.tsx:17
+msgid "Locale settings"
+msgstr "Nastavení národního prostředí"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:103
+msgid "Logged in as"
+msgstr "Přihlášen jako"
+
+#: src/components/Shared/GlobalModals.tsx:42
+#: src/components/Shared/Navbar/LoginButton.tsx:19
+msgid "Login"
+msgstr "Přihlásit se"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:186
+msgid "Logout"
+msgstr "Odhlásit se"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:173
+msgid "Moderation"
+msgstr "Umírněnost"
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx:25
+msgid "More"
+msgstr "Více"
+
+#: src/components/Home/SeeThroughLens.tsx:100
+msgid "My Feed"
+msgstr "Můj příspěvek"
+
+#: src/components/Settings/Account/Verification.tsx:25
+msgid "No."
+msgstr "Ne."
+
+#: src/components/Settings/Account/SetProfile.tsx:151
+msgid "Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc."
+msgstr "V aplikaci {APP_NAME}, příkladech oznámení, sledování atd. bude viditelný pouze výchozí profil."
+
+#: src/components/Shared/Login/index.tsx:20
+msgid "Please sign the message"
+msgstr "Podepište prosím zprávu"
+
+#: src/components/Explore/index.tsx:26
+msgid "Popular"
+msgstr "Oblíbený"
+
+#: src/components/Shared/Footer.tsx:22
+msgid "Privacy"
+msgstr "Soukromí"
+
+#: src/components/Settings/Sidebar.tsx:49
+msgid "Profile"
+msgstr "Profil"
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx:66
+msgid "Report a bug"
+msgstr "Nahlásit chybu"
+
+#: src/components/Settings/Account/Verification.tsx:34
+msgid "Request Verification"
+msgstr "Požádat o ověření"
+
+#: src/components/Home/SeeThroughLens.tsx:124
+msgid "Search"
+msgstr "Vyhledávání"
+
+#: src/components/Shared/Navbar/Search.tsx:28
+msgid "Search…"
+msgstr "Vyhledávání…"
+
+#: src/components/Settings/Account/SuperFollow.tsx:165
+msgid "Select Currency"
+msgstr "Vyberte možnost Měna"
+
+#: src/components/Settings/Account/SetProfile.tsx:138
+msgid "Select default profile"
+msgstr "Vyberte výchozí profil"
+
+#: src/components/Settings/Account/Language.tsx:21
+msgid "Select display language"
+msgstr "Vyberte jazyk zobrazení"
+
+#: src/components/Settings/Account/SetProfile.tsx:161
+msgid "Select profile"
+msgstr "Vyberte profil"
+
+#: src/components/Home/SetProfile.tsx:67
+msgid "Select profile interests"
+msgstr "Vyberte zájmy profilu"
+
+#: src/components/Settings/Account/SetProfile.tsx:141
+msgid "Selecting your default account helps to display the selected profile across {APP_NAME}, you can change your default profile anytime."
+msgstr "Výběr výchozího účtu pomůže zobrazit vybraný profil v aplikaci {APP_NAME}. Výchozí profil můžete kdykoli změnit."
+
+#: src/components/Settings/Account/SuperFollow.tsx:225
+msgid "Set Super follow"
+msgstr "Nastavte Super sledování"
+
+#: src/components/Home/SetProfile.tsx:57
+msgid "Set profile bio"
+msgstr "Nastavit bio profilu"
+
+#: src/components/Home/SetProfile.tsx:56
+msgid "Set profile name"
+msgstr "Nastavte název profilu"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:127
+msgid "Set status"
+msgstr "Nastavit stav"
+
+#: src/components/Settings/Account/SuperFollow.tsx:155
+msgid "Set super follow"
+msgstr "Nastavit super sledování"
+
+#: src/components/Home/SetProfile.tsx:58
+msgid "Set your avatar"
+msgstr "Nastavte si avatara"
+
+#: src/components/Settings/Account/SuperFollow.tsx:158
+msgid "Setting super follow makes users spend crypto to follow you, and it’s a good way to earn it, you can change the amount and currency or disable/enable it anytime."
+msgstr "Nastavení supersledování způsobí, že uživatelé utrácejí kryptoměny, aby vás sledovali, a je to dobrý způsob, jak je vydělat, můžete změnit částku a měnu nebo je kdykoli zakázat/povolit."
+
+#: src/components/Shared/Navbar/SignedUser.tsx:158
+msgid "Settings"
+msgstr "Nastavení"
+
+#: src/components/Home/SetProfile.tsx:52
+msgid "Setup your {APP_NAME} profile"
+msgstr "Nastavte si svůj profil {APP_NAME}"
+
+#: src/components/Home/RecommendedProfiles.tsx:89
+msgid "Show more"
+msgstr "Zobrazit více"
+
+#: src/components/Shared/Login/WalletSelector.tsx:123
+msgid "Sign-In with Lens"
+msgstr "Přihlaste se pomocí Lens"
+
+#: src/components/Shared/Footer.tsx:45
+msgid "Status"
+msgstr "Postavení"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:197
+msgid "Switch to"
+msgstr "Přepnout na"
+
+#: src/components/Shared/Footer.tsx:21
+msgid "Terms"
+msgstr "Podmínky"
+
+#: src/components/Explore/FeedType.tsx:38
+msgid "Text"
+msgstr "Text"
+
+#: src/components/Shared/Footer.tsx:55
+msgid "Thanks"
+msgstr "Dík"
+
+#: src/components/Home/FeedType.tsx:21
+msgid "Timeline"
+msgstr "Časová osa"
+
+#: src/components/Explore/index.tsx:27
+#: src/components/Home/Trending.tsx:19
+msgid "Trending"
+msgstr "Trendy"
+
+#: src/components/Settings/Account/SuperFollow.tsx:225
+msgid "Update Super follow"
+msgstr "Aktualizovat Super sledování"
+
+#: src/components/Home/SetProfile.tsx:76
+msgid "Update profile now"
+msgstr "Aktualizujte profil nyní"
+
+#: src/components/Settings/Account/Verification.tsx:16
+msgid "Verified"
+msgstr "Ověřeno"
+
+#: src/components/Explore/FeedType.tsx:39
+msgid "Video"
+msgstr "Video"
+
+#: src/components/Home/Hero.tsx:11
+msgid "Welcome to {APP_NAME} 👋"
+msgstr "Vítejte v {APP_NAME} 👋"
+
+#: src/components/Settings/Account/SetProfile.tsx:147
+msgid "What else you should know"
+msgstr "Co byste ještě měli vědět"
+
+#: src/components/Composer/Post/New.tsx:86
+msgid "What's happening?"
+msgstr "Co se děje?"
+
+#: src/components/Home/RecommendedProfiles.tsx:24
+msgid "Who to follow"
+msgstr "Koho následovat"
+
+#: src/components/Settings/Account/SetProfile.tsx:156
+msgid "You can change default profile anytime here."
+msgstr "Zde můžete kdykoli změnit výchozí profil."
+
+#: src/components/Home/EnableDispatcher.tsx:28
+msgid "You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions."
+msgstr "Dispečerovi můžete povolit interakci s aplikací {APP_NAME}, aniž byste museli podepisovat jakoukoli z vašich transakcí."
+
+#: src/components/Settings/Account/SetProfile.tsx:133
+msgid "You don’t have any default profile set!"
+msgstr "Nemáte nastaven žádný výchozí profil!"
+
+#: src/components/Shared/Navbar/SignedUser.tsx:144
+msgid "Your Profile"
+msgstr "Tvůj profil"
+
+#: src/components/Settings/Account/SetProfile.tsx:125
+msgid "Your default profile"
+msgstr "Váš výchozí profil"
+
+#: src/components/Notification/Type/CollectNotification/index.tsx:40
+msgid "{0} <0>collected your </0><1>{1}</1>"
+msgstr "{0} <0>shromáždil vaše </0><1>{1}</1>"
+
+#: src/components/Notification/Type/FollowerNotification.tsx:42
+msgid "{0} <0>{1} followed you</0>"
+msgstr "{0} <0>{1} vás sleduje</0>"
+
+#: src/components/Home/Hero.tsx:14
+msgid "{APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿"
+msgstr "{APP_NAME} je decentralizovaná aplikace sociálních médií bez povolení vytvořená pomocí protokolu Lens 🌿"
+
+#: src/components/Home/BetaWarning.tsx:20
+msgid "{APP_NAME} is still in the beta phase, things may break, please handle us with care."
+msgstr "Aplikace {APP_NAME} je stále ve fázi beta, může se něco pokazit, zacházejte s námi prosím opatrně."
+
+#: src/components/Shared/Login/index.tsx:23
+msgid "{APP_NAME} uses this signature to verify that you’re the owner of this address."
+msgstr "Aplikace {APP_NAME} používá tento podpis k ověření, že jste vlastníkem této adresy."
+
+#: src/components/Shared/Footer.tsx:71
+msgid "▲ Powered by Vercel"
+msgstr "▲ Používá technologii Vercel"
+
+#: src/components/Home/SeeThroughLens.tsx:118
+msgid "👀 See the feed through..."
+msgstr "👀 Podívejte se na feed přes..."

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -22,6 +22,13 @@ msgstr ""
 msgid "What's happening?"
 msgstr ""
 
+#: src/components/Explore/Feed.tsx
+#: src/components/Home/Highlights.tsx
+#: src/components/Home/Timeline/index.tsx
+#: src/components/Mod/Feed.tsx
+msgid "No posts yet!"
+msgstr ""
+
 #: src/components/Explore/FeedType.tsx
 msgid "All posts"
 msgstr ""
@@ -203,7 +210,11 @@ msgid "<0><1/> mentioned you in a <2>post</2></0>"
 msgstr ""
 
 #: src/components/Publication/Type/Mirrored.tsx
-msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
+msgid "<0><1/> mirrored the <2>comment</2></0>"
+msgstr ""
+
+#: src/components/Publication/Type/Mirrored.tsx
+msgid "<0><1/> mirrored the <2>post</2></0>"
 msgstr ""
 
 #: src/components/Settings/Account/Language.tsx

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -13,408 +13,408 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Notification/Type/CommentNotification.tsx:31
-msgid "<0/> <1>commented on your </1><2>{0}</2>"
-msgstr ""
-
-#: src/components/Notification/Type/LikeNotification.tsx:31
-msgid "<0/> <1>liked your </1><2>{0}</2>"
-msgstr ""
-
-#: src/components/Notification/Type/MentionNotification.tsx:33
-msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
-msgstr ""
-
-#: src/components/Notification/Type/MirrorNotification.tsx:31
-msgid "<0/> <1>mirrored your </1><2>{0}</2>"
-msgstr ""
-
-#: src/components/Publication/Type/Mirrored.tsx:17
-msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
-msgstr ""
-
-#: src/components/Settings/Sidebar.tsx:55
-msgid "Account"
-msgstr ""
-
-#: src/components/Home/EnableDispatcher.tsx:24
-msgid "Action Required"
-msgstr ""
-
-#: src/components/Explore/FeedType.tsx:37
-msgid "All posts"
-msgstr ""
-
-#: src/components/Settings/Sidebar.tsx:73
-msgid "Allowance"
-msgstr ""
-
-#: src/components/Explore/FeedType.tsx:40
-msgid "Audio"
-msgstr ""
-
-#: src/components/Home/BetaWarning.tsx:16
-msgid "Beta warning!"
-msgstr ""
-
-#: src/components/Shared/Login/WalletSelector.tsx:150
-msgid "Browser Wallet"
-msgstr ""
-
-#: src/components/Settings/Sidebar.tsx:79
-msgid "Cleanup"
-msgstr ""
-
-#: src/components/Shared/Login/index.tsx:34
-msgid "Connect with one of our available wallet providers or create a new one."
-msgstr ""
-
-#: src/components/Shared/Login/index.tsx:31
-msgid "Connect your wallet"
-msgstr ""
-
-#: src/components/Shared/Navbar/MoreNavItems.tsx:51
-msgid "Contact"
-msgstr ""
-
-#: src/components/Settings/Sidebar.tsx:85
-msgid "Danger Zone"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:246
-msgid "Dark mode"
-msgstr ""
-
-#: src/components/Settings/Account/SuperFollow.tsx:217
-msgid "Disable Super follow"
-msgstr ""
-
-#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx:115
-msgid "Disable dispatcher"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:287
-msgid "Disable staff mode"
-msgstr ""
-
-#: src/components/Shared/Footer.tsx:29
-msgid "Discord"
-msgstr ""
-
-#: src/components/Settings/Sidebar.tsx:67
-msgid "Dispatcher"
-msgstr ""
-
-#: src/components/Shared/Footer.tsx:37
-msgid "Donate"
-msgstr ""
-
-#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx:115
-msgid "Enable dispatcher"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:294
-msgid "Enable staff mode"
-msgstr ""
-
-#: src/components/Shared/Navbar/index.tsx:61
-msgid "Explore"
-msgstr ""
-
-#: src/components/Shared/Footer.tsx:53
-msgid "Feedback"
-msgstr ""
-
-#: src/components/Home/FeedEventFilters.tsx:22
-msgid "Filter"
-msgstr ""
-
-#: src/components/Settings/Account/SuperFollow.tsx:183
-msgid "Follow amount"
-msgstr ""
-
-#: src/components/Explore/index.tsx:25
-msgid "For you"
-msgstr ""
-
-#: src/components/Settings/Account/SuperFollow.tsx:201
-msgid "Funds recipient"
-msgstr ""
-
-#: src/components/Home/BetaWarning.tsx:26
-msgid "Get testnet tokens"
-msgstr ""
-
-#: src/components/Shared/Footer.tsx:62
-msgid "GitHub"
-msgstr ""
-
-#: src/components/Home/FeedType.tsx:31
-msgid "Highlights"
-msgstr ""
-
-#: src/components/Shared/Navbar/index.tsx:60
-msgid "Home"
-msgstr ""
-
-#: src/components/Explore/FeedType.tsx:41
-msgid "Images"
-msgstr ""
-
-#: src/components/Explore/index.tsx:28
-msgid "Interesting"
-msgstr ""
-
-#: src/components/Settings/Sidebar.tsx:61
-msgid "Interests"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:253
-msgid "Light mode"
-msgstr ""
-
-#: src/components/Settings/Account/Language.tsx:17
-msgid "Locale settings"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:103
-msgid "Logged in as"
-msgstr ""
-
-#: src/components/Shared/GlobalModals.tsx:42
-#: src/components/Shared/Navbar/LoginButton.tsx:19
-msgid "Login"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:186
-msgid "Logout"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:173
-msgid "Moderation"
-msgstr ""
-
-#: src/components/Shared/Navbar/MoreNavItems.tsx:25
-msgid "More"
-msgstr ""
-
-#: src/components/Home/SeeThroughLens.tsx:100
-msgid "My Feed"
-msgstr ""
-
-#: src/components/Settings/Account/Verification.tsx:25
-msgid "No."
-msgstr ""
-
-#: src/components/Settings/Account/SetProfile.tsx:151
-msgid "Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc."
-msgstr ""
-
-#: src/components/Shared/Login/index.tsx:20
-msgid "Please sign the message"
-msgstr ""
-
-#: src/components/Explore/index.tsx:26
-msgid "Popular"
-msgstr ""
-
-#: src/components/Shared/Footer.tsx:22
-msgid "Privacy"
-msgstr ""
-
-#: src/components/Settings/Sidebar.tsx:49
-msgid "Profile"
-msgstr ""
-
-#: src/components/Shared/Navbar/MoreNavItems.tsx:66
-msgid "Report a bug"
-msgstr ""
-
-#: src/components/Settings/Account/Verification.tsx:34
-msgid "Request Verification"
-msgstr ""
-
-#: src/components/Home/SeeThroughLens.tsx:124
-msgid "Search"
-msgstr ""
-
-#: src/components/Shared/Navbar/Search.tsx:28
-msgid "Search…"
-msgstr ""
-
-#: src/components/Settings/Account/SuperFollow.tsx:165
-msgid "Select Currency"
-msgstr ""
-
-#: src/components/Settings/Account/SetProfile.tsx:138
-msgid "Select default profile"
-msgstr ""
-
-#: src/components/Settings/Account/Language.tsx:21
-msgid "Select display language"
-msgstr ""
-
-#: src/components/Settings/Account/SetProfile.tsx:161
-msgid "Select profile"
-msgstr ""
-
-#: src/components/Home/SetProfile.tsx:67
-msgid "Select profile interests"
-msgstr ""
-
-#: src/components/Settings/Account/SetProfile.tsx:141
-msgid "Selecting your default account helps to display the selected profile across {APP_NAME}, you can change your default profile anytime."
-msgstr ""
-
-#: src/components/Settings/Account/SuperFollow.tsx:225
-msgid "Set Super follow"
-msgstr ""
-
-#: src/components/Home/SetProfile.tsx:57
-msgid "Set profile bio"
-msgstr ""
-
-#: src/components/Home/SetProfile.tsx:56
-msgid "Set profile name"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:127
-msgid "Set status"
-msgstr ""
-
-#: src/components/Settings/Account/SuperFollow.tsx:155
-msgid "Set super follow"
-msgstr ""
-
-#: src/components/Home/SetProfile.tsx:58
-msgid "Set your avatar"
-msgstr ""
-
-#: src/components/Settings/Account/SuperFollow.tsx:158
-msgid "Setting super follow makes users spend crypto to follow you, and it’s a good way to earn it, you can change the amount and currency or disable/enable it anytime."
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:158
-msgid "Settings"
-msgstr ""
-
-#: src/components/Home/SetProfile.tsx:52
-msgid "Setup your {APP_NAME} profile"
-msgstr ""
-
-#: src/components/Home/RecommendedProfiles.tsx:89
-msgid "Show more"
-msgstr ""
-
-#: src/components/Shared/Login/WalletSelector.tsx:123
-msgid "Sign-In with Lens"
-msgstr ""
-
-#: src/components/Shared/Footer.tsx:45
-msgid "Status"
-msgstr ""
-
-#: src/components/Shared/Navbar/SignedUser.tsx:197
-msgid "Switch to"
-msgstr ""
-
-#: src/components/Shared/Footer.tsx:21
-msgid "Terms"
-msgstr ""
-
-#: src/components/Explore/FeedType.tsx:38
-msgid "Text"
-msgstr ""
-
-#: src/components/Shared/Footer.tsx:55
-msgid "Thanks"
-msgstr ""
-
-#: src/components/Home/FeedType.tsx:21
-msgid "Timeline"
-msgstr ""
-
-#: src/components/Explore/index.tsx:27
-#: src/components/Home/Trending.tsx:19
-msgid "Trending"
-msgstr ""
-
-#: src/components/Settings/Account/SuperFollow.tsx:225
-msgid "Update Super follow"
-msgstr ""
-
-#: src/components/Home/SetProfile.tsx:76
-msgid "Update profile now"
-msgstr ""
-
-#: src/components/Settings/Account/Verification.tsx:16
-msgid "Verified"
-msgstr ""
-
-#: src/components/Explore/FeedType.tsx:39
-msgid "Video"
-msgstr ""
-
-#: src/components/Home/Hero.tsx:11
-msgid "Welcome to {APP_NAME} 👋"
-msgstr ""
-
-#: src/components/Settings/Account/SetProfile.tsx:147
-msgid "What else you should know"
-msgstr ""
-
-#: src/components/Composer/Post/New.tsx:86
+#: src/components/Composer/Post/New.tsx
 msgid "What's happening?"
 msgstr ""
 
-#: src/components/Home/RecommendedProfiles.tsx:24
-msgid "Who to follow"
+#: src/components/Explore/FeedType.tsx
+msgid "All posts"
 msgstr ""
 
-#: src/components/Settings/Account/SetProfile.tsx:156
-msgid "You can change default profile anytime here."
+#: src/components/Explore/FeedType.tsx
+msgid "Text"
 msgstr ""
 
-#: src/components/Home/EnableDispatcher.tsx:28
-msgid "You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions."
+#: src/components/Explore/FeedType.tsx
+msgid "Video"
 msgstr ""
 
-#: src/components/Settings/Account/SetProfile.tsx:133
-msgid "You don’t have any default profile set!"
+#: src/components/Explore/FeedType.tsx
+msgid "Audio"
 msgstr ""
 
-#: src/components/Shared/Navbar/SignedUser.tsx:144
-msgid "Your Profile"
+#: src/components/Explore/FeedType.tsx
+msgid "Images"
 msgstr ""
 
-#: src/components/Settings/Account/SetProfile.tsx:125
-msgid "Your default profile"
+#: src/components/Explore/index.tsx
+msgid "For you"
 msgstr ""
 
-#: src/components/Notification/Type/CollectNotification/index.tsx:40
-msgid "{0} <0>collected your </0><1>{1}</1>"
+#: src/components/Explore/index.tsx
+msgid "Popular"
 msgstr ""
 
-#: src/components/Notification/Type/FollowerNotification.tsx:42
-msgid "{0} <0>{1} followed you</0>"
+#: src/components/Explore/index.tsx
+#: src/components/Home/Trending.tsx
+msgid "Trending"
 msgstr ""
 
-#: src/components/Home/Hero.tsx:14
-msgid "{APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿"
+#: src/components/Explore/index.tsx
+msgid "Interesting"
 msgstr ""
 
-#: src/components/Home/BetaWarning.tsx:20
+#: src/components/Home/BetaWarning.tsx
+msgid "Beta warning!"
+msgstr ""
+
+#: src/components/Home/BetaWarning.tsx
 msgid "{APP_NAME} is still in the beta phase, things may break, please handle us with care."
 msgstr ""
 
-#: src/components/Shared/Login/index.tsx:23
-msgid "{APP_NAME} uses this signature to verify that you’re the owner of this address."
+#: src/components/Home/BetaWarning.tsx
+msgid "Get testnet tokens"
 msgstr ""
 
-#: src/components/Shared/Footer.tsx:71
+#: src/components/Home/EnableDispatcher.tsx
+msgid "Action Required"
+msgstr ""
+
+#: src/components/Home/EnableDispatcher.tsx
+msgid "You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions."
+msgstr ""
+
+#: src/components/Home/FeedEventFilters.tsx
+msgid "Filter"
+msgstr ""
+
+#: src/components/Home/FeedType.tsx
+msgid "Timeline"
+msgstr ""
+
+#: src/components/Home/FeedType.tsx
+msgid "Highlights"
+msgstr ""
+
+#: src/components/Home/Hero.tsx
+msgid "Welcome to {APP_NAME} 👋"
+msgstr ""
+
+#: src/components/Home/Hero.tsx
+msgid "{APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿"
+msgstr ""
+
+#: src/components/Home/RecommendedProfiles.tsx
+msgid "Who to follow"
+msgstr ""
+
+#: src/components/Home/RecommendedProfiles.tsx
+msgid "Show more"
+msgstr ""
+
+#: src/components/Home/SeeThroughLens.tsx
+msgid "My Feed"
+msgstr ""
+
+#: src/components/Home/SeeThroughLens.tsx
+msgid "👀 See the feed through..."
+msgstr ""
+
+#: src/components/Home/SeeThroughLens.tsx
+msgid "Search"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx
+msgid "Setup your {APP_NAME} profile"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx
+msgid "Set profile name"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx
+msgid "Set profile bio"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx
+msgid "Set your avatar"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx
+msgid "Select profile interests"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx
+msgid "Update profile now"
+msgstr ""
+
+#: src/components/Notification/Type/CollectNotification/index.tsx
+msgid "{0} <0>collected your </0><1>{1}</1>"
+msgstr ""
+
+#: src/components/Notification/Type/CommentNotification.tsx
+msgid "<0/> <1>commented on your </1><2>{0}</2>"
+msgstr ""
+
+#: src/components/Notification/Type/FollowerNotification.tsx
+msgid "{0} <0>{1} followed you</0>"
+msgstr ""
+
+#: src/components/Notification/Type/LikeNotification.tsx
+msgid "<0/> <1>liked your </1><2>{0}</2>"
+msgstr ""
+
+#: src/components/Notification/Type/MentionNotification.tsx
+msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
+msgstr ""
+
+#: src/components/Notification/Type/MirrorNotification.tsx
+msgid "<0/> <1>mirrored your </1><2>{0}</2>"
+msgstr ""
+
+#: src/components/Publication/Type/Mirrored.tsx
+msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
+msgstr ""
+
+#: src/components/Settings/Account/Language.tsx
+msgid "Locale settings"
+msgstr ""
+
+#: src/components/Settings/Account/Language.tsx
+msgid "Select display language"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Your default profile"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "You don’t have any default profile set!"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Select default profile"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Selecting your default account helps to display the selected profile across {APP_NAME}, you can change your default profile anytime."
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "What else you should know"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc."
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "You can change default profile anytime here."
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx
+msgid "Select profile"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Set super follow"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Setting super follow makes users spend crypto to follow you, and it’s a good way to earn it, you can change the amount and currency or disable/enable it anytime."
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Select Currency"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Follow amount"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Funds recipient"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Disable Super follow"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Update Super follow"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
+msgid "Set Super follow"
+msgstr ""
+
+#: src/components/Settings/Account/Verification.tsx
+msgid "Verified"
+msgstr ""
+
+#: src/components/Settings/Account/Verification.tsx
+msgid "No."
+msgstr ""
+
+#: src/components/Settings/Account/Verification.tsx
+msgid "Request Verification"
+msgstr ""
+
+#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx
+msgid "Disable dispatcher"
+msgstr ""
+
+#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx
+msgid "Enable dispatcher"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Profile"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Account"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Interests"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Dispatcher"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Allowance"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Cleanup"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Danger Zone"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
+msgid "Terms"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
+msgid "Privacy"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
+msgid "Discord"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
+msgid "Donate"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
+msgid "Status"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
+msgid "Feedback"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
+msgid "Thanks"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
+msgid "GitHub"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx
 msgid "▲ Powered by Vercel"
 msgstr ""
 
-#: src/components/Home/SeeThroughLens.tsx:118
-msgid "👀 See the feed through..."
+#: src/components/Shared/GlobalModals.tsx
+#: src/components/Shared/Navbar/LoginButton.tsx
+msgid "Login"
+msgstr ""
+
+#: src/components/Shared/Login/WalletSelector.tsx
+msgid "Sign-In with Lens"
+msgstr ""
+
+#: src/components/Shared/Login/WalletSelector.tsx
+msgid "Browser Wallet"
+msgstr ""
+
+#: src/components/Shared/Login/index.tsx
+msgid "Please sign the message"
+msgstr ""
+
+#: src/components/Shared/Login/index.tsx
+msgid "{APP_NAME} uses this signature to verify that you’re the owner of this address."
+msgstr ""
+
+#: src/components/Shared/Login/index.tsx
+msgid "Connect your wallet"
+msgstr ""
+
+#: src/components/Shared/Login/index.tsx
+msgid "Connect with one of our available wallet providers or create a new one."
+msgstr ""
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx
+msgid "More"
+msgstr ""
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx
+msgid "Contact"
+msgstr ""
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx
+msgid "Report a bug"
+msgstr ""
+
+#: src/components/Shared/Navbar/Search.tsx
+msgid "Search…"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Logged in as"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Set status"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Your Profile"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Settings"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Moderation"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Logout"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Switch to"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Dark mode"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Light mode"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Disable staff mode"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx
+msgid "Enable staff mode"
+msgstr ""
+
+#: src/components/Shared/Navbar/index.tsx
+msgid "Home"
+msgstr ""
+
+#: src/components/Shared/Navbar/index.tsx
+msgid "Explore"
 msgstr ""

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -2,16 +2,21 @@ msgid ""
 msgstr ""
 "POT-Creation-Date: 2022-12-16 21:10+0100\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: en\n"
-"Project-Id-Version: \n"
+"Project-Id-Version: lenstertest\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: \n"
+"PO-Revision-Date: 2022-12-25 13:24\n"
 "Last-Translator: \n"
-"Language-Team: \n"
-"Plural-Forms: \n"
+"Language-Team: English\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Crowdin-Project: lenstertest\n"
+"X-Crowdin-Project-ID: 556737\n"
+"X-Crowdin-Language: en\n"
+"X-Crowdin-File: /src/locales/en/messages.po\n"
+"X-Crowdin-File-ID: 9\n"
 
 #: src/components/Composer/Post/New.tsx
 msgid "What's happening?"
@@ -139,27 +144,62 @@ msgid "Update profile now"
 msgstr ""
 
 #: src/components/Notification/Type/CollectNotification/index.tsx
-msgid "{0} <0>collected your </0><1>{1}</1>"
+msgid "<0><1/> collected your <2>comment</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/CollectNotification/index.tsx
+msgid "<0><1/> collected your <2>mirror</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/CollectNotification/index.tsx
+msgid "<0><1/> collected your <2>post</2></0>"
 msgstr ""
 
 #: src/components/Notification/Type/CommentNotification.tsx
-msgid "<0/> <1>commented on your </1><2>{0}</2>"
+#: src/components/Notification/Type/MirrorNotification.tsx
+msgid "<0><1/> commented on your <2>comment</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/CommentNotification.tsx
+#: src/components/Notification/Type/MirrorNotification.tsx
+msgid "<0><1/> commented on your <2>mirror</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/CommentNotification.tsx
+#: src/components/Notification/Type/MirrorNotification.tsx
+msgid "<0><1/> commented on your <2>post</2></0>"
 msgstr ""
 
 #: src/components/Notification/Type/FollowerNotification.tsx
-msgid "{0} <0>{1} followed you</0>"
+msgid "<0><1/> followed you</0>"
+msgstr ""
+
+#: src/components/Notification/Type/FollowerNotification.tsx
+msgid "<0><1/> super followed you</0>"
 msgstr ""
 
 #: src/components/Notification/Type/LikeNotification.tsx
-msgid "<0/> <1>liked your </1><2>{0}</2>"
+msgid "<0><1/> liked your <2>comment</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/LikeNotification.tsx
+msgid "<0><1/> liked your <2>mirror</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/LikeNotification.tsx
+msgid "<0><1/> liked your <2>post</2></0>"
 msgstr ""
 
 #: src/components/Notification/Type/MentionNotification.tsx
-msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
+msgid "<0><1/> mentioned you in a <2>comment</2></0>"
 msgstr ""
 
-#: src/components/Notification/Type/MirrorNotification.tsx
-msgid "<0/> <1>mirrored your </1><2>{0}</2>"
+#: src/components/Notification/Type/MentionNotification.tsx
+msgid "<0><1/> mentioned you in a <2>mirror</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/MentionNotification.tsx
+msgid "<0><1/> mentioned you in a <2>post</2></0>"
 msgstr ""
 
 #: src/components/Publication/Type/Mirrored.tsx

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -18,8 +18,22 @@ msgstr ""
 "X-Crowdin-File: /src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 9\n"
 
+#: src/components/Composer/Editor/index.tsx
 #: src/components/Composer/Post/New.tsx
+#: src/components/Shared/Status.tsx
 msgid "What's happening?"
+msgstr ""
+
+#: src/components/Composer/NewPublication.tsx
+msgid "[cta]Comment"
+msgstr "Comment"
+
+#: src/components/Composer/NewPublication.tsx
+msgid "[cta]Post"
+msgstr "Post"
+
+#: src/components/Composer/Post/New.tsx
+msgid "Create post"
 msgstr ""
 
 #: src/components/Explore/Feed.tsx
@@ -150,6 +164,10 @@ msgstr ""
 msgid "Update profile now"
 msgstr ""
 
+#: src/components/Home/Trending.tsx
+msgid "<0>{0} Publications</0>"
+msgstr ""
+
 #: src/components/Notification/Type/CollectNotification/index.tsx
 msgid "<0><1/> collected your <2>comment</2></0>"
 msgstr ""
@@ -207,6 +225,42 @@ msgstr ""
 
 #: src/components/Notification/Type/MentionNotification.tsx
 msgid "<0><1/> mentioned you in a <2>post</2></0>"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Contact • {APP_NAME}"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Contact {APP_NAME}"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Contact us to help you get the issue resolved."
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Publication reported successfully!"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Subject"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "What happened?"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "How can we help?"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Submit"
 msgstr ""
 
 #: src/components/Publication/Type/Mirrored.tsx
@@ -376,6 +430,18 @@ msgstr ""
 #: src/components/Shared/GlobalModals.tsx
 #: src/components/Shared/Navbar/LoginButton.tsx
 msgid "Login"
+msgstr ""
+
+#: src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
+msgid "Bold"
+msgstr ""
+
+#: src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
+msgid "Italic"
+msgstr ""
+
+#: src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
+msgid "Code"
 msgstr ""
 
 #: src/components/Shared/Login/WalletSelector.tsx

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1,0 +1,420 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2022-12-16 21:10+0100\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/components/Notification/Type/CommentNotification.tsx:31
+msgid "<0/> <1>commented on your </1><2>{0}</2>"
+msgstr ""
+
+#: src/components/Notification/Type/LikeNotification.tsx:31
+msgid "<0/> <1>liked your </1><2>{0}</2>"
+msgstr ""
+
+#: src/components/Notification/Type/MentionNotification.tsx:33
+msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
+msgstr ""
+
+#: src/components/Notification/Type/MirrorNotification.tsx:31
+msgid "<0/> <1>mirrored your </1><2>{0}</2>"
+msgstr ""
+
+#: src/components/Publication/Type/Mirrored.tsx:17
+msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx:55
+msgid "Account"
+msgstr ""
+
+#: src/components/Home/EnableDispatcher.tsx:24
+msgid "Action Required"
+msgstr ""
+
+#: src/components/Explore/FeedType.tsx:37
+msgid "All posts"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx:73
+msgid "Allowance"
+msgstr ""
+
+#: src/components/Explore/FeedType.tsx:40
+msgid "Audio"
+msgstr ""
+
+#: src/components/Home/BetaWarning.tsx:16
+msgid "Beta warning!"
+msgstr ""
+
+#: src/components/Shared/Login/WalletSelector.tsx:150
+msgid "Browser Wallet"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx:79
+msgid "Cleanup"
+msgstr ""
+
+#: src/components/Shared/Login/index.tsx:34
+msgid "Connect with one of our available wallet providers or create a new one."
+msgstr ""
+
+#: src/components/Shared/Login/index.tsx:31
+msgid "Connect your wallet"
+msgstr ""
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx:51
+msgid "Contact"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx:85
+msgid "Danger Zone"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:246
+msgid "Dark mode"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx:217
+msgid "Disable Super follow"
+msgstr ""
+
+#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx:115
+msgid "Disable dispatcher"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:287
+msgid "Disable staff mode"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:29
+msgid "Discord"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx:67
+msgid "Dispatcher"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:37
+msgid "Donate"
+msgstr ""
+
+#: src/components/Settings/Dispatcher/ToggleDispatcher.tsx:115
+msgid "Enable dispatcher"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:294
+msgid "Enable staff mode"
+msgstr ""
+
+#: src/components/Shared/Navbar/index.tsx:61
+msgid "Explore"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:53
+msgid "Feedback"
+msgstr ""
+
+#: src/components/Home/FeedEventFilters.tsx:22
+msgid "Filter"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx:183
+msgid "Follow amount"
+msgstr ""
+
+#: src/components/Explore/index.tsx:25
+msgid "For you"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx:201
+msgid "Funds recipient"
+msgstr ""
+
+#: src/components/Home/BetaWarning.tsx:26
+msgid "Get testnet tokens"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:62
+msgid "GitHub"
+msgstr ""
+
+#: src/components/Home/FeedType.tsx:31
+msgid "Highlights"
+msgstr ""
+
+#: src/components/Shared/Navbar/index.tsx:60
+msgid "Home"
+msgstr ""
+
+#: src/components/Explore/FeedType.tsx:41
+msgid "Images"
+msgstr ""
+
+#: src/components/Explore/index.tsx:28
+msgid "Interesting"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx:61
+msgid "Interests"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:253
+msgid "Light mode"
+msgstr ""
+
+#: src/components/Settings/Account/Language.tsx:17
+msgid "Locale settings"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:103
+msgid "Logged in as"
+msgstr ""
+
+#: src/components/Shared/GlobalModals.tsx:42
+#: src/components/Shared/Navbar/LoginButton.tsx:19
+msgid "Login"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:186
+msgid "Logout"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:173
+msgid "Moderation"
+msgstr ""
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx:25
+msgid "More"
+msgstr ""
+
+#: src/components/Home/SeeThroughLens.tsx:100
+msgid "My Feed"
+msgstr ""
+
+#: src/components/Settings/Account/Verification.tsx:25
+msgid "No."
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx:151
+msgid "Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc."
+msgstr ""
+
+#: src/components/Shared/Login/index.tsx:20
+msgid "Please sign the message"
+msgstr ""
+
+#: src/components/Explore/index.tsx:26
+msgid "Popular"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:22
+msgid "Privacy"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx:49
+msgid "Profile"
+msgstr ""
+
+#: src/components/Shared/Navbar/MoreNavItems.tsx:66
+msgid "Report a bug"
+msgstr ""
+
+#: src/components/Settings/Account/Verification.tsx:34
+msgid "Request Verification"
+msgstr ""
+
+#: src/components/Home/SeeThroughLens.tsx:124
+msgid "Search"
+msgstr ""
+
+#: src/components/Shared/Navbar/Search.tsx:28
+msgid "Search…"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx:165
+msgid "Select Currency"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx:138
+msgid "Select default profile"
+msgstr ""
+
+#: src/components/Settings/Account/Language.tsx:21
+msgid "Select display language"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx:161
+msgid "Select profile"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx:67
+msgid "Select profile interests"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx:141
+msgid "Selecting your default account helps to display the selected profile across {APP_NAME}, you can change your default profile anytime."
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx:225
+msgid "Set Super follow"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx:57
+msgid "Set profile bio"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx:56
+msgid "Set profile name"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:127
+msgid "Set status"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx:155
+msgid "Set super follow"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx:58
+msgid "Set your avatar"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx:158
+msgid "Setting super follow makes users spend crypto to follow you, and it’s a good way to earn it, you can change the amount and currency or disable/enable it anytime."
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:158
+msgid "Settings"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx:52
+msgid "Setup your {APP_NAME} profile"
+msgstr ""
+
+#: src/components/Home/RecommendedProfiles.tsx:89
+msgid "Show more"
+msgstr ""
+
+#: src/components/Shared/Login/WalletSelector.tsx:123
+msgid "Sign-In with Lens"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:45
+msgid "Status"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:197
+msgid "Switch to"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:21
+msgid "Terms"
+msgstr ""
+
+#: src/components/Explore/FeedType.tsx:38
+msgid "Text"
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:55
+msgid "Thanks"
+msgstr ""
+
+#: src/components/Home/FeedType.tsx:21
+msgid "Timeline"
+msgstr ""
+
+#: src/components/Explore/index.tsx:27
+#: src/components/Home/Trending.tsx:19
+msgid "Trending"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx:225
+msgid "Update Super follow"
+msgstr ""
+
+#: src/components/Home/SetProfile.tsx:76
+msgid "Update profile now"
+msgstr ""
+
+#: src/components/Settings/Account/Verification.tsx:16
+msgid "Verified"
+msgstr ""
+
+#: src/components/Explore/FeedType.tsx:39
+msgid "Video"
+msgstr ""
+
+#: src/components/Home/Hero.tsx:11
+msgid "Welcome to {APP_NAME} 👋"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx:147
+msgid "What else you should know"
+msgstr ""
+
+#: src/components/Composer/Post/New.tsx:86
+msgid "What's happening?"
+msgstr ""
+
+#: src/components/Home/RecommendedProfiles.tsx:24
+msgid "Who to follow"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx:156
+msgid "You can change default profile anytime here."
+msgstr ""
+
+#: src/components/Home/EnableDispatcher.tsx:28
+msgid "You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions."
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx:133
+msgid "You don’t have any default profile set!"
+msgstr ""
+
+#: src/components/Shared/Navbar/SignedUser.tsx:144
+msgid "Your Profile"
+msgstr ""
+
+#: src/components/Settings/Account/SetProfile.tsx:125
+msgid "Your default profile"
+msgstr ""
+
+#: src/components/Notification/Type/CollectNotification/index.tsx:40
+msgid "{0} <0>collected your </0><1>{1}</1>"
+msgstr ""
+
+#: src/components/Notification/Type/FollowerNotification.tsx:42
+msgid "{0} <0>{1} followed you</0>"
+msgstr ""
+
+#: src/components/Home/Hero.tsx:14
+msgid "{APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿"
+msgstr ""
+
+#: src/components/Home/BetaWarning.tsx:20
+msgid "{APP_NAME} is still in the beta phase, things may break, please handle us with care."
+msgstr ""
+
+#: src/components/Shared/Login/index.tsx:23
+msgid "{APP_NAME} uses this signature to verify that you’re the owner of this address."
+msgstr ""
+
+#: src/components/Shared/Footer.tsx:71
+msgid "▲ Powered by Vercel"
+msgstr ""
+
+#: src/components/Home/SeeThroughLens.tsx:118
+msgid "👀 See the feed through..."
+msgstr ""

--- a/apps/web/src/locales/qaa/messages.po
+++ b/apps/web/src/locales/qaa/messages.po
@@ -13,8 +13,22 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/Composer/Editor/index.tsx
 #: src/components/Composer/Post/New.tsx
+#: src/components/Shared/Status.tsx
 msgid "What's happening?"
+msgstr ""
+
+#: src/components/Composer/NewPublication.tsx
+msgid "[cta]Comment"
+msgstr ""
+
+#: src/components/Composer/NewPublication.tsx
+msgid "[cta]Post"
+msgstr ""
+
+#: src/components/Composer/Post/New.tsx
+msgid "Create post"
 msgstr ""
 
 #: src/components/Explore/Feed.tsx
@@ -145,6 +159,10 @@ msgstr ""
 msgid "Update profile now"
 msgstr ""
 
+#: src/components/Home/Trending.tsx
+msgid "<0>{0} Publications</0>"
+msgstr ""
+
 #: src/components/Notification/Type/CollectNotification/index.tsx
 msgid "<0><1/> collected your <2>comment</2></0>"
 msgstr ""
@@ -202,6 +220,42 @@ msgstr ""
 
 #: src/components/Notification/Type/MentionNotification.tsx
 msgid "<0><1/> mentioned you in a <2>post</2></0>"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Contact • {APP_NAME}"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Contact {APP_NAME}"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Contact us to help you get the issue resolved."
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Publication reported successfully!"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Subject"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "What happened?"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Message"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "How can we help?"
+msgstr ""
+
+#: src/components/Pages/Contact.tsx
+msgid "Submit"
 msgstr ""
 
 #: src/components/Publication/Type/Mirrored.tsx
@@ -371,6 +425,18 @@ msgstr ""
 #: src/components/Shared/GlobalModals.tsx
 #: src/components/Shared/Navbar/LoginButton.tsx
 msgid "Login"
+msgstr ""
+
+#: src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
+msgid "Bold"
+msgstr ""
+
+#: src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
+msgid "Italic"
+msgstr ""
+
+#: src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
+msgid "Code"
 msgstr ""
 
 #: src/components/Shared/Login/WalletSelector.tsx

--- a/apps/web/src/locales/qaa/messages.po
+++ b/apps/web/src/locales/qaa/messages.po
@@ -1,11 +1,11 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2022-12-16 21:10+0100\n"
+"POT-Creation-Date: 2022-12-23 15:59+0100\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: cs\n"
+"Language: qaa\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: \n"
@@ -15,406 +15,406 @@ msgstr ""
 
 #: src/components/Composer/Post/New.tsx
 msgid "What's happening?"
-msgstr "Co se děje?"
+msgstr ""
 
 #: src/components/Explore/FeedType.tsx
 msgid "All posts"
-msgstr "Všechny příspěvky"
+msgstr ""
 
 #: src/components/Explore/FeedType.tsx
 msgid "Text"
-msgstr "Text"
+msgstr ""
 
 #: src/components/Explore/FeedType.tsx
 msgid "Video"
-msgstr "Video"
+msgstr ""
 
 #: src/components/Explore/FeedType.tsx
 msgid "Audio"
-msgstr "Zvuk"
+msgstr ""
 
 #: src/components/Explore/FeedType.tsx
 msgid "Images"
-msgstr "Snímky"
+msgstr ""
 
 #: src/components/Explore/index.tsx
 msgid "For you"
-msgstr "Pro tebe"
+msgstr ""
 
 #: src/components/Explore/index.tsx
 msgid "Popular"
-msgstr "Oblíbený"
+msgstr ""
 
 #: src/components/Explore/index.tsx
 #: src/components/Home/Trending.tsx
 msgid "Trending"
-msgstr "Trendy"
+msgstr ""
 
 #: src/components/Explore/index.tsx
 msgid "Interesting"
-msgstr "Zajímavý"
+msgstr ""
 
 #: src/components/Home/BetaWarning.tsx
 msgid "Beta warning!"
-msgstr "Upozornění beta!"
+msgstr ""
 
 #: src/components/Home/BetaWarning.tsx
 msgid "{APP_NAME} is still in the beta phase, things may break, please handle us with care."
-msgstr "Aplikace {APP_NAME} je stále ve fázi beta, může se něco pokazit, zacházejte s námi prosím opatrně."
+msgstr ""
 
 #: src/components/Home/BetaWarning.tsx
 msgid "Get testnet tokens"
-msgstr "Získejte tokeny testnet"
+msgstr ""
 
 #: src/components/Home/EnableDispatcher.tsx
 msgid "Action Required"
-msgstr "Je vyžadována akce"
+msgstr ""
 
 #: src/components/Home/EnableDispatcher.tsx
 msgid "You can enable dispatcher to interact with {APP_NAME} without signing any of your transactions."
-msgstr "Dispečerovi můžete povolit interakci s aplikací {APP_NAME}, aniž byste museli podepisovat jakoukoli z vašich transakcí."
+msgstr ""
 
 #: src/components/Home/FeedEventFilters.tsx
 msgid "Filter"
-msgstr "Filtr"
+msgstr ""
 
 #: src/components/Home/FeedType.tsx
 msgid "Timeline"
-msgstr "Časová osa"
+msgstr ""
 
 #: src/components/Home/FeedType.tsx
 msgid "Highlights"
-msgstr "Zvýraznění"
+msgstr ""
 
 #: src/components/Home/Hero.tsx
 msgid "Welcome to {APP_NAME} 👋"
-msgstr "Vítejte v {APP_NAME} 👋"
+msgstr ""
 
 #: src/components/Home/Hero.tsx
 msgid "{APP_NAME} is a decentralized, and permissionless social media app built with Lens Protocol 🌿"
-msgstr "{APP_NAME} je decentralizovaná aplikace sociálních médií bez povolení vytvořená pomocí protokolu Lens 🌿"
+msgstr ""
 
 #: src/components/Home/RecommendedProfiles.tsx
 msgid "Who to follow"
-msgstr "Koho následovat"
+msgstr ""
 
 #: src/components/Home/RecommendedProfiles.tsx
 msgid "Show more"
-msgstr "Zobrazit více"
+msgstr ""
 
 #: src/components/Home/SeeThroughLens.tsx
 msgid "My Feed"
-msgstr "Můj příspěvek"
+msgstr ""
 
 #: src/components/Home/SeeThroughLens.tsx
 msgid "👀 See the feed through..."
-msgstr "👀 Podívejte se na feed přes..."
+msgstr ""
 
 #: src/components/Home/SeeThroughLens.tsx
 msgid "Search"
-msgstr "Vyhledávání"
+msgstr ""
 
 #: src/components/Home/SetProfile.tsx
 msgid "Setup your {APP_NAME} profile"
-msgstr "Nastavte si svůj profil {APP_NAME}"
+msgstr ""
 
 #: src/components/Home/SetProfile.tsx
 msgid "Set profile name"
-msgstr "Nastavte název profilu"
+msgstr ""
 
 #: src/components/Home/SetProfile.tsx
 msgid "Set profile bio"
-msgstr "Nastavit bio profilu"
+msgstr ""
 
 #: src/components/Home/SetProfile.tsx
 msgid "Set your avatar"
-msgstr "Nastavte si avatara"
+msgstr ""
 
 #: src/components/Home/SetProfile.tsx
 msgid "Select profile interests"
-msgstr "Vyberte zájmy profilu"
+msgstr ""
 
 #: src/components/Home/SetProfile.tsx
 msgid "Update profile now"
-msgstr "Aktualizujte profil nyní"
+msgstr ""
 
 #: src/components/Notification/Type/CollectNotification/index.tsx
 msgid "{0} <0>collected your </0><1>{1}</1>"
-msgstr "{0} <0>shromáždil vaše </0><1>{1}</1>"
+msgstr ""
 
 #: src/components/Notification/Type/CommentNotification.tsx
 msgid "<0/> <1>commented on your </1><2>{0}</2>"
-msgstr "<0/> <1>přidal komentář k vašemu </1><2>{0}</2>"
+msgstr ""
 
 #: src/components/Notification/Type/FollowerNotification.tsx
 msgid "{0} <0>{1} followed you</0>"
-msgstr "{0} <0>{1} vás sleduje</0>"
+msgstr ""
 
 #: src/components/Notification/Type/LikeNotification.tsx
 msgid "<0/> <1>liked your </1><2>{0}</2>"
-msgstr "<0/> <1>olajkovalo vaše </1><2>{0}</2>"
+msgstr ""
 
 #: src/components/Notification/Type/MentionNotification.tsx
 msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
-msgstr "<0/> <1>se o vás zmínil v </1><2>{0}</2>"
+msgstr ""
 
 #: src/components/Notification/Type/MirrorNotification.tsx
 msgid "<0/> <1>mirrored your </1><2>{0}</2>"
-msgstr "<0/> <1>zrcadlil vaše </1><2>{0}</2>"
+msgstr ""
 
 #: src/components/Publication/Type/Mirrored.tsx
 msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
-msgstr "<0>{0}</0><1><2>zrcadlil </2><3>{1}</3></1>"
+msgstr ""
 
 #: src/components/Settings/Account/Language.tsx
 msgid "Locale settings"
-msgstr "Nastavení národního prostředí"
+msgstr ""
 
 #: src/components/Settings/Account/Language.tsx
 msgid "Select display language"
-msgstr "Vyberte jazyk zobrazení"
+msgstr ""
 
 #: src/components/Settings/Account/SetProfile.tsx
 msgid "Your default profile"
-msgstr "Váš výchozí profil"
+msgstr ""
 
 #: src/components/Settings/Account/SetProfile.tsx
 msgid "You don’t have any default profile set!"
-msgstr "Nemáte nastaven žádný výchozí profil!"
+msgstr ""
 
 #: src/components/Settings/Account/SetProfile.tsx
 msgid "Select default profile"
-msgstr "Vyberte výchozí profil"
+msgstr ""
 
 #: src/components/Settings/Account/SetProfile.tsx
 msgid "Selecting your default account helps to display the selected profile across {APP_NAME}, you can change your default profile anytime."
-msgstr "Výběr výchozího účtu pomůže zobrazit vybraný profil v aplikaci {APP_NAME}. Výchozí profil můžete kdykoli změnit."
+msgstr ""
 
 #: src/components/Settings/Account/SetProfile.tsx
 msgid "What else you should know"
-msgstr "Co byste ještě měli vědět"
+msgstr ""
 
 #: src/components/Settings/Account/SetProfile.tsx
 msgid "Only the default profile will be visible across the {APP_NAME}, example notifications, follow etc."
-msgstr "V aplikaci {APP_NAME}, příkladech oznámení, sledování atd. bude viditelný pouze výchozí profil."
+msgstr ""
 
 #: src/components/Settings/Account/SetProfile.tsx
 msgid "You can change default profile anytime here."
-msgstr "Zde můžete kdykoli změnit výchozí profil."
+msgstr ""
 
 #: src/components/Settings/Account/SetProfile.tsx
 msgid "Select profile"
-msgstr "Vyberte profil"
+msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
 msgid "Set super follow"
-msgstr "Nastavit super sledování"
+msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
 msgid "Setting super follow makes users spend crypto to follow you, and it’s a good way to earn it, you can change the amount and currency or disable/enable it anytime."
-msgstr "Nastavení supersledování způsobí, že uživatelé utrácejí kryptoměny, aby vás sledovali, a je to dobrý způsob, jak je vydělat, můžete změnit částku a měnu nebo je kdykoli zakázat/povolit."
+msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
 msgid "Select Currency"
-msgstr "Vyberte možnost Měna"
+msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
 msgid "Follow amount"
-msgstr "Sledujte množství"
+msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
 msgid "Funds recipient"
-msgstr "Příjemce prostředků"
+msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
 msgid "Disable Super follow"
-msgstr "Zakázat Super sledování"
+msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
 msgid "Update Super follow"
-msgstr "Aktualizovat Super sledování"
+msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
 msgid "Set Super follow"
-msgstr "Nastavte Super sledování"
+msgstr ""
 
 #: src/components/Settings/Account/Verification.tsx
 msgid "Verified"
-msgstr "Ověřeno"
+msgstr ""
 
 #: src/components/Settings/Account/Verification.tsx
 msgid "No."
-msgstr "Ne."
+msgstr ""
 
 #: src/components/Settings/Account/Verification.tsx
 msgid "Request Verification"
-msgstr "Požádat o ověření"
+msgstr ""
 
 #: src/components/Settings/Dispatcher/ToggleDispatcher.tsx
 msgid "Disable dispatcher"
-msgstr "Zakázat dispečera"
+msgstr ""
 
 #: src/components/Settings/Dispatcher/ToggleDispatcher.tsx
 msgid "Enable dispatcher"
-msgstr "Povolit dispečera"
+msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Profile"
-msgstr "Profil"
+msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Account"
-msgstr "Účet"
+msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Interests"
-msgstr "Zájmy"
+msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Dispatcher"
-msgstr "Odesílatel"
+msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Allowance"
-msgstr "Příspěvek"
+msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Cleanup"
-msgstr "Čištění"
+msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Danger Zone"
-msgstr "Nebezpečná zóna"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "Terms"
-msgstr "Podmínky"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "Privacy"
-msgstr "Soukromí"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "Discord"
-msgstr "Discord"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "Donate"
-msgstr "Darovat"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "Status"
-msgstr "Postavení"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "Feedback"
-msgstr "Zpětná vazba"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "Thanks"
-msgstr "Dík"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "GitHub"
-msgstr "GitHub"
+msgstr ""
 
 #: src/components/Shared/Footer.tsx
 msgid "▲ Powered by Vercel"
-msgstr "▲ Používá technologii Vercel"
+msgstr ""
 
 #: src/components/Shared/GlobalModals.tsx
 #: src/components/Shared/Navbar/LoginButton.tsx
 msgid "Login"
-msgstr "Přihlásit se"
+msgstr ""
 
 #: src/components/Shared/Login/WalletSelector.tsx
 msgid "Sign-In with Lens"
-msgstr "Přihlaste se pomocí Lens"
+msgstr ""
 
 #: src/components/Shared/Login/WalletSelector.tsx
 msgid "Browser Wallet"
-msgstr "Peněženka prohlížeče"
+msgstr ""
 
 #: src/components/Shared/Login/index.tsx
 msgid "Please sign the message"
-msgstr "Podepište prosím zprávu"
+msgstr ""
 
 #: src/components/Shared/Login/index.tsx
 msgid "{APP_NAME} uses this signature to verify that you’re the owner of this address."
-msgstr "Aplikace {APP_NAME} používá tento podpis k ověření, že jste vlastníkem této adresy."
+msgstr ""
 
 #: src/components/Shared/Login/index.tsx
 msgid "Connect your wallet"
-msgstr "Připojte svou peněženku"
+msgstr ""
 
 #: src/components/Shared/Login/index.tsx
 msgid "Connect with one of our available wallet providers or create a new one."
-msgstr "Spojte se s jedním z našich dostupných poskytovatelů peněženek nebo vytvořte nového."
+msgstr ""
 
 #: src/components/Shared/Navbar/MoreNavItems.tsx
 msgid "More"
-msgstr "Více"
+msgstr ""
 
 #: src/components/Shared/Navbar/MoreNavItems.tsx
 msgid "Contact"
-msgstr "Kontakt"
+msgstr ""
 
 #: src/components/Shared/Navbar/MoreNavItems.tsx
 msgid "Report a bug"
-msgstr "Nahlásit chybu"
+msgstr ""
 
 #: src/components/Shared/Navbar/Search.tsx
 msgid "Search…"
-msgstr "Vyhledávání…"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Logged in as"
-msgstr "Přihlášen jako"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Set status"
-msgstr "Nastavit stav"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Your Profile"
-msgstr "Tvůj profil"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Settings"
-msgstr "Nastavení"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Moderation"
-msgstr "Umírněnost"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Logout"
-msgstr "Odhlásit se"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Switch to"
-msgstr "Přepnout na"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Dark mode"
-msgstr "Tmavý režim"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Light mode"
-msgstr "Světelný režim"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Disable staff mode"
-msgstr "Zakázat režim pro zaměstnance"
+msgstr ""
 
 #: src/components/Shared/Navbar/SignedUser.tsx
 msgid "Enable staff mode"
-msgstr "Povolit režim zaměstnanců"
+msgstr ""
 
 #: src/components/Shared/Navbar/index.tsx
 msgid "Home"
-msgstr "Domov"
+msgstr ""
 
 #: src/components/Shared/Navbar/index.tsx
 msgid "Explore"
-msgstr "Prozkoumat"
+msgstr ""

--- a/apps/web/src/locales/qaa/messages.po
+++ b/apps/web/src/locales/qaa/messages.po
@@ -139,27 +139,62 @@ msgid "Update profile now"
 msgstr ""
 
 #: src/components/Notification/Type/CollectNotification/index.tsx
-msgid "{0} <0>collected your </0><1>{1}</1>"
+msgid "<0><1/> collected your <2>comment</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/CollectNotification/index.tsx
+msgid "<0><1/> collected your <2>mirror</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/CollectNotification/index.tsx
+msgid "<0><1/> collected your <2>post</2></0>"
 msgstr ""
 
 #: src/components/Notification/Type/CommentNotification.tsx
-msgid "<0/> <1>commented on your </1><2>{0}</2>"
+#: src/components/Notification/Type/MirrorNotification.tsx
+msgid "<0><1/> commented on your <2>comment</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/CommentNotification.tsx
+#: src/components/Notification/Type/MirrorNotification.tsx
+msgid "<0><1/> commented on your <2>mirror</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/CommentNotification.tsx
+#: src/components/Notification/Type/MirrorNotification.tsx
+msgid "<0><1/> commented on your <2>post</2></0>"
 msgstr ""
 
 #: src/components/Notification/Type/FollowerNotification.tsx
-msgid "{0} <0>{1} followed you</0>"
+msgid "<0><1/> followed you</0>"
+msgstr ""
+
+#: src/components/Notification/Type/FollowerNotification.tsx
+msgid "<0><1/> super followed you</0>"
 msgstr ""
 
 #: src/components/Notification/Type/LikeNotification.tsx
-msgid "<0/> <1>liked your </1><2>{0}</2>"
+msgid "<0><1/> liked your <2>comment</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/LikeNotification.tsx
+msgid "<0><1/> liked your <2>mirror</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/LikeNotification.tsx
+msgid "<0><1/> liked your <2>post</2></0>"
 msgstr ""
 
 #: src/components/Notification/Type/MentionNotification.tsx
-msgid "<0/> <1>mentioned you in a </1><2>{0}</2>"
+msgid "<0><1/> mentioned you in a <2>comment</2></0>"
 msgstr ""
 
-#: src/components/Notification/Type/MirrorNotification.tsx
-msgid "<0/> <1>mirrored your </1><2>{0}</2>"
+#: src/components/Notification/Type/MentionNotification.tsx
+msgid "<0><1/> mentioned you in a <2>mirror</2></0>"
+msgstr ""
+
+#: src/components/Notification/Type/MentionNotification.tsx
+msgid "<0><1/> mentioned you in a <2>post</2></0>"
 msgstr ""
 
 #: src/components/Publication/Type/Mirrored.tsx

--- a/apps/web/src/locales/qaa/messages.po
+++ b/apps/web/src/locales/qaa/messages.po
@@ -17,6 +17,13 @@ msgstr ""
 msgid "What's happening?"
 msgstr ""
 
+#: src/components/Explore/Feed.tsx
+#: src/components/Home/Highlights.tsx
+#: src/components/Home/Timeline/index.tsx
+#: src/components/Mod/Feed.tsx
+msgid "No posts yet!"
+msgstr ""
+
 #: src/components/Explore/FeedType.tsx
 msgid "All posts"
 msgstr ""
@@ -198,7 +205,11 @@ msgid "<0><1/> mentioned you in a <2>post</2></0>"
 msgstr ""
 
 #: src/components/Publication/Type/Mirrored.tsx
-msgid "<0>{0}</0><1><2>mirrored the </2><3>{1}</3></1>"
+msgid "<0><1/> mirrored the <2>comment</2></0>"
+msgstr ""
+
+#: src/components/Publication/Type/Mirrored.tsx
+msgid "<0><1/> mirrored the <2>post</2></0>"
 msgstr ""
 
 #: src/components/Settings/Account/Language.tsx

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,27 +1,18 @@
 import '../styles.css';
 
 import Loading from '@components/Shared/Loading';
-import { initLocale } from '@lib/i18n';
-import { i18n } from '@lingui/core';
-import { I18nProvider } from '@lingui/react';
 import type { AppProps } from 'next/app';
-import React, { lazy, Suspense, useEffect } from 'react';
+import { lazy, Suspense } from 'react';
 
 const Providers = lazy(() => import('@components/Common/Providers'));
 
 const App = ({ Component, pageProps }: AppProps) => {
-  useEffect(() => {
-    initLocale();
-  }, []);
-
   return (
-    <I18nProvider i18n={i18n}>
-      <Suspense fallback={<Loading />}>
-        <Providers>
-          <Component {...pageProps} />
-        </Providers>
-      </Suspense>
-    </I18nProvider>
+    <Suspense fallback={<Loading />}>
+      <Providers>
+        <Component {...pageProps} />
+      </Providers>
+    </Suspense>
   );
 };
 

--- a/apps/web/src/pages/_app.tsx
+++ b/apps/web/src/pages/_app.tsx
@@ -1,18 +1,27 @@
 import '../styles.css';
 
 import Loading from '@components/Shared/Loading';
+import { initLocale } from '@lib/i18n';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
 import type { AppProps } from 'next/app';
-import { lazy, Suspense } from 'react';
+import React, { lazy, Suspense, useEffect } from 'react';
 
 const Providers = lazy(() => import('@components/Common/Providers'));
 
 const App = ({ Component, pageProps }: AppProps) => {
+  useEffect(() => {
+    initLocale();
+  }, []);
+
   return (
-    <Suspense fallback={<Loading />}>
-      <Providers>
-        <Component {...pageProps} />
-      </Providers>
-    </Suspense>
+    <I18nProvider i18n={i18n}>
+      <Suspense fallback={<Loading />}>
+        <Providers>
+          <Component {...pageProps} />
+        </Providers>
+      </Suspense>
+    </I18nProvider>
   );
 };
 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,5 @@
-project_id: '556737'
-api_token: 'f412c35a318449726ab736218ecf26de4293a8b63f4987303960b7f463e8a3a1a64c8932142764ff'
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
 
 preserve_hierarchy: true
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "codegen": "turbo run codegen",
     "prettier": "prettier --check \"**/*.{ts,tsx,md}\"",
     "prettier:fix": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "crowdin": "crowdin",
+    "sync": "crowdin push && crowdin pull",
+    "sync:sources": "crowdin push",
+    "sync:translations": "crowdin pull"
   },
   "devDependencies": {
     "husky": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,7 @@
     "prettier": "prettier --check \"**/*.{ts,tsx,md}\"",
     "prettier:fix": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky install",
-    "crowdin": "crowdin",
-    "sync": "crowdin push && crowdin pull",
-    "sync:sources": "crowdin push",
-    "sync:translations": "crowdin pull"
+    "crowdin": "crowdin"
   },
   "devDependencies": {
     "husky": "^8.0.2",

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -115,7 +115,8 @@ export const LS_KEYS = {
   LENSTER_STORE: 'lenster.store',
   TRANSACTION_STORE: 'transaction.store',
   TIMELINE_STORE: 'timeline.store',
-  MESSAGE_STORE: 'message.store'
+  MESSAGE_STORE: 'message.store',
+  SELECTED_LOCALE: 'selected.locale'
 };
 
 // S3 bucket

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -3,6 +3,7 @@ import getEnvConfig from './utils/getEnvConfig';
 
 // Environments
 export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+export const IS_PREVIEW = process.env.NEXT_PUBLIC_VERCEL_ENV === 'preview';
 
 // Lens Network
 export const LENS_NETWORK = process.env.NEXT_PUBLIC_LENS_NETWORK ?? 'mainnet';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,7 +1046,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
   integrity sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==
 
-"@babel/core@^7.11.1", "@babel/core@^7.14.0":
+"@babel/core@^7.11.1", "@babel/core@^7.14.0", "@babel/core@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.7.tgz#37072f951bd4d28315445f66e0ec9f6ae0c8c35f"
   integrity sha512-t1ZjCluspe5DW24bn2Rr1CDb2v9rn/hROtg9a2tmd0+QYf4bsloYfLQzjG4qHPNMhWtKdGC33R5AxGR2Af2cBw==
@@ -1067,12 +1067,21 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/generator@^7.14.0", "@babel/generator@^7.18.13", "@babel/generator@^7.20.7":
+"@babel/generator@^7.11.6", "@babel/generator@^7.20.5", "@babel/generator@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.7.tgz#f8ef57c8242665c5929fe2e8d82ba75460187b4a"
   integrity sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==
   dependencies:
     "@babel/types" "^7.20.7"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.14.0", "@babel/generator@^7.18.13":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.5.tgz#cb25abee3178adf58d6814b68517c62bdbfdda95"
+  integrity sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==
+  dependencies:
+    "@babel/types" "^7.20.5"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -1102,7 +1111,20 @@
     lru-cache "^5.1.1"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.20.5", "@babel/helper-create-class-features-plugin@^7.20.7":
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.5.tgz#327154eedfb12e977baa4ecc72e5806720a85a06"
+  integrity sha512-3RCdA/EmEaikrhayahwToF0fpweU/8o2p8vhc1c/1kftHOdTKuC65kik/TLc+qfbS8JKw4qqJbne4ovICDhmww==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/helper-replace-supers" "^7.19.1"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+
+"@babel/helper-create-class-features-plugin@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.7.tgz#d0e1f8d7e4ed5dac0389364d9c0c191d948ade6f"
   integrity sha512-LtoWbDXOaidEf50hmdDqn9g8VEzsorMexoWMQdQODbvmqYmaF23pBP5VNPAGIFHsFQCIeKokDiz3CH5Y2jlY6w==
@@ -1162,7 +1184,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-member-expression-to-functions@^7.20.7":
+"@babel/helper-member-expression-to-functions@^7.18.9", "@babel/helper-member-expression-to-functions@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz#a6f26e919582275a93c3aa6594756d71b0bb7f05"
   integrity sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==
@@ -1176,7 +1198,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.20.11", "@babel/helper-module-transforms@^7.20.7":
+"@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.20.11":
   version "7.20.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz#df4c7af713c557938c50ea3ad0117a7944b2f1b0"
   integrity sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==
@@ -1188,6 +1210,20 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     "@babel/template" "^7.20.7"
     "@babel/traverse" "^7.20.10"
+    "@babel/types" "^7.20.7"
+
+"@babel/helper-module-transforms@^7.20.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.7.tgz#7a6c9a1155bef55e914af574153069c9d9470c43"
+  integrity sha512-FNdu7r67fqMUSVuQpFQGE6BPdhJIhitoxhGzDbAXNcA07uoVG37fOiMk3OSV8rEICuyG6t8LGkd9EE64qIEoIA==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.20.2"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/template" "^7.20.7"
+    "@babel/traverse" "^7.20.7"
     "@babel/types" "^7.20.7"
 
 "@babel/helper-optimise-call-expression@^7.18.6":
@@ -1212,7 +1248,7 @@
     "@babel/helper-wrap-function" "^7.18.9"
     "@babel/types" "^7.18.9"
 
-"@babel/helper-replace-supers@^7.18.6", "@babel/helper-replace-supers@^7.20.7":
+"@babel/helper-replace-supers@^7.18.6", "@babel/helper-replace-supers@^7.19.1", "@babel/helper-replace-supers@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz#243ecd2724d2071532b2c8ad2f0f9f083bcae331"
   integrity sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==
@@ -1288,10 +1324,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.14.0", "@babel/parser@^7.16.8", "@babel/parser@^7.20.7":
+"@babel/parser@^7.11.5", "@babel/parser@^7.20.5", "@babel/parser@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.7.tgz#66fe23b3c8569220817d5feb8b9dcdc95bb4f71b"
   integrity sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==
+
+"@babel/parser@^7.14.0", "@babel/parser@^7.16.8":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.5.tgz#7f3c7335fe417665d929f34ae5dceae4c04015e8"
+  integrity sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1494,7 +1535,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.17.12", "@babel/plugin-syntax-jsx@^7.18.6":
+"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.10.4", "@babel/plugin-syntax-jsx@^7.17.12", "@babel/plugin-syntax-jsx@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.18.6.tgz#a8feef63b010150abd97f1649ec296e849943ca0"
   integrity sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==
@@ -1962,7 +2003,23 @@
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
 
-"@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.20.10", "@babel/traverse@^7.20.5", "@babel/traverse@^7.20.7":
+"@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.20.5":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.5.tgz#78eb244bea8270fdda1ef9af22a5d5e5b7e57133"
+  integrity sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.20.5"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.19.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.20.5"
+    "@babel/types" "^7.20.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.20.10", "@babel/traverse@^7.20.7":
   version "7.20.10"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.10.tgz#2bf98239597fcec12f842756f186a9dde6d09230"
   integrity sha512-oSf1juCgymrSez8NI4A2sr4+uB/mFd9MXplYGPEBnfAuWmmyeVcHa6xLPiaRBcXkcb/28bgxmQLTVwFKE1yfsg==
@@ -1978,7 +2035,16 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.4.4":
+"@babel/types@^7.0.0", "@babel/types@^7.16.8", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.4.4":
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.5.tgz#e206ae370b5393d94dfd1d04cd687cace53efa84"
+  integrity sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.11.5", "@babel/types@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz#54ec75e252318423fc07fb644dc6a58a64c09b7f"
   integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
@@ -2040,6 +2106,14 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
+"@crowdin/cli@3":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@crowdin/cli/-/cli-3.9.1.tgz#f09f3616798ec7474c2c7d162a40bf875e0c9e74"
+  integrity sha512-Ca+mzVvLE9lYmTA4peTHOQdH42+eThwQ0DK6URT7crInQKJRjVJdsA2kkfEwi2mQPruAIG/KIKaPieRWPanlIQ==
+  dependencies:
+    njre "^0.2.0"
+    shelljs "^0.8.4"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -3512,6 +3586,17 @@
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
@@ -3769,6 +3854,91 @@
   integrity sha512-pNyw175VfWhJQj4pnvXgddfjyZhF/lotn7/4MTKbtGxyAI61LrjV7Z3M7v76003v4SEIyQ3WqWOU4TCjNt+alQ==
   dependencies:
     "@lexical/offset" "0.7.5"
+
+"@lingui/babel-plugin-extract-messages@^3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-3.15.0.tgz#370c5fa3a677252c13fc6709ee56defbffb692fc"
+  integrity sha512-iMQmJIkC18Zwc/IDpm3Oclj3KMDQuvipCS2yVHr0MyaeOCeOZ3ZoLVeaa8pfE5pImzlHJ0ss8RRm/St54JElhw==
+  dependencies:
+    "@babel/generator" "^7.11.6"
+    "@babel/runtime" "^7.11.2"
+    "@lingui/conf" "^3.15.0"
+    mkdirp "^1.0.4"
+
+"@lingui/cli@^3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@lingui/cli/-/cli-3.15.0.tgz#61db86dc89858e03fdd3952a4a62d4a6bf9f0aa0"
+  integrity sha512-6arKc0Mc1z3ABHobjPkhViV+7VUjBhwFwoU0VlT7HBmtrOYad9CBwWEiD+oiEhiHYzLTR7lHTVf674IjTuVvJQ==
+  dependencies:
+    "@babel/generator" "^7.11.6"
+    "@babel/parser" "^7.11.5"
+    "@babel/plugin-syntax-jsx" "^7.10.4"
+    "@babel/runtime" "^7.11.2"
+    "@babel/types" "^7.11.5"
+    "@lingui/babel-plugin-extract-messages" "^3.15.0"
+    "@lingui/conf" "^3.15.0"
+    babel-plugin-macros "^3.0.1"
+    bcp-47 "^1.0.7"
+    chalk "^4.1.0"
+    chokidar "3.5.1"
+    cli-table "0.3.6"
+    commander "^6.1.0"
+    date-fns "^2.16.1"
+    fs-extra "^9.0.1"
+    fuzzaldrin "^2.1.0"
+    glob "^7.1.4"
+    inquirer "^7.3.3"
+    make-plural "^6.2.2"
+    messageformat-parser "^4.1.3"
+    micromatch "4.0.2"
+    mkdirp "^1.0.4"
+    node-gettext "^3.0.0"
+    normalize-path "^3.0.0"
+    ora "^5.1.0"
+    papaparse "^5.3.0"
+    pkg-up "^3.1.0"
+    plurals-cldr "^1.0.4"
+    pofile "^1.1.0"
+    pseudolocale "^1.1.0"
+    ramda "^0.27.1"
+
+"@lingui/conf@^3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@lingui/conf/-/conf-3.15.0.tgz#0866bdf92bc72525dd657270c454a2fbe9277b87"
+  integrity sha512-gDGBbqWo6+B3PNjxTGl2asVdd8hC6w+iGsEPonvMw7GFmXb99qybBGdV2ofDlwlT9vChcPwMVtrYE6H0fTZuzA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    chalk "^4.1.0"
+    cosmiconfig "^7.0.0"
+    cosmiconfig-typescript-loader "^2.0.1"
+    jest-validate "^26.5.2"
+    lodash.get "^4.4.2"
+
+"@lingui/core@^3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@lingui/core/-/core-3.15.0.tgz#1f65bd6c1430133f1233dc9942c05c8bd9348e9d"
+  integrity sha512-owjYOn/3xaWVW01p32Ylt3cXkCP79oudJCHdcNOn4noxd/9BhyFX2wLiVf02DxGYnkAgAD3KCp3Z4iyKlueymg==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    make-plural "^6.2.2"
+    messageformat-parser "^4.1.3"
+
+"@lingui/macro@^3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@lingui/macro/-/macro-3.15.0.tgz#52b8219d470e72d37bdf052d748ffd6163d23fb8"
+  integrity sha512-3+txZQM5UmC+t1zkoYeYkg3r5pIGo9KdD+csX0u4F0IUE2GJkjy+sG917hOhw3QsDUqiCIqDJ503AdSfFbO+uA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@lingui/conf" "^3.15.0"
+    ramda "^0.27.1"
+
+"@lingui/react@^3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@lingui/react/-/react-3.15.0.tgz#6de83da27b4145e30f4dffc6a2947eecf3a954e4"
+  integrity sha512-Xq/48yf2IQhOPpgpqydj1OUyfDgNOY4aattmG4195LeqGPhN0ckiUCBLlNm0vHRsO3ZGwzfprTLYfI9WbfLBzA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    "@lingui/core" "^3.15.0"
 
 "@metamask/detect-provider@^1.2.0":
   version "1.2.0"
@@ -4437,6 +4607,25 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
+  integrity sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz#9153fe98bba2bd565a63add9436d6f0d7f8468ff"
+  integrity sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==
+  dependencies:
+    "@types/istanbul-lib-report" "*"
+
 "@types/js-cookie@^2.2.6":
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
@@ -4603,6 +4792,18 @@
   integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
   dependencies:
     "@types/node" "*"
+
+"@types/yargs-parser@*":
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
+  integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
+
+"@types/yargs@^15.0.0":
+  version "15.0.14"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.14.tgz#26d821ddb89e70492160b66d10a0eb6df8f6fb06"
+  integrity sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@types/yauzl@^2.9.1":
   version "2.10.0"
@@ -5322,7 +5523,7 @@ ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
   integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
 
-ansi-regex@^5.0.1:
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -5341,7 +5542,7 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-anymatch@~3.1.2:
+anymatch@~3.1.1, anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -5706,7 +5907,7 @@ babel-plugin-macros@^2.0.0:
     cosmiconfig "^6.0.0"
     resolve "^1.12.0"
 
-babel-plugin-macros@^3.1.0:
+babel-plugin-macros@^3.0.1, babel-plugin-macros@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
   integrity sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==
@@ -5803,6 +6004,15 @@ base64url@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
   integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
+
+bcp-47@^1.0.7:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/bcp-47/-/bcp-47-1.0.8.tgz#bf63ae4269faabe7c100deac0811121a48b6a561"
+  integrity sha512-Y9y1QNBBtYtv7hcmoX0tR+tUNSFZGZ6OL6vKPObq8BbOhkCoyayF6ogfLTgAli/KuAEbsYHYUNq2AQuY6IuLag==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -5950,7 +6160,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.1, braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -6129,6 +6339,11 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+camelcase@^6.0.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
+
 caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001406, caniuse-lite@^1.0.30001426:
   version "1.0.30001441"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz#987437b266260b640a23cd18fbddb509d7f69f3e"
@@ -6230,6 +6445,21 @@ check-more-types@^2.24.0:
   resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
   integrity sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==
 
+chokidar@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
+
 chokidar@^3.5.2, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
@@ -6244,6 +6474,11 @@ chokidar@^3.5.2, chokidar@^3.5.3:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+chownr@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 ci-info@^3.2.0, ci-info@^3.6.1:
   version "3.7.0"
@@ -6297,6 +6532,13 @@ cli-table3@~0.6.1:
     string-width "^4.2.0"
   optionalDependencies:
     "@colors/colors" "1.5.0"
+
+cli-table@0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.6.tgz#e9d6aa859c7fe636981fd3787378c2a20bce92fc"
+  integrity sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==
+  dependencies:
+    colors "1.0.3"
 
 cli-truncate@^2.1.0:
   version "2.1.0"
@@ -6387,12 +6629,27 @@ colorette@^2.0.16:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+colors@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
+  integrity sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==
+
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+command-exists-promise@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/command-exists-promise/-/command-exists-promise-2.0.2.tgz#7beecc4b218299f3c61fa69a4047aa0b36a64a99"
+  integrity sha512-T6PB6vdFrwnHXg/I0kivM3DqaCGZLjjYSOe0a5WgFKcz1sOnmOeIjnhQPXVXX3QjVbLyTJ85lJkX6lUpukTzaA==
+
+commander@*:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
+  integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
 
 commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
@@ -6403,6 +6660,11 @@ commander@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+
+commander@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commander@^8.2.0:
   version "8.3.0"
@@ -6479,6 +6741,14 @@ cosmiconfig-typescript-loader@4.3.0, cosmiconfig-typescript-loader@^4.0.0:
   resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz#c4259ce474c9df0f32274ed162c0447c951ef073"
   integrity sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==
 
+cosmiconfig-typescript-loader@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-2.0.2.tgz#7e7ce6064af041c910e1e43fb0fd9625cee56e93"
+  integrity sha512-KmE+bMjWMXJbkWCeY4FJX/npHuZPNr9XF9q9CIQ/bpFwi1qHfCmSiKarrCcRa0LO4fWjk93pVoeRtJAkTGcYNw==
+  dependencies:
+    cosmiconfig "^7"
+    ts-node "^10.8.1"
+
 cosmiconfig@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
@@ -6501,7 +6771,7 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-cosmiconfig@^7.0.0:
+cosmiconfig@^7, cosmiconfig@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.1.0.tgz#1443b9afa596b670082ea46cbd8f6a62b84635f6"
   integrity sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==
@@ -6703,6 +6973,11 @@ dataloader@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
   integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
+
+date-fns@^2.16.1:
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 dayjs-twitter@^0.5.0:
   version "0.5.0"
@@ -8029,12 +8304,19 @@ fs-extra@^9.0.1, fs-extra@^9.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-minipass@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
+  integrity sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==
+  dependencies:
+    minipass "^2.6.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -8058,6 +8340,11 @@ functions-have-names@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+fuzzaldrin@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz#90204c3e2fdaa6941bb28d16645d418063a90e9b"
+  integrity sha512-zgllBYwfHR5P3CncJiGbGVPpa3iFYW1yuPaIv8DiTVRrcg5/6uETNL5zvIoKflG1aifXVUZTlIroDehw4WygGA==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -8117,7 +8404,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -8143,7 +8430,7 @@ glob@7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -8518,6 +8805,25 @@ inline-style-prefixer@^6.0.0:
     css-in-js-utils "^3.1.0"
     fast-loops "^1.1.3"
 
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 inquirer@^8.0.0, inquirer@^8.2.0:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
@@ -8548,6 +8854,11 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
+interpret@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
+  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
 intersection-observer@^0.12.2:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.12.2.tgz#4a45349cc0cd91916682b1f44c28d7ec737dc375"
@@ -8574,6 +8885,19 @@ is-absolute@^1.0.0:
   dependencies:
     is-relative "^1.0.0"
     is-windows "^1.0.1"
+
+is-alphabetical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.4.tgz#9e7d6b94916be22153745d184c298cbf986a686d"
+  integrity sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==
+
+is-alphanumerical@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz#7eb9a2431f855f6b1ef1a78e326df515696c4dbf"
+  integrity sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
 
 is-arguments@^1.0.4:
   version "1.1.1"
@@ -8642,6 +8966,11 @@ is-date-object@^1.0.1:
   integrity sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==
   dependencies:
     has-tostringtag "^1.0.0"
+
+is-decimal@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
@@ -8914,6 +9243,23 @@ jayson@^3.4.4:
     lodash "^4.17.20"
     uuid "^8.3.2"
     ws "^7.4.5"
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-validate@^26.5.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-26.6.2.tgz#23d380971587150467342911c3d7b4ac57ab20ec"
+  integrity sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    camelcase "^6.0.0"
+    chalk "^4.0.0"
+    jest-get-type "^26.3.0"
+    leven "^3.1.0"
+    pretty-format "^26.6.2"
 
 jest-worker@^26.2.1:
   version "26.6.2"
@@ -9277,6 +9623,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
 lodash.isequal@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -9297,7 +9648,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
+lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@~4.17.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -9379,6 +9730,11 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+make-plural@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/make-plural/-/make-plural-6.2.2.tgz#beb5fd751355e72660eeb2218bb98eec92853c6c"
+  integrity sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA==
+
 map-cache@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -9412,6 +9768,19 @@ meros@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/meros/-/meros-1.2.1.tgz#056f7a76e8571d0aaf3c7afcbe7eb6407ff7329e"
   integrity sha512-R2f/jxYqCAGI19KhAvaxSOxALBMkaXWH2a7rOyqQw+ZmizX5bKkEYWLzdhC+U82ZVVPVp6MCXe3EkVligh+12g==
+
+messageformat-parser@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/messageformat-parser/-/messageformat-parser-4.1.3.tgz#b824787f57fcda7d50769f5b63e8d4fda68f5b9e"
+  integrity sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg==
+
+micromatch@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
+  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.0.5"
 
 micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
@@ -9483,6 +9852,33 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+
+minipass@^2.6.0, minipass@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
+minizlib@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
+  integrity sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==
+  dependencies:
+    minipass "^2.9.0"
+
+mkdirp@^0.5.5:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
+  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
+  dependencies:
+    minimist "^1.2.6"
+
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 ms@2.0.0:
   version "2.0.0"
@@ -9641,6 +10037,16 @@ next@^13.1.1:
     "@next/swc-win32-ia32-msvc" "13.1.1"
     "@next/swc-win32-x64-msvc" "13.1.1"
 
+njre@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/njre/-/njre-0.2.0.tgz#e5abfbafafb3db4438fe6b149da9a733fab0bf3d"
+  integrity sha512-+Wq8R6VmjK+jI8a9NdzfU6Vh50r3tjsdvl5KJE1OyHeH8I/nx5Ptm12qpO3qNUbstXuZfBDgDL0qQZw9JyjhMw==
+  dependencies:
+    command-exists-promise "^2.0.2"
+    node-fetch "^2.5.0"
+    tar "^4.4.8"
+    yauzl "^2.10.0"
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
@@ -9659,12 +10065,19 @@ node-domexception@1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@2, node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2, node-fetch@2.6.7, node-fetch@^2.5.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-gettext@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/node-gettext/-/node-gettext-3.0.0.tgz#6b3a253309aa1e53164646c6c644fcddd0d45c58"
+  integrity sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==
+  dependencies:
+    lodash.get "^4.4.2"
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.5.0"
@@ -9840,7 +10253,7 @@ optionator@^0.9.1:
     type-check "^0.4.0"
     word-wrap "^1.2.3"
 
-ora@^5.4.1:
+ora@^5.1.0, ora@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/ora/-/ora-5.4.1.tgz#1b2678426af4ac4a509008e5e4ac9e9959db9e18"
   integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
@@ -9921,6 +10334,11 @@ pako@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
+
+papaparse@^5.3.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.2.tgz#d1abed498a0ee299f103130a6109720404fbd467"
+  integrity sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw==
 
 param-case@^3.0.4:
   version "3.0.4"
@@ -10045,7 +10463,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -10119,10 +10537,22 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
+
 pluralize@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
+plurals-cldr@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/plurals-cldr/-/plurals-cldr-1.0.4.tgz#534e4784f80679d3b0b39b0fb6cc46645fcf5de8"
+  integrity sha512-4nLXqtel7fsCgzi8dvRZvUjfL8SXpP982sKg7b2TgpnR8rDnes06iuQ83trQ/+XdtyMIQkBBbKzX6x97eLfsJQ==
 
 plyr-react@^5.1.0:
   version "5.1.2"
@@ -10147,6 +10577,11 @@ pngjs@^3.3.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+
+pofile@^1.1.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/pofile/-/pofile-1.1.4.tgz#eab7e29f5017589b2a61b2259dff608c0cad76a2"
+  integrity sha512-r6Q21sKsY1AjTVVjOuU02VYKVNQGJNQHjTIvs4dEbeuuYfxgYk/DGD2mqqq4RDaVkwdSq0VEtmQUOPe/wH8X3g==
 
 postcss-import@^14.1.0:
   version "14.1.0"
@@ -10242,6 +10677,16 @@ pretty-bytes@^5.3.0, pretty-bytes@^5.4.1, pretty-bytes@^5.6.0:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"
   integrity sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==
 
+pretty-format@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.2.tgz#e35c2705f14cb7fe2fe94fa078345b444120fc93"
+  integrity sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
 prismjs@^1.27.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
@@ -10300,6 +10745,13 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+pseudolocale@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pseudolocale/-/pseudolocale-1.2.0.tgz#787021d9a11abfdd8f084eabe0e59845ba571453"
+  integrity sha512-k0OQFvIlvpRdzR0dPVrrbWX7eE9EaZ6gpZtTlFSDi1Gf9tMy9wiANCNu7JZ0drcKgUri/39a2mBbH0goiQmrmQ==
+  dependencies:
+    commander "*"
 
 psl@^1.1.28:
   version "1.9.0"
@@ -10390,6 +10842,11 @@ quick-lru@^5.1.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
   integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
 
+ramda@^0.27.1:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
+  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
+
 randombytes@^2.0.1, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -10453,6 +10910,11 @@ react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-universal-interface@^0.6.2:
   version "0.6.2"
@@ -10521,6 +10983,13 @@ readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.5.0, readable
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -10532,6 +11001,13 @@ real-require@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.1.0.tgz#736ac214caa20632847b7ca8c1056a0767df9381"
   integrity sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
+  dependencies:
+    resolve "^1.1.6"
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.0"
@@ -10661,7 +11137,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -10785,7 +11261,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.6.3:
+rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -10799,7 +11275,7 @@ rxjs@^7.5.1, rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -10975,6 +11451,15 @@ shell-quote@^1.7.3:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.4.tgz#33fe15dee71ab2a81fcbd3a52106c5cfb9fb75d8"
   integrity sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==
+
+shelljs@^0.8.4:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -11432,6 +11917,19 @@ tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
+tar@^4.4.8:
+  version "4.4.19"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.19.tgz#2e4d7263df26f2b914dee10c825ab132123742f3"
+  integrity sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==
+  dependencies:
+    chownr "^1.1.4"
+    fs-minipass "^1.2.7"
+    minipass "^2.9.0"
+    minizlib "^1.3.3"
+    mkdirp "^0.5.5"
+    safe-buffer "^5.2.1"
+    yallist "^3.1.1"
 
 temp-dir@^2.0.0:
   version "2.0.0"
@@ -12349,7 +12847,7 @@ yaeti@^0.0.6:
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
   integrity sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==
 
-yallist@^3.0.2:
+yallist@^3.0.0, yallist@^3.0.2, yallist@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2107,7 +2107,7 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
-"@crowdin/cli@3":
+"@crowdin/cli@^3.9.1":
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/@crowdin/cli/-/cli-3.9.1.tgz#f09f3616798ec7474c2c7d162a40bf875e0c9e74"
   integrity sha512-Ca+mzVvLE9lYmTA4peTHOQdH42+eThwQ0DK6URT7crInQKJRjVJdsA2kkfEwi2mQPruAIG/KIKaPieRWPanlIQ==


### PR DESCRIPTION
## What does this PR do?

Port to LinguiJS and add Crowdin integration.
Fixes #1343

The feature can be tested on Vercel deployment, by switching to PseudoLanguage under _Settings > Account > Locale settings_. (About pseudolocalization: https://lingui.js.org/guides/pseudolocalization.html )

Screen capture: https://user-images.githubusercontent.com/667227/209463143-41576848-31d9-4267-a7f4-9f388abd1d04.mp4

Temporary Crowdin project: https://crowdin.com/project/lenstertest

**Important files in this PR:**
`apps/web/src/lib/i18n.ts` - Helper for loading and switching locales on-the-fly
`apps/web/src/locales/en/messages.po` - English source strings, uploaded to Crowdin
`apps/web/src/locales/*/messages.po` - Translated strings, will be updated with translations from Crowdin
`apps/web/package.json` - added/updated scripts (see `I18N.md`)
`apps/web/src/components/Settings/Account/Language.tsx` - Settings page
`I18N.md` - i18n readme
`apps/web/.babelrc`, `apps/web/.linguirc`, `apps/web/crowdin.yml` - config files


