### PR TITLE
fix: change bolt icon to bell icon for notification in navbar

### DIFF
--- a/apps/web/src/components/Notification/FeedType.tsx
+++ b/apps/web/src/components/Notification/FeedType.tsx
@@ -1,11 +1,5 @@
 import TabButton from '@components/UI/TabButton';
-import {
-  AtSymbolIcon,
-  ChatAlt2Icon,
-  CollectionIcon,
-  HeartIcon,
-  LightningBoltIcon
-} from '@heroicons/react/outline';
+import { AtSymbolIcon, BellIcon, ChatAlt2Icon, CollectionIcon, HeartIcon } from '@heroicons/react/outline';
 import { Mixpanel } from '@lib/mixpanel';
 import { t } from '@lingui/macro';
 import type { Dispatch, FC } from 'react';
@@ -30,7 +24,7 @@ const FeedType: FC<FeedTypeProps> = ({ setFeedType, feedType }) => {
       <div className="mt-3 flex gap-3 overflow-x-auto px-5 pb-2 sm:mt-0 sm:px-0 md:pb-0">
         <TabButton
           name={t`All notifications`}
-          icon={<LightningBoltIcon className="h-4 w-4" />}
+          icon={<BellIcon className="h-4 w-4" />}
           active={feedType === NotificationType.All}
           type={NotificationType.All.toLowerCase()}
           onClick={() => switchTab(NotificationType.All)}

--- a/apps/web/src/components/Notification/List.tsx
+++ b/apps/web/src/components/Notification/List.tsx
@@ -1,6 +1,6 @@
 import { EmptyState } from '@components/UI/EmptyState';
 import { ErrorMessage } from '@components/UI/ErrorMessage';
-import { LightningBoltIcon } from '@heroicons/react/outline';
+import { BellIcon } from '@heroicons/react/outline';
 import { t } from '@lingui/macro';
 import type {
   NewCollectNotification,
@@ -98,11 +98,7 @@ const List: FC<ListProps> = ({ feedType }) => {
 
   if (notifications?.length === 0) {
     return (
-      <EmptyState
-        message={t`Inbox zero!`}
-        icon={<LightningBoltIcon className="text-brand h-8 w-8" />}
-        hideCard
-      />
+      <EmptyState message={t`Inbox zero!`} icon={<BellIcon className="text-brand h-8 w-8" />} hideCard />
     );
   }
 

--- a/apps/web/src/components/Notification/NotificationIcon.tsx
+++ b/apps/web/src/components/Notification/NotificationIcon.tsx
@@ -1,4 +1,4 @@
-import { LightningBoltIcon } from '@heroicons/react/outline';
+import { BellIcon } from '@heroicons/react/outline';
 import { CustomFiltersTypes, useNotificationCountQuery } from 'lens';
 import Link from 'next/link';
 import type { FC } from 'react';
@@ -33,7 +33,7 @@ const NotificationIcon: FC = () => {
         setShowBadge(false);
       }}
     >
-      <LightningBoltIcon className="h-5 w-5 sm:h-6 sm:w-6" />
+      <BellIcon className="h-5 w-5 sm:h-6 sm:w-6" />
       {showBadge && <span className="h-2 w-2 rounded-full bg-red-500" />}
     </Link>
   );

--- a/apps/web/src/components/Shared/Navbar/BottomNavigation.tsx
+++ b/apps/web/src/components/Shared/Navbar/BottomNavigation.tsx
@@ -1,7 +1,7 @@
-import { HomeIcon, LightningBoltIcon, MailIcon, ViewGridIcon } from '@heroicons/react/outline';
+import { BellIcon, HomeIcon, MailIcon, ViewGridIcon } from '@heroicons/react/outline';
 import {
+  BellIcon as BellIconSolid,
   HomeIcon as HomeIconSolid,
-  LightningBoltIcon as LightningBoltIconSolid,
   MailIcon as MailIconSolid,
   ViewGridIcon as ViewGridIconSolid
 } from '@heroicons/react/solid';
@@ -32,9 +32,9 @@ const BottomNavigation = () => {
         </Link>
         <Link href="/notifications" className="my-3 mx-auto">
           {isActivePath('/notifications') ? (
-            <LightningBoltIconSolid className="text-brand-500 h-6 w-6" />
+            <BellIconSolid className="text-brand-500 h-6 w-6" />
           ) : (
-            <LightningBoltIcon className="h-6 w-6" />
+            <BellIcon className="h-6 w-6" />
           )}
         </Link>
         <Link href="/messages" className="my-3 mx-auto">


### PR DESCRIPTION
## What does this PR do?

Fixes #2172

New look:
![newicon](https://user-images.githubusercontent.com/667227/227588038-4e866fb0-6d48-4718-8d40-c0e4f533eeb7.png)

Note: I think the bell icon in Heroicons V2 looks a bit better:
![bell_v2](https://user-images.githubusercontent.com/667227/227588260-26893bb0-8579-4e1c-bfef-25da49ed7713.png)

But then we would need to switch to V2, which would change all other icons too, so it may not be desired right now.

## Type of change

- [x] Enhancement (non-breaking small changes to existing functionality)
