### PR TITLE
fix: url matcher for parentheses

### DIFF
--- a/apps/web/src/components/Shared/Markup.tsx
+++ b/apps/web/src/components/Shared/Markup.tsx
@@ -6,7 +6,7 @@ import { MDLinkMatcher } from '@components/utils/matchers/markdown/MDLinkMatcher
 import { MDQuoteMatcher } from '@components/utils/matchers/markdown/MDQuoteMatcher';
 import { MDStrikeMatcher } from '@components/utils/matchers/markdown/MDStrikeMatcher';
 import { MentionMatcher } from '@components/utils/matchers/MentionMatcher';
-import { PUrlMatcher, UrlMatcher } from '@components/utils/matchers/UrlMatcher';
+import { ParenthesesUrlMatcher, UrlMatcher } from '@components/utils/matchers/UrlMatcher';
 import trimify from '@lib/trimify';
 import { Interweave } from 'interweave';
 import type { FC, MouseEvent } from 'react';
@@ -22,7 +22,7 @@ const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
     new MDCodeMatcher('mdCode'),
     new MentionMatcher('mention'),
     new MDLinkMatcher('mdLink'),
-    new PUrlMatcher('purl'),
+    new ParenthesesUrlMatcher('pUrl'),
     new UrlMatcher('url'),
     new HashtagMatcher('hashtag'),
     new MDBoldMatcher('mdBold'),
@@ -37,7 +37,7 @@ const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
       content={trimify(children)}
       escapeHtml
       allowList={['b', 'i', 'a', 'br', 'code', 'span']}
-      matchers={matchOnlyUrl ? [new PUrlMatcher('purl'), new UrlMatcher('url')] : defaultMatchers}
+      matchers={matchOnlyUrl ? [new ParenthesesUrlMatcher('pUrl'), new UrlMatcher('url')] : defaultMatchers}
       onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
     />
   );

--- a/apps/web/src/components/Shared/Markup.tsx
+++ b/apps/web/src/components/Shared/Markup.tsx
@@ -6,7 +6,7 @@ import { MDLinkMatcher } from '@components/utils/matchers/markdown/MDLinkMatcher
 import { MDQuoteMatcher } from '@components/utils/matchers/markdown/MDQuoteMatcher';
 import { MDStrikeMatcher } from '@components/utils/matchers/markdown/MDStrikeMatcher';
 import { MentionMatcher } from '@components/utils/matchers/MentionMatcher';
-import { UrlMatcher } from '@components/utils/matchers/UrlMatcher';
+import { PUrlMatcher, UrlMatcher } from '@components/utils/matchers/UrlMatcher';
 import trimify from '@lib/trimify';
 import { Interweave } from 'interweave';
 import type { FC, MouseEvent } from 'react';
@@ -22,6 +22,7 @@ const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
     new MDCodeMatcher('mdCode'),
     new MentionMatcher('mention'),
     new MDLinkMatcher('mdLink'),
+    new PUrlMatcher('purl'),
     new UrlMatcher('url'),
     new HashtagMatcher('hashtag'),
     new MDBoldMatcher('mdBold'),
@@ -36,7 +37,7 @@ const Markup: FC<Props> = ({ children, className = '', matchOnlyUrl }) => {
       content={trimify(children)}
       escapeHtml
       allowList={['b', 'i', 'a', 'br', 'code', 'span']}
-      matchers={matchOnlyUrl ? [new UrlMatcher('url')] : defaultMatchers}
+      matchers={matchOnlyUrl ? [new PUrlMatcher('purl'), new UrlMatcher('url')] : defaultMatchers}
       onClick={(event: MouseEvent<HTMLDivElement>) => event.stopPropagation()}
     />
   );

