### PR TITLE
chore: add unstable_runtimeJS to speed prerender app

### DIFF
--- a/apps/prerender/src/pages/posts/[id].tsx
+++ b/apps/prerender/src/pages/posts/[id].tsx
@@ -9,6 +9,10 @@ import {
 import { nodeClient } from 'lens/apollo';
 import type { GetServerSidePropsContext } from 'next';
 
+export const config = {
+  unstable_runtimeJS: false
+};
+
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const id = context.params?.id;
 

--- a/apps/prerender/src/pages/u/[handle].tsx
+++ b/apps/prerender/src/pages/u/[handle].tsx
@@ -4,6 +4,10 @@ import { CustomFiltersTypes, ProfileDocument, ProfileFeedDocument } from 'lens';
 import { nodeClient } from 'lens/apollo';
 import type { GetServerSidePropsContext } from 'next';
 
+export const config = {
+  unstable_runtimeJS: false
+};
+
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const handle = context.params?.handle;
 


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c753fb2</samp>

This pull request disables the runtime JavaScript for two page components, `posts/[id].tsx` and `u/[handle].tsx`, in the `prerender` app. This improves the performance and SEO of these pages, as they only render static content.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c753fb2</samp>

*  Disable runtime JavaScript for two static pages (`config` in [link](https://github.com/lensterxyz/lenster/pull/2447/files?diff=unified&w=0#diff-21ccb9b3dc1427c7e20f80056ed2abce0deee24aecf5d25ca9a3cd0e17573649R12-R15) and [link](https://github.com/lensterxyz/lenster/pull/2447/files?diff=unified&w=0#diff-fb8214ba9b2f45ac4262b9b58717164f4201af0b5c33fb3f8feb175138449728R7-R10))

## Emoji

<!--
copilot:emoji
-->

🚀🕷️🔥

<!--
1.  🚀 - This emoji represents the performance improvement and speed boost that the changes bring to the page loading and rendering.
2.  🕷️ - This emoji represents the SEO benefit and crawlability of the pages, as they are fully rendered on the server and do not require any JavaScript to display the content.
3.  🔥 - This emoji represents the removal of unnecessary code and resources, as the pages do not need to load or execute any JavaScript bundles or scripts.
-->
