### PR TITLE
fix: keep auth modal when no profile was found

### DIFF
--- a/apps/web/src/components/Shared/Login/WalletSelector.tsx
+++ b/apps/web/src/components/Shared/Login/WalletSelector.tsx
@@ -57,6 +57,7 @@ const WalletSelector: FC<Props> = ({ setHasConnected, setHasProfile }) => {
   };
 
   const handleSign = async () => {
+    let keepModal = false;
     try {
       setLoading(true);
       // Get challenge
@@ -87,6 +88,7 @@ const WalletSelector: FC<Props> = ({ setHasConnected, setHasProfile }) => {
 
       if (profilesData?.profiles?.items?.length === 0) {
         setHasProfile(false);
+        keepModal = true;
       } else {
         const profiles: any = profilesData?.profiles?.items
           ?.slice()
@@ -102,7 +104,9 @@ const WalletSelector: FC<Props> = ({ setHasConnected, setHasProfile }) => {
       console.error(error);
     } finally {
       setLoading(false);
-      setShowAuthModal(false);
+      if (!keepModal) {
+        setShowAuthModal(false);
+      }
     }
   };
 


### PR DESCRIPTION
## What does this PR do?

Avoid closing the login form when it should show "Claim your Lens profile".
[Screen recording](https://user-images.githubusercontent.com/667227/210209658-06a5fd1f-5bde-4184-9168-1b23e4542293.mp4)

Notes:
The three dialogs "Connect your wallet", "Please sign the message" and "Claim your Lens profile" use the same modal (apps/web/src/components/Shared/Login/index.tsx).
When the user tries to login with an address that has no account, the "Claim your Lens profile" should display. Therefor, in that scenario, the modal should not be closed.

Fixes #1497

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

In #1497, perform steps to reproduce and verify expected behavior


