### PR TITLE
chore: add missing lint scripts

### DIFF
--- a/packages/lens/package.json
+++ b/packages/lens/package.json
@@ -6,7 +6,9 @@
   "license": "GPL-3.0",
   "scripts": {
     "codegen": "graphql-codegen",
-    "typecheck": "tsc --pretty --noEmit"
+    "typecheck": "tsc --pretty --noEmit",
+    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint:fix": "eslint . --fix --ext .js,.ts,.tsx"
   },
   "dependencies": {
     "@apollo/client": "^3.7.11",

--- a/packages/snapshot/package.json
+++ b/packages/snapshot/package.json
@@ -6,7 +6,9 @@
   "license": "GPL-3.0",
   "scripts": {
     "codegen": "graphql-codegen",
-    "typecheck": "tsc --pretty --noEmit"
+    "typecheck": "tsc --pretty --noEmit",
+    "lint": "eslint . --ext .js,.ts,.tsx",
+    "lint:fix": "eslint . --fix --ext .js,.ts,.tsx"
   },
   "dependencies": {
     "@apollo/client": "^3.7.11",


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e06487</samp>

This pull request adds `lint` and `lint:fix` scripts to the `package.json` files of the `lens` and `snapshot` packages. These scripts run eslint on the source files to enforce consistent coding style and quality.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e06487</samp>

*  Add linting scripts to `lens` and `snapshot` packages ([link](https://github.com/lensterxyz/lenster/pull/2405/files?diff=unified&w=0#diff-844e7e7237755894506b2221ff9dea76ae4f4b5c336c3f2473d3f7ea9d19c9c1L9-R11), [link](https://github.com/lensterxyz/lenster/pull/2405/files?diff=unified&w=0#diff-7ce58c543d1dad86fa444289b592b1a0403e2dbd9278c81c1d1908366a23a8a3L9-R11))

## Emoji

<!--
copilot:emoji
-->

🧹🛠️🚚

<!--
1.  🧹 - This emoji represents the linting and cleaning up of the code, as well as the fixing of any issues. It conveys the idea of improving the code quality and making it more readable and maintainable.
2.  🛠️ - This emoji represents the addition of new scripts and tools to the package, as well as the modification of existing ones. It conveys the idea of enhancing the development workflow and adding more functionality and features to the package.
3.  🚚 - This emoji represents the copying of the same scripts and tools from one package to another, as well as the synchronization of the code between the two packages. It conveys the idea of moving and sharing resources and code across the monorepo and ensuring consistency and compatibility between the packages.
-->
