### PR TITLE
adding meta description and og:description

### DIFF
--- a/apps/web/src/pages/_document.tsx
+++ b/apps/web/src/pages/_document.tsx
@@ -22,8 +22,14 @@ class LensterDocument extends Document {
           <meta name="apple-mobile-web-app-title" content="Lenster" />
 
           {/* SEO */}
-          <meta name="description" content="Lenster is a decentralized, and permissionless social media app built with Lens Protocol." />
-          <meta property="og:description" content="Lenster is a decentralized, and permissionless social media app built with Lens Protocol." />
+          <meta
+            name="description"
+            content="Lenster is a decentralized, and permissionless social media app built with Lens Protocol."
+          />
+          <meta
+            property="og:description"
+            content="Lenster is a decentralized, and permissionless social media app built with Lens Protocol."
+          />
 
           {/* Icons */}
           <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/apps/web/src/pages/_document.tsx
+++ b/apps/web/src/pages/_document.tsx
@@ -21,6 +21,10 @@ class LensterDocument extends Document {
           <meta name="apple-mobile-web-app-status-bar-style" content="default" />
           <meta name="apple-mobile-web-app-title" content="Lenster" />
 
+          {/* SEO */}
+          <meta name="description" content="Lenster is a decentralized, and permissionless social media app built with Lens Protocol." />
+          <meta property="og:description" content="Lenster is a decentralized, and permissionless social media app built with Lens Protocol." />
+
           {/* Icons */}
           <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
           <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />


### PR DESCRIPTION
## What does this PR do?
This PR adds `<meta>` tags of `description` (for search engines like Google) and `og:description` (for open-graph/social media networks). The content for both the tags is the same, and copied exactly from Lenster's profile from Github/Twitter, etc.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # None, but the issue image is displayed as follows:

![lenster](https://user-images.githubusercontent.com/20269286/219983740-72de22d6-0e26-4877-b2bd-c64de60d2be6.JPG)


<!-- Please provide a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] Enhancement (non-breaking small changes to existing functionality)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- N/A 😢

## Checklist
All seems clear.


**P.S. I am new to open-source contribution, so I am all ears to feedback!**