### PR TITLE
chore: spread attributes and dont reset

### DIFF
--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -169,6 +169,20 @@ const Profile: FC<Props> = ({ profile }) => {
         bio,
         cover_picture: cover ? cover : null,
         attributes: [
+          ...(profile?.attributes
+            ?.filter(
+              (attr) =>
+                ![
+                  'location',
+                  'website',
+                  'twitter',
+                  'hasPrideLogo',
+                  'statusEmoji',
+                  'statusMessage',
+                  'app'
+                ].includes(attr.key)
+            )
+            .map(({ key, value }) => ({ traitType: 'string', key, value })) ?? []),
           { traitType: 'string', key: 'location', value: location },
           { traitType: 'string', key: 'website', value: website },
           { traitType: 'string', key: 'twitter', value: twitter },


### PR DESCRIPTION
We dont reset the attributes rather we spread attributes other than that lenster uses....