### PR TITLE
chore: add .po to CI ignore list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths-ignore:
       - "**.md"
+      - "**.po"
       - ".github/CODEOWNERS"
       - ".github/FUNDING.yml"
       - ".github/PULL_REQUEST_TEMPLATE.md"


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e49a1dc</samp>

This pull request updates the GitHub workflow to skip the `ci` job when only translation files are changed. This improves the efficiency of the workflow and avoids unnecessary checks for `.po` files.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e49a1dc</samp>

*  Add `paths-ignore` option to `push` trigger in GitHub workflow ([link](https://github.com/lensterxyz/lenster/pull/2450/files?diff=unified&w=0#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR8))

## Emoji

<!--
copilot:emoji
-->

🌐🚫🚀

<!--
1.  🌐 - This emoji represents the translation or localization aspect of the change, as it is often used to indicate different languages or regions on websites or apps. It also matches the globe icon of the gettext project.
2.  🚫 - This emoji represents the exclusion or ignoring of certain files from the workflow, as it is a common symbol for prohibition or denial. It also conveys the idea of saving resources or avoiding unnecessary actions by skipping the workflow.
3.  🚀 - This emoji represents the workflow or deployment aspect of the change, as it is often used to indicate speed, performance, or automation of tasks. It also suggests that the change will make the workflow more efficient or streamlined by avoiding irrelevant changes.
-->
