### PR TITLE
feat: update atob api

### DIFF
--- a/apps/web/src/lib/parseJwt.ts
+++ b/apps/web/src/lib/parseJwt.ts
@@ -1,5 +1,12 @@
 /**
  *
+ * @param str jwt token
+ * @returns atob data
+ */
+ const decoded = (str: string): string => Buffer.from(str, 'base64').toString('binary');
+
+/**
+ *
  * @param token jwt token
  * @returns expiry time in seconds
  */
@@ -9,7 +16,7 @@ const parseJwt = (
   exp: number;
 } => {
   try {
-    return JSON.parse(atob(token.split('.')[1]));
+    return JSON.parse(decoded(token.split('.')[1]));
   } catch (error) {
     console.error(error);
     return { exp: 0 };

--- a/apps/web/src/lib/parseJwt.ts
+++ b/apps/web/src/lib/parseJwt.ts
@@ -3,7 +3,7 @@
  * @param str jwt token
  * @returns atob data
  */
- const decoded = (str: string): string => Buffer.from(str, 'base64').toString('binary');
+const decoded = (str: string): string => Buffer.from(str, 'base64').toString('binary');
 
 /**
  *


### PR DESCRIPTION
What does this PR do?
This function is only provided for compatibility with legacy web platform APIs and should never be used in new code, because they use strings to represent binary data and predate the introduction of typed arrays in JavaScript. For code running using Node.js APIs, converting between base64-encoded strings and binary data should be performed using Buffer.from()

How should this be tested?
Check that the warning is gone in code scanning results
