### PR TITLE
Change readme.md license MIT to GPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ We love contributors! Feel free to contribute to this project but please read th
 
 ## ⚖️ License
 
-Lenster is open-sourced software licensed under the © [MIT](LICENSE).
+Lenster is open-sourced software licensed under the © [GPLv3](LICENSE).


### PR DESCRIPTION
## What does this PR do?

the current readme.md license name wa error

Fixes # (issue)

change license MIT to GPLv3
