### PR TITLE
fix paragraph spacing

### DIFF
--- a/apps/web/src/components/Composer/Editor/index.tsx
+++ b/apps/web/src/components/Composer/Editor/index.tsx
@@ -40,7 +40,7 @@ const Editor: FC = () => {
       <EmojiPickerPlugin />
       <ToolbarPlugin />
       <RichTextPlugin
-        contentEditable={<ContentEditable className="px-5 block my-4 min-h-[65px] overflow-auto" />}
+        contentEditable={<ContentEditable className="px-5 block my-4 min-h-[65px] overflow-auto editor" />}
         placeholder={
           <div className="px-5 absolute top-[65px] text-gray-400 pointer-events-none whitespace-nowrap">
             <Trans>What's happening?</Trans>

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -187,3 +187,7 @@ div[data-lexical-editor='true'] {
 #typeahead-menu {
   @apply z-20;
 }
+
+.editor p:not(:last-child) {
+	margin-bottom: 1em;
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #1193
Problem: In editor, user could not see the difference between paragraph and newline. But in the published post, paragraph and newline are displayed differently (correctly).

So in this PR, the rendering of the published post is **not** changed. Instead, we fix the style in the editor, so that user sees how the post will actually look when published.

Note: Tailwind was setting all margins to 0, so therefor all elements, both `<p>` and `<br>`  had a margin of 0.

## Appearance before PR
![Screenshot_2023-01-15_09-03-29 (copy 1)](https://user-images.githubusercontent.com/667227/212530721-03caa4d2-2583-4cdc-b6ad-81a95cad32e3.png)

## Appearance after PR
![Screenshot_2023-01-15_09-44-33 (copy 1)](https://user-images.githubusercontent.com/667227/212531529-2f0109c3-0cb8-4eff-b79d-d72f2482fba8.png)

## Appearance of published post (not changed with this PR)
![Screenshot_2023-01-15_09-54-44](https://user-images.githubusercontent.com/667227/212531880-9b11a113-3d64-4595-bca5-909d952ee46a.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Open editor,
Type a line
Create new paragraph by pressing Enter
Observe large spacing
Type two more lines, separated by Shift+Enter
Observe smaller spacing
