### PR TITLE
Image cropper cover 2110

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -61,6 +61,7 @@
     "remark-linkify-regex": "^1.2.1",
     "strip-markdown": "^5.0.0",
     "tlds": "^1.238.0",
+    "use-resize-observer": "^9.1.0",
     "utils": "*",
     "uuid": "^9.0.0",
     "wagmi": "^0.12.2",

--- a/apps/web/src/components/Settings/Profile/ImageCropperController.tsx
+++ b/apps/web/src/components/Settings/Profile/ImageCropperController.tsx
@@ -9,14 +9,12 @@ import { useEffect, useRef, useState } from 'react';
 import useResizeObserver from 'use-resize-observer';
 
 interface ImageCropperControllerProps {
-  borderSize: number;
   targetSize: Size;
   imageSrc: string;
   setCroppedAreaPixels: Dispatch<Area>;
 }
 
 const ImageCropperController: FC<ImageCropperControllerProps> = ({
-  borderSize,
   targetSize,
   imageSrc,
   setCroppedAreaPixels
@@ -36,6 +34,7 @@ const ImageCropperController: FC<ImageCropperControllerProps> = ({
   };
 
   const aspectRatio = targetSize.width / targetSize.height;
+  const borderSize = 20;
 
   useEffect(() => {
     const newWidth = divWidth - borderSize * 2;

--- a/apps/web/src/components/Settings/Profile/ImageCropperController.tsx
+++ b/apps/web/src/components/Settings/Profile/ImageCropperController.tsx
@@ -5,18 +5,19 @@ import ImageCropper from 'image-cropper/ImageCropper';
 import type { Area, Point, Size } from 'image-cropper/types';
 import Slider from 'rc-slider';
 import type { Dispatch, FC } from 'react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import useResizeObserver from 'use-resize-observer';
 
 interface ImageCropperControllerProps {
-  cropSize: Size;
   borderSize: number;
+  targetSize: Size;
   imageSrc: string;
   setCroppedAreaPixels: Dispatch<Area>;
 }
 
 const ImageCropperController: FC<ImageCropperControllerProps> = ({
-  cropSize,
   borderSize,
+  targetSize,
   imageSrc,
   setCroppedAreaPixels
 }) => {
@@ -24,6 +25,8 @@ const ImageCropperController: FC<ImageCropperControllerProps> = ({
   const [zoom, setZoom] = useState(1);
   const [maxZoom, setMaxZoom] = useState(1);
   const cropper = useRef<ImageCropper>(null);
+  const [cropSize, setCropSize] = useState<Size>(targetSize);
+  const { ref: divref, width: divWidth = cropSize.width } = useResizeObserver<HTMLDivElement>();
 
   const onSliderChange = (value: number | number[]) => {
     const logarithmicZoomValue = Array.isArray(value) ? value[0] : value;
@@ -32,14 +35,23 @@ const ImageCropperController: FC<ImageCropperControllerProps> = ({
     cropper.current?.setNewZoom(zoomValue, null);
   };
 
+  const aspectRatio = targetSize.width / targetSize.height;
+
+  useEffect(() => {
+    const newWidth = divWidth - borderSize * 2;
+    const newHeight = newWidth / aspectRatio;
+    setCropSize({ width: newWidth, height: newHeight });
+  }, [divWidth, borderSize, aspectRatio]);
+
   return (
-    <>
+    <div ref={divref}>
       <ImageCropper
         ref={cropper}
         image={imageSrc}
         cropSize={cropSize}
+        targetSize={targetSize}
         borderSize={borderSize}
-        cropPosition={crop}
+        cropPositionPercent={crop}
         zoom={zoom}
         zoomSpeed={1.2}
         onCropChange={setCrop}
@@ -61,7 +73,7 @@ const ImageCropperController: FC<ImageCropperControllerProps> = ({
         />
         <ZoomInIcon className="m-1 h-6 w-6" />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/apps/web/src/components/Settings/Profile/Picture.tsx
+++ b/apps/web/src/components/Settings/Profile/Picture.tsx
@@ -195,7 +195,7 @@ const Picture: FC<PictureProps> = ({ profile }) => {
         <div className="space-y-3">
           <div>
             <Image
-              className="rounded-lg"
+              className="max-w-xs rounded-lg"
               src={avatarDataUrl || profilePictureIpfsUrl}
               alt={t`Profile picture crop preview`}
             />

--- a/apps/web/src/components/Settings/Profile/Picture.tsx
+++ b/apps/web/src/components/Settings/Profile/Picture.tsx
@@ -159,8 +159,6 @@ const Picture: FC<PictureProps> = ({ profile }) => {
   const profilePictureUrl = profile?.picture?.original?.url ?? profile?.picture?.uri;
   const profilePictureIpfsUrl = profilePictureUrl ? imageProxy(getIPFSLink(profilePictureUrl), AVATAR) : '';
 
-  const cropperBorderSize = 20;
-
   return (
     <>
       <Modal
@@ -180,7 +178,6 @@ const Picture: FC<PictureProps> = ({ profile }) => {
           <ImageCropperController
             imageSrc={imageSrc}
             setCroppedAreaPixels={setCroppedAreaPixels}
-            borderSize={cropperBorderSize}
             targetSize={{ width: 300, height: 300 }}
           />
           <Button

--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -249,6 +249,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
       <Modal
         title={t`Crop image`}
         show={showCropModal}
+        size="md"
         onClose={
           isLoading
             ? undefined
@@ -257,7 +258,6 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
                 setShowCropModal(false);
               }
         }
-        size="md"
       >
         <div className="p-5 text-right">
           <ImageCropperController

--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -67,7 +67,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
   const [imageSrc, setImageSrc] = useState('');
   const [showCropModal, setShowCropModal] = useState(false);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
-  const [avatarDataUrl, setAvatarDataUrl] = useState('');
+  const [uploadedImageUrl, setUploadedImageUrl] = useState('');
 
   const onCompleted = () => {
     toast.success(t`Profile updated successfully!`);
@@ -215,7 +215,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
       const ipfsUrl = await uploadCroppedImage(croppedImage);
       const dataUrl = croppedImage.toDataURL('image/png');
       setCover(ipfsUrl);
-      setAvatarDataUrl(dataUrl);
+      setUploadedImageUrl(dataUrl);
     } catch (error) {
       toast.error(t`Upload failed`);
     } finally {
@@ -314,7 +314,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
                   onError={({ currentTarget }) => {
                     currentTarget.src = getIPFSLink(cover);
                   }}
-                  src={avatarDataUrl || coverPictureIpfsUrl}
+                  src={uploadedImageUrl || coverPictureIpfsUrl}
                   alt={cover}
                 />
               </div>

--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -244,8 +244,6 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
   const coverPictureUrl = profile?.coverPicture?.original?.url;
   const coverPictureIpfsUrl = coverPictureUrl ? imageProxy(getIPFSLink(coverPictureUrl), COVER) : '';
 
-  const cropperBorderSize = 20;
-
   return (
     <>
       <Modal
@@ -265,7 +263,6 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
           <ImageCropperController
             imageSrc={imageSrc}
             setCroppedAreaPixels={setCroppedAreaPixels}
-            borderSize={cropperBorderSize}
             targetSize={{ width: 1500, height: 500 }}
           />
           <Button

--- a/apps/web/src/components/UI/Modal.tsx
+++ b/apps/web/src/components/UI/Modal.tsx
@@ -7,7 +7,7 @@ import { Fragment } from 'react';
 interface ModalProps {
   icon?: ReactNode;
   title?: ReactNode;
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'fit-content';
+  size?: 'xs' | 'sm' | 'md' | 'lg';
   show: boolean;
   children: ReactNode[] | ReactNode;
   dataTestId?: string;
@@ -55,11 +55,11 @@ export const Modal: FC<ModalProps> = ({
           >
             <div
               className={clsx(
-                { 'w-full sm:max-w-5xl': size === 'lg' },
-                { 'w-full sm:max-w-3xl': size === 'md' },
-                { 'w-full sm:max-w-lg': size === 'sm' },
-                { 'w-full sm:max-w-sm': size === 'xs' },
-                'inline-block transform rounded-xl bg-white text-left align-bottom shadow-xl transition-all dark:bg-gray-800 sm:my-8 sm:align-middle'
+                { 'sm:max-w-5xl': size === 'lg' },
+                { 'sm:max-w-3xl': size === 'md' },
+                { 'sm:max-w-lg': size === 'sm' },
+                { 'sm:max-w-sm': size === 'xs' },
+                'inline-block w-full transform rounded-xl bg-white text-left align-bottom shadow-xl transition-all dark:bg-gray-800 sm:my-8 sm:align-middle'
               )}
             >
               {title && (

--- a/apps/web/src/lib/profilePictureUtils.ts
+++ b/apps/web/src/lib/profilePictureUtils.ts
@@ -1,0 +1,22 @@
+import uploadToIPFS from './uploadToIPFS';
+
+export function readFile(file: Blob): Promise<string> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.addEventListener('load', () => resolve(reader.result as string), false);
+    reader.readAsDataURL(file);
+  });
+}
+
+const uploadCroppedImage = async (image: HTMLCanvasElement): Promise<string> => {
+  const blob = await new Promise((resolve) => image.toBlob(resolve));
+  let file = new File([blob as Blob], 'cropped_image.png', { type: (blob as Blob).type });
+  const attachment = await uploadToIPFS([file]);
+  const ipfsUrl = attachment[0]?.item;
+  if (!ipfsUrl) {
+    throw new Error('uploadToIPFS failed');
+  }
+  return ipfsUrl;
+};
+
+export default uploadCroppedImage;

--- a/packages/image-cropper/package.json
+++ b/packages/image-cropper/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --fix --ext .ts"
+    "lint": "eslint . --ext .ts,.tsx",
+    "lint:fix": "eslint . --fix --ext .ts,.tsx"
   },
   "dependencies": {
     "normalize-wheel": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3259,6 +3259,11 @@
     "@json-rpc-tools/types" "^1.7.6"
     "@pedrouid/environment" "^1.0.1"
 
+"@juggle/resize-observer@^3.3.1":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
+  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
+
 "@ledgerhq/connect-kit-loader@^1.0.1":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.0.2.tgz#8554e16943f86cc2a5f6348a14dfe6e5bd0c572a"
@@ -12284,6 +12289,13 @@ urlpattern-polyfill@^6.0.2:
   integrity sha512-5vZjFlH9ofROmuWmXM9yj2wljYKgWstGwe8YTyiqM7hVum/g9LyCizPZtb3UqsuppVwety9QJmfc42VggLpTgg==
   dependencies:
     braces "^3.0.2"
+
+use-resize-observer@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/use-resize-observer/-/use-resize-observer-9.1.0.tgz#14735235cf3268569c1ea468f8a90c5789fc5c6c"
+  integrity sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==
+  dependencies:
+    "@juggle/resize-observer" "^3.3.1"
 
 use-sync-external-store@1.2.0, use-sync-external-store@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## What does this PR do?

Use the image cropper when uploading a cover picture on profile settings page.
Add dynamic resizing to image cropper, to fit the with of the modal, which may change when user resizes browser, etc.

Fixes #2110

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)

## How should this be tested?

Visit Profile settings > Profile > Cover > Choose file
In the modal that pops up, crop the image and click Upload. Modal will close.
Click Save
Go to profile page and verify that the cover image is updated with the cropped image.