### PR TITLE
feat: add tooltips

### DIFF
--- a/apps/web/src/components/Messages/MessageIcon.tsx
+++ b/apps/web/src/components/Messages/MessageIcon.tsx
@@ -1,6 +1,8 @@
+import { Tooltip } from '@components/UI/Tooltip';
 import useXmtpClient from '@components/utils/hooks/useXmtpClient';
 import { MailIcon } from '@heroicons/react/outline';
 import conversationMatchesProfile from '@lib/conversationMatchesProfile';
+import { t } from '@lingui/macro';
 import type { DecodedMessage } from '@xmtp/xmtp-js';
 import { fromNanoString, SortDirection } from '@xmtp/xmtp-js';
 import Link from 'next/link';
@@ -99,18 +101,20 @@ const MessageIcon: FC = () => {
   }, [cachedClient, currentProfile?.id]);
 
   return (
-    <Link
-      href="/messages"
-      className="hidden min-w-[40px] items-start justify-center rounded-md p-1 hover:bg-gray-300 hover:bg-opacity-20 md:flex"
-      onClick={() => {
-        currentProfile && clearMessagesBadge(currentProfile.id);
-      }}
-    >
-      <MailIcon className="h-5 w-5 sm:h-6 sm:w-6" />
-      {showMessagesBadge.get(currentProfile?.id) ? (
-        <span className="h-2 w-2 rounded-full bg-red-500" />
-      ) : null}
-    </Link>
+    <Tooltip content={t`Messages`} placement="bottom" withDelay>
+      <Link
+        href="/messages"
+        className="hidden min-w-[40px] items-start justify-center rounded-md p-1 hover:bg-gray-300 hover:bg-opacity-20 md:flex"
+        onClick={() => {
+          currentProfile && clearMessagesBadge(currentProfile.id);
+        }}
+      >
+        <MailIcon className="h-5 w-5 sm:h-6 sm:w-6" />
+        {showMessagesBadge.get(currentProfile?.id) ? (
+          <span className="h-2 w-2 rounded-full bg-red-500" />
+        ) : null}
+      </Link>
+    </Tooltip>
   );
 };
 

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from '@components/UI/EmptyState';
 import { ErrorMessage } from '@components/UI/ErrorMessage';
 import { GridItemFour } from '@components/UI/GridLayout';
 import { Modal } from '@components/UI/Modal';
+import { Tooltip } from '@components/UI/Tooltip';
 import useMessagePreviews from '@components/utils/hooks/useMessagePreviews';
 import { MailIcon, PlusCircleIcon, UsersIcon } from '@heroicons/react/outline';
 import buildConversationId from '@lib/buildConversationId';
@@ -80,9 +81,11 @@ const PreviewList: FC<Props> = ({ className, selectedConversationKey }) => {
         <div className="flex items-center justify-between border-b p-5 dark:border-gray-700">
           <div className="font-bold">Messages</div>
           {currentProfile && !showAuthenticating && !showLoading && (
-            <button onClick={newMessageClick} type="button">
-              <PlusCircleIcon className="h-6 w-6" />
-            </button>
+            <Tooltip content={t`New conversation`} placement="top" withDelay>
+              <button onClick={newMessageClick} type="button">
+                <PlusCircleIcon className="h-6 w-6" />
+              </button>
+            </Tooltip>
           )}
         </div>
         <div className="flex">
@@ -160,7 +163,7 @@ const PreviewList: FC<Props> = ({ className, selectedConversationKey }) => {
         </div>
       </Card>
       <Modal
-        title={t`New message`}
+        title={t`New conversation`}
         icon={<MailIcon className="text-brand h-5 w-5" />}
         size="sm"
         show={showSearchModal}

--- a/apps/web/src/components/Notification/NotificationIcon.tsx
+++ b/apps/web/src/components/Notification/NotificationIcon.tsx
@@ -1,4 +1,6 @@
+import { Tooltip } from '@components/UI/Tooltip';
 import { LightningBoltIcon } from '@heroicons/react/outline';
+import { t } from '@lingui/macro';
 import { CustomFiltersTypes, useNotificationCountQuery } from 'lens';
 import Link from 'next/link';
 import type { FC } from 'react';
@@ -25,17 +27,19 @@ const NotificationIcon: FC = () => {
   }, [data]);
 
   return (
-    <Link
-      href="/notifications"
-      className="hidden min-w-[40px] items-start justify-center rounded-md p-1 hover:bg-gray-300 hover:bg-opacity-20 md:flex"
-      onClick={() => {
-        setNotificationCount(data?.notifications?.pageInfo?.totalCount || 0);
-        setShowBadge(false);
-      }}
-    >
-      <LightningBoltIcon className="h-5 w-5 sm:h-6 sm:w-6" />
-      {showBadge && <span className="h-2 w-2 rounded-full bg-red-500" />}
-    </Link>
+    <Tooltip content={t`Notifications`} placement="bottom" withDelay>
+      <Link
+        href="/notifications"
+        className="hidden min-w-[40px] items-start justify-center rounded-md p-1 hover:bg-gray-300 hover:bg-opacity-20 md:flex"
+        onClick={() => {
+          setNotificationCount(data?.notifications?.pageInfo?.totalCount || 0);
+          setShowBadge(false);
+        }}
+      >
+        <LightningBoltIcon className="h-5 w-5 sm:h-6 sm:w-6" />
+        {showBadge && <span className="h-2 w-2 rounded-full bg-red-500" />}
+      </Link>
+    </Tooltip>
   );
 };
 

--- a/apps/web/src/components/Profile/Message.tsx
+++ b/apps/web/src/components/Profile/Message.tsx
@@ -1,5 +1,7 @@
 import { Button } from '@components/UI/Button';
+import { Tooltip } from '@components/UI/Tooltip';
 import { MailIcon } from '@heroicons/react/outline';
+import { t } from '@lingui/macro';
 import type { FC } from 'react';
 
 interface Props {
@@ -8,13 +10,15 @@ interface Props {
 
 const Message: FC<Props> = ({ onClick }) => {
   return (
-    <Button
-      className="!px-3 !py-1.5 text-sm"
-      icon={<MailIcon className="h-5 w-5" />}
-      outline
-      onClick={onClick}
-      aria-label="Message"
-    />
+    <Tooltip content={t`Message`} placement="top" withDelay>
+      <Button
+        className="!px-3 !py-1.5 text-sm"
+        icon={<MailIcon className="h-5 w-5" />}
+        outline
+        onClick={onClick}
+        aria-label="Message"
+      />
+    </Tooltip>
   );
 };
 

--- a/apps/web/src/components/Shared/Follow.tsx
+++ b/apps/web/src/components/Shared/Follow.tsx
@@ -1,6 +1,7 @@
 import type { ApolloCache } from '@apollo/client';
 import { Button } from '@components/UI/Button';
 import { Spinner } from '@components/UI/Spinner';
+import { Tooltip } from '@components/UI/Tooltip';
 import { UserAddIcon } from '@heroicons/react/outline';
 import getSignature from '@lib/getSignature';
 import { Mixpanel } from '@lib/mixpanel';
@@ -178,16 +179,18 @@ const Follow: FC<Props> = ({
   const isLoading = typedDataLoading || proxyActionLoading || signLoading || writeLoading || broadcastLoading;
 
   return (
-    <Button
-      className="!px-3 !py-1.5 text-sm"
-      outline={outline}
-      onClick={createFollow}
-      aria-label="Follow"
-      disabled={isLoading}
-      icon={isLoading ? <Spinner size="xs" /> : <UserAddIcon className="h-4 w-4" />}
-    >
-      {showText && t`Follow`}
-    </Button>
+    <Tooltip content={t`Follow`} placement="top" withDelay disabled={showText}>
+      <Button
+        className="!px-3 !py-1.5 text-sm"
+        outline={outline}
+        onClick={createFollow}
+        aria-label={t`Follow`}
+        disabled={isLoading}
+        icon={isLoading ? <Spinner size="xs" /> : <UserAddIcon className="h-4 w-4" />}
+      >
+        {showText && t`Follow`}
+      </Button>
+    </Tooltip>
   );
 };
 

--- a/apps/web/src/components/UI/Tooltip.tsx
+++ b/apps/web/src/components/UI/Tooltip.tsx
@@ -6,8 +6,9 @@ import type { FC, ReactNode } from 'react';
 interface Props {
   children: ReactNode;
   content: ReactNode;
-  placement?: 'top' | 'right';
+  placement?: 'top' | 'right' | 'bottom';
   className?: string;
+  disabled?: boolean;
   withDelay?: boolean;
 }
 
@@ -16,10 +17,12 @@ export const Tooltip: FC<Props> = ({
   content,
   placement = 'right',
   className = '',
+  disabled = false,
   withDelay = false
 }) => {
   return (
     <Tippy
+      disabled={disabled}
       placement={placement}
       duration={0}
       delay={[withDelay ? 500 : 0, 0]}


### PR DESCRIPTION
## What does this PR do?

Improve user experience of first-time visitors by adding tooltips for buttons that have no text on them.
(For example, from my own experience I remember being a bit confused by the notification icon when i visited the site the first time).

Also changed one tooltip text to "New conversation" which is what it does, (and it's also the title of the dialog that pops up when clicking the button).

![Screenshot_2023-03-09_10-49-02](https://user-images.githubusercontent.com/667227/223986945-fad58e55-8d28-4943-a958-b0f56c6a0558.png)
![Screenshot_2023-03-09_10-49-10](https://user-images.githubusercontent.com/667227/223986956-f3711015-2ebc-4d72-8cdd-72c96ce8fac5.png)
![Screenshot_2023-03-09_10-50-48](https://user-images.githubusercontent.com/667227/223986959-bdcbb242-20b0-47aa-aa8b-7044eeb6ad84.png)
![Screenshot_2023-03-09_10-49-58](https://user-images.githubusercontent.com/667227/223986962-da935524-0b0e-4482-817b-8ec884bc7c59.png)
![Screenshot_2023-03-09_10-51-14](https://user-images.githubusercontent.com/667227/223986966-5e93e296-dcb0-49dd-8d68-1ee035be6a27.png)


## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)
