### PR TITLE
fix: let NftPicture set the correct chain ID

### DIFF
--- a/apps/web/src/components/Settings/Profile/NftPicture.tsx
+++ b/apps/web/src/components/Settings/Profile/NftPicture.tsx
@@ -42,7 +42,7 @@ const NftPicture: FC<NftPictureProps> = ({ profile }) => {
   const userSigNonce = useAppStore((state) => state.userSigNonce);
   const setUserSigNonce = useAppStore((state) => state.setUserSigNonce);
   const currentProfile = useAppStore((state) => state.currentProfile);
-  const [chainId, setChainId] = useState<number>(mainnet.id);
+  const [chainId, setChainId] = useState<number>(profile?.picture?.chainId || mainnet.id);
   const { isLoading: signLoading, signTypedDataAsync } = useSignTypedData({ onError });
   const { signMessageAsync } = useSignMessage();
 

--- a/packages/lens/documents/queries/ProfileSettings.graphql
+++ b/packages/lens/documents/queries/ProfileSettings.graphql
@@ -25,6 +25,7 @@ query ProfileSettings($request: SingleProfileQueryRequest!) {
         uri
         tokenId
         contractAddress
+        chainId
       }
     }
   }

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -19538,7 +19538,7 @@ export type ProfileSettingsQuery = {
       | null;
     picture?:
       | { __typename?: 'MediaSet'; original: { __typename?: 'Media'; url: any } }
-      | { __typename?: 'NftImage'; uri: any; tokenId: string; contractAddress: any }
+      | { __typename?: 'NftImage'; uri: any; tokenId: string; contractAddress: any; chainId: number }
       | null;
   } | null;
 };
@@ -33798,6 +33798,7 @@ export const ProfileSettingsDocument = gql`
           uri
           tokenId
           contractAddress
+          chainId
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

The default chain ID for the form should be taken from the profile picture if it's been already configured. If not, we should fallback to Mainnet.

Currently, it always shows me Ethereum, even though my NFT avatar is on Polygon. And that's really confusing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

Unfortunately, there are no tests for the settings page. Hopefully, it's trivial enough to be accepted anyway.

## Checklist

- I haven't added tests that prove my fix is effective or that my feature works