### PR TITLE
fix: create only line breaks in editor

### DIFF
--- a/apps/web/src/components/Composer/Editor/index.tsx
+++ b/apps/web/src/components/Composer/Editor/index.tsx
@@ -5,6 +5,7 @@ import ImagesPlugin from '@components/Shared/Lexical/Plugins/ImagesPlugin';
 import ToolbarPlugin from '@components/Shared/Lexical/Plugins/ToolbarPlugin';
 import useUploadAttachments from '@components/utils/hooks/useUploadAttachments';
 import { $convertToMarkdownString, TEXT_FORMAT_TRANSFORMERS } from '@lexical/markdown';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
 import { ContentEditable } from '@lexical/react/LexicalContentEditable';
 import { HashtagPlugin } from '@lexical/react/LexicalHashtagPlugin';
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin';
@@ -13,7 +14,9 @@ import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin';
 import { t, Trans } from '@lingui/macro';
 import { ERROR_MESSAGE } from 'data/constants';
+import { COMMAND_PRIORITY_NORMAL, INSERT_LINE_BREAK_COMMAND, INSERT_PARAGRAPH_COMMAND } from 'lexical';
 import type { FC } from 'react';
+import { useEffect } from 'react';
 import { toast } from 'react-hot-toast';
 import { usePublicationStore } from 'src/store/publication';
 
@@ -25,6 +28,7 @@ const Editor: FC = () => {
   const setPublicationContent = usePublicationStore((state) => state.setPublicationContent);
   const attachments = usePublicationStore((state) => state.attachments);
   const { handleUploadAttachments } = useUploadAttachments();
+  const [editor] = useLexicalComposerContext();
 
   const handlePaste = async (pastedFiles: FileList) => {
     if (attachments.length === 4 || attachments.length + pastedFiles.length > 4) {
@@ -34,6 +38,17 @@ const Editor: FC = () => {
       await handleUploadAttachments(pastedFiles);
     }
   };
+
+  useEffect(() => {
+    return editor.registerCommand(
+      INSERT_PARAGRAPH_COMMAND,
+      () => {
+        editor.dispatchCommand(INSERT_LINE_BREAK_COMMAND, false);
+        return true;
+      },
+      COMMAND_PRIORITY_NORMAL
+    );
+  }, [editor]);
 
   return (
     <div className="relative">


### PR DESCRIPTION
## What does this PR do?

New PR for #1193

As concluded in chat with @bigint :

> fix Lexical so that it only support newlines (similar to twitter)

After this PR, the Lexical editor will **only** create line breaks (\n), regardless of whether user presses _Shift+Enter_ or _Enter_.
(It will not create paragraphs (exported as \n\n), which it did before on _Enter_)



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Write a post, try separating some lines with _Enter_ and some with _Shift+Enter_. Verify that in the resulting published post, the line breaks match how it looked in the editor.
