### PR TITLE
fix: persist tab in explore

### DIFF
--- a/apps/web/src/components/Explore/index.tsx
+++ b/apps/web/src/components/Explore/index.tsx
@@ -11,6 +11,7 @@ import clsx from 'clsx';
 import { APP_NAME, STATIC_IMAGES_URL } from 'data/constants';
 import { PublicationSortCriteria } from 'lens';
 import type { NextPage } from 'next';
+import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useAppStore } from 'src/store/app';
 
@@ -20,6 +21,7 @@ import FeedType from './FeedType';
 const Explore: NextPage = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [focus, setFocus] = useState<any>();
+  const router = useRouter();
 
   const tabs = [
     { name: t`For you`, emoji: 'leaf-fluttering-in-wind.png', type: PublicationSortCriteria.CuratedProfiles },
@@ -35,7 +37,12 @@ const Explore: NextPage = () => {
         description={`Explore top commented, collected and latest publications in the ${APP_NAME}.`}
       />
       <GridItemEight className="space-y-5">
-        <Tab.Group>
+        <Tab.Group
+          defaultIndex={Number(router.query.tabIndex)}
+          onChange={(index) => {
+            router.replace({ query: { ...router.query, tabIndex: index } }, undefined, { shallow: true });
+          }}
+        >
           <Tab.List className="divider space-x-8">
             {tabs.map((tab, index) => (
               <Tab

--- a/apps/web/src/components/Explore/index.tsx
+++ b/apps/web/src/components/Explore/index.tsx
@@ -38,9 +38,9 @@ const Explore: NextPage = () => {
       />
       <GridItemEight className="space-y-5">
         <Tab.Group
-          defaultIndex={Number(router.query.tabIndex)}
+          defaultIndex={Number(router.query.tab)}
           onChange={(index) => {
-            router.replace({ query: { ...router.query, tabIndex: index } }, undefined, { shallow: true });
+            router.replace({ query: { ...router.query, tab: index } }, undefined, { shallow: true });
           }}
         >
           <Tab.List className="divider space-x-8">


### PR DESCRIPTION
## What does this PR do?

Fixes #997
Save selected tab in http://localhost:4783/explore as a URL query parameter.
[Screen recording](https://user-images.githubusercontent.com/667227/210841401-fba1d09b-e59e-41c0-b8f2-df393b77b28b.mp4)

Note: Using `router.replace` so that the user can click around among the tabs without creating more browser history. If this is not the desired behavior, it can simply be changed to `router.push`.

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)