--- a/apps/web/src/components/utils/matchers/UrlMatcher/constants.ts
+++ b/apps/web/src/components/utils/matchers/UrlMatcher/constants.ts
@@ -39,8 +39,8 @@ const URL_PATH = combinePatterns(
     /\//,
     combinePatterns(
       [
-        /[\d!$%&'*+,./:;=@[\]_a-z|~-]*/,
-        /[\d+/a-z-]/ // Valid ending chars
+        /[\d!$%&'()*+,./:;=@[\]_a-z|~-]*/,
+        /[\d()+/a-z-]/ // Valid ending chars
       ],
       { match: '*', nonCapture: true }
     )

--- a/apps/web/src/components/utils/matchers/UrlMatcher/constants.ts
+++ b/apps/web/src/components/utils/matchers/UrlMatcher/constants.ts
@@ -80,4 +80,6 @@ export const URL_PATTERN = combinePatterns([URL_SCHEME, URL_HOST, URL_PATH, URL_
   flags: 'i'
 });
 
+export const PARENTHESES_URL_PATTERN = new RegExp(`\\((${URL_PATTERN.source})\\)`, 'i');
+
 export const BLOCKED_TLDS = ['lens'];

--- a/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
+++ b/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
@@ -73,7 +73,6 @@ export class ParenthesesUrlMatcher extends UrlMatcher {
   }
 
   handleMatches(matches: string[]): UrlMatch {
-    console.log(matches);
     return {
       url: matches[1],
       host: matches[4]

--- a/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
+++ b/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
@@ -61,7 +61,7 @@ export class UrlMatcher extends Matcher<UrlProps> {
 
 export class PUrlMatcher extends Matcher<UrlProps> {
   replaceWith(children: ChildrenNode, props: UrlProps): Node {
-    return createElement(Url, props, children);
+    return <>({createElement(Url, props, props.url)})</>;
   }
 
   asTag(): string {

--- a/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
+++ b/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
@@ -63,7 +63,7 @@ export class UrlMatcher extends Matcher<UrlProps> {
   }
 }
 
-export class PUrlMatcher extends UrlMatcher {
+export class ParenthesesUrlMatcher extends UrlMatcher {
   replaceWith(children: ChildrenNode, props: UrlProps): Node {
     return <>({createElement(Url, props, props.url)})</>;
   }

--- a/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
+++ b/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
@@ -2,7 +2,7 @@ import type { ChildrenNode, MatchResponse, Node } from 'interweave';
 import { Matcher } from 'interweave';
 import { createElement } from 'react';
 
-import { BLOCKED_TLDS, URL_PATTERN } from './constants';
+import { BLOCKED_TLDS, PARENTHESES_URL_PATTERN, URL_PATTERN } from './constants';
 
 interface UrlProps {
   children: ChildrenNode;
@@ -55,6 +55,39 @@ export class UrlMatcher extends Matcher<UrlProps> {
     return {
       url: matches[0],
       host: matches[3]
+    };
+  }
+}
+
+export class PUrlMatcher extends Matcher<UrlProps> {
+  replaceWith(children: ChildrenNode, props: UrlProps): Node {
+    return createElement(Url, props, children);
+  }
+
+  asTag(): string {
+    return 'a';
+  }
+
+  match(string: string): MatchResponse<UrlMatch> | null {
+    const response = this.doMatch(string, PARENTHESES_URL_PATTERN, this.handleMatches, true);
+
+    if (response?.valid) {
+      const { host } = response;
+      const tld = host.slice(host.lastIndexOf('.') + 1).toLowerCase();
+
+      if (BLOCKED_TLDS.includes(tld)) {
+        response.valid = false;
+      }
+    }
+
+    return response;
+  }
+
+  handleMatches(matches: string[]): UrlMatch {
+    console.log(matches);
+    return {
+      url: matches[1],
+      host: matches[4]
     };
   }
 }

--- a/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
+++ b/apps/web/src/components/utils/matchers/UrlMatcher/index.tsx
@@ -32,12 +32,16 @@ export class UrlMatcher extends Matcher<UrlProps> {
     return createElement(Url, props, children);
   }
 
+  getPattern(): RegExp {
+    return URL_PATTERN;
+  }
+
   asTag(): string {
     return 'a';
   }
 
   match(string: string): MatchResponse<UrlMatch> | null {
-    const response = this.doMatch(string, URL_PATTERN, this.handleMatches, true);
+    const response = this.doMatch(string, this.getPattern(), this.handleMatches, true);
 
     if (response?.valid) {
       const { host } = response;
@@ -59,28 +63,13 @@ export class UrlMatcher extends Matcher<UrlProps> {
   }
 }
 
-export class PUrlMatcher extends Matcher<UrlProps> {
+export class PUrlMatcher extends UrlMatcher {
   replaceWith(children: ChildrenNode, props: UrlProps): Node {
     return <>({createElement(Url, props, props.url)})</>;
   }
 
-  asTag(): string {
-    return 'a';
-  }
-
-  match(string: string): MatchResponse<UrlMatch> | null {
-    const response = this.doMatch(string, PARENTHESES_URL_PATTERN, this.handleMatches, true);
-
-    if (response?.valid) {
-      const { host } = response;
-      const tld = host.slice(host.lastIndexOf('.') + 1).toLowerCase();
-
-      if (BLOCKED_TLDS.includes(tld)) {
-        response.valid = false;
-      }
-    }
-
-    return response;
+  getPattern(): RegExp {
+    return PARENTHESES_URL_PATTERN;
   }
 
   handleMatches(matches: string[]): UrlMatch {


### PR DESCRIPTION
## What does this PR do?

Fixes #1599

After fix:
![Screenshot_2023-01-12_18-20-10](https://user-images.githubusercontent.com/667227/212135730-f8050cd7-71a2-4dec-93e9-4b76319089c3.png)
(purple color brightened for the screenshot to distinguish clearly from the black text)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

See steps in #1599
