### PR TITLE
fix: dayjs localization

### DIFF
--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -2,6 +2,9 @@ import { i18n } from '@lingui/core';
 import { IS_PREVIEW, IS_PRODUCTION, LS_KEYS } from 'data/constants';
 import dayjs from 'dayjs';
 import { en, es, kn, ta } from 'make-plural/plurals';
+import('dayjs/locale/es');
+import('dayjs/locale/kn');
+import('dayjs/locale/ta');
 
 export const supportedLocales: Record<string, string> = {
   en: 'English',
@@ -37,7 +40,10 @@ export async function setLocale(locale: string) {
   const { messages } = await import(`src/locales/${locale}/messages`);
   i18n.load(locale, messages);
   i18n.activate(locale);
-  dayjs.locale(locale);
+  const loadResult = dayjs.locale(locale);
+  if (loadResult != locale) {
+    dayjs.locale(defaultLocale);
+  }
 }
 
 export const initLocale = () => {


### PR DESCRIPTION
## What does this PR do?

Show dayjs strings (e.g. "5 days ago") in active language.

**Before:**
![Screenshot_2022-12-30_18-11-23](https://user-images.githubusercontent.com/667227/210096675-a1d508d2-927d-445b-908a-0d7df510442e.png)

**After:**
![Screenshot_2022-12-30_18-12-25](https://user-images.githubusercontent.com/667227/210096676-07eccf09-f556-453e-9ccb-66975c675afc.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Go to Settings > Account > Locale settings > Switch to a non-English language.
Go to notifications page and check the upper right timestamp. Timestamp should show translated to the active language.

