### PR TITLE
fix: set chainid to wagmi connectors

### DIFF
--- a/apps/web/src/components/Shared/Login/WalletSelector.tsx
+++ b/apps/web/src/components/Shared/Login/WalletSelector.tsx
@@ -36,7 +36,7 @@ const WalletSelector: FC<Props> = ({ setHasConnected, setHasProfile }) => {
 
   const { mounted } = useIsMounted();
   const { chain } = useNetwork();
-  const { connectors, error, connectAsync } = useConnect();
+  const { connectors, error, connectAsync } = useConnect({ chainId: CHAIN_ID });
   const { disconnect } = useDisconnect();
   const { address, connector: activeConnector } = useAccount();
   const { signMessageAsync } = useSignMessage({ onError });


### PR DESCRIPTION
## What does this PR do?

Explicitly adds chainId to wagmi `useConnect` hook so that chainId is properly populated when instantiating a WalletConnectConnector.

Fixes #1668 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Successfully connected with WalletConnect to Sequence wallet.  
