### PR TITLE
feat: add kannada language

### DIFF
--- a/apps/web/.linguirc
+++ b/apps/web/.linguirc
@@ -23,7 +23,8 @@
     "en",
     "es",
     "ta",
-    "zh"
+    "zh",
+    "kn"
   ],
   "sourceLocale": "en",
   "fallbackLocales": {

--- a/apps/web/src/components/Shared/Footer/Locale.tsx
+++ b/apps/web/src/components/Shared/Footer/Locale.tsx
@@ -14,7 +14,7 @@ import MenuTransition from '../MenuTransition';
 const Locale: FC = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const { i18n } = useLingui();
-  const gatedLocales = ['ta', 'es'];
+  const gatedLocales = ['ta', 'es', 'kn'];
   const locales = Object.fromEntries(
     Object.entries(supportedLocales).filter(([key]) =>
       isFeatureEnabled('gated-locales', currentProfile?.id) ? true : !gatedLocales.includes(key)

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -7,7 +7,8 @@ export const supportedLocales: Record<string, string> = {
   en: 'English',
   es: 'Spanish - Español',
   ta: 'Tamil - தமிழ்',
-  zh: 'Chinese - 中文'
+  zh: 'Chinese - 中文',
+  kn: 'Kannada - ಕನ್ನಡ'
 };
 
 const defaultLocale = 'en';

--- a/packages/data/lenster-members.ts
+++ b/packages/data/lenster-members.ts
@@ -1,4 +1,5 @@
 export const lensterMembers = [
+  '0x01b69c', // sagargowda.lens
   '0x0d', // yoginth.lens
   '0x0c' // lenster.lens
 ];

--- a/packages/data/staffs.ts
+++ b/packages/data/staffs.ts
@@ -1,9 +1,11 @@
+import { lensterMembers } from './lenster-members';
+
 export const mainnetStaffs = [
   '0x2d', // sasicodes.lens
-  '0x16', // davidev.lens,
+  '0x16', // davidev.lens
   '0x06', // wagmi.lens
   '0x05', // stani.lens
-  '0x0d' // yoginth.lens
+  ...lensterMembers
 ];
 
 export const testnetStaffs = [

--- a/packages/data/verified.ts
+++ b/packages/data/verified.ts
@@ -11,7 +11,6 @@ export const mainnetVerified = [
   '0x01852a', // beatsapp.lens
   '0x01c48b', // soundxyz_.lens
   '0x01bff3', // glassxyz.lens
-  '0x01b69c', // sagargowda.lens
   '0x8a58', // fabri.lens
   '0x01bc17', // argent.lens
   '0x01ab4f', // therugofficial.lens


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5579c28</samp>

This pull request adds Kannada language support to the web app and updates the data package to reflect the Lenster membership status of sagargowda.lens. It also removes sagargowda.lens from the verified users list.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5579c28</samp>

*  Enable Kannada language support for the web app ([link](https://github.com/lensterxyz/lenster/pull/2458/files?diff=unified&w=0#diff-a3599e528ca1d0c17da537bea7bd676d91bad764dee256ffd09fafe30fffe187L26-R27), [link](https://github.com/lensterxyz/lenster/pull/2458/files?diff=unified&w=0#diff-2d9af24d277e24d0e5b89b5e09bf7745dd1a4c55b9630b816484d0319313cacbL17-R17), [link](https://github.com/lensterxyz/lenster/pull/2458/files?diff=unified&w=0#diff-a0b11c1dcd224a0790b465ed1cf240b02162b537383602c72fcbc02eb3e6d688L10-R11))
*  Add sagargowda.lens as a Lenster member and grant staff privileges ([link](https://github.com/lensterxyz/lenster/pull/2458/files?diff=unified&w=0#diff-9a8d03c05e39f46256bea17a0a1eec69d1e955553a708ab2e6ad814369e7840aR2), [link](https://github.com/lensterxyz/lenster/pull/2458/files?diff=unified&w=0#diff-1d00c09528308d0b026cd6fe1a20bc27d560aff8dc368ceff7db46627457a1f6L1-R8))
*  Remove sagargowda.lens from the verified users list ([link](https://github.com/lensterxyz/lenster/pull/2458/files?diff=unified&w=0#diff-69bd9eeef6f40b8dd678399c98bd97c89224c70ee5ed8ccabdc96533deff2918L14))

## Emoji

<!--
copilot:emoji
-->

🌐🏅🚫

<!--
1.  🌐 - This emoji represents the addition of a new language support for the web app, which is a global feature that affects the user interface and experience.
2.  🏅 - This emoji represents the gating of a language support for Lenster members only, which is a reward feature that distinguishes the members from the regular users.
3.  🚫 - This emoji represents the removal of a verified status for a user, which is a negative feature that affects the user's access and reputation on the platform.
-->
