### PR TITLE
feat: add metadata tests and update bootstrap and ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,25 +32,8 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "yarn"
 
-      - name: Cache Playwright 📦
-        id: cache-playwright
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/ms-playwright
-            ${{ github.workspace }}/node_modules/playwright
-          key: cache-playwright-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: cache-playwright-
-
-      - name: Install dependencies 📦
-        run: yarn install --frozen-lockfile
-
-      - name: Install Playwright browsers 🕹️
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
-        run: yarn playwright install
-
-      - name: GraphQL Codegen 🕸
-        run: yarn codegen
+      - name: Bootstrap 📦
+        run: script/bootstrap
 
       - name: Typecheck 🔡
         run: yarn typecheck

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prettier:fix": "prettier --write \"**/*.{ts,tsx,md}\"",
     "prepare": "husky install",
     "test:dev": "turbo run test:dev",
-    "test:e2e": "start-server-and-test start '4783|4784' test:dev"
+    "test:e2e": "start-server-and-test start '4783|4784|8083' test:dev"
   },
   "devDependencies": {
     "husky": "^8.0.3",

--- a/packages/workers/metadata/package.json
+++ b/packages/workers/metadata/package.json
@@ -5,6 +5,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "dev": "wrangler dev --port 8083 --local",
+    "start": "dev",
     "worker:deploy": "wrangler publish",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --fix --ext .ts"

--- a/packages/workers/metadata/package.json
+++ b/packages/workers/metadata/package.json
@@ -5,7 +5,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "dev": "wrangler dev --port 8083 --local",
-    "start": "dev",
+    "start": "yarn dev",
     "worker:deploy": "wrangler publish",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --fix --ext .ts"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -27,7 +27,13 @@ cd packages/workers/sts-generator; cp .dev.vars.example .dev.vars
 cd ../../../
 # -------------------------------------
 echo "Installing dependencies 📦"
-yarn install
+yarn install --frozen-lockfile
 echo "Dependencies installed 📦"
+echo "Installing playwright 🎭"
+yarn playwright install
+echo "Playwright installed 🎭"
+echo "GraphQL Codegen 🧬"
+yarn codegen
+echo "GraphQL Codegen complete 🧬"
 # -------------------------------------
 echo "Project bootstrap complete 🎉"

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -1,2 +1,3 @@
 export const WEB_BASE_URL = 'http://localhost:4783';
 export const PRERENDER_BASE_URL = 'http://localhost:4784';
+export const METADATA_BASE_URL = 'http://localhost:8083';

--- a/tests/scripts/packages/workers/metadata.spec.ts
+++ b/tests/scripts/packages/workers/metadata.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+import { METADATA_BASE_URL } from 'test/constants';
+
+const expectedArweaveId = 'JulWV7TSj0BopTFhW0dvdo0ZtRdHFc6Rg-OjhcAWBsY';
+const metatadata = { ping: 'pong' };
+
+test('should upload to arweave', async ({ request }) => {
+  const postMetadata = request.post(METADATA_BASE_URL, {
+    data: metatadata
+  });
+  const response = await (await postMetadata).json();
+
+  expect(response.success).toBeTruthy();
+  expect(response.id).toBe(expectedArweaveId);
+});
+
+test('should have arweave metadata', async ({ request }) => {
+  const arweaveData = request.get(`https://arweave.net/${expectedArweaveId}`);
+  const response = await (await arweaveData).json();
+
+  expect(metatadata.ping).toBe(response.ping);
+});


### PR DESCRIPTION
- feat: test for arweave
- chore: update ci workflow

## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 904fbcb</samp>

The pull request simplifies the CI workflow and the local environment setup by using a bootstrap script that installs playwright and graphql codegen. It also adds a new test file for the metadata service and a constant for the metadata base URL.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 904fbcb</samp>

*  Simplify CI workflow by running bootstrap script instead of separate steps for caching and installing dependencies ([link](https://github.com/lensterxyz/lenster/pull/2463/files?diff=unified&w=0#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL35-R37))
*  Update bootstrap script to install playwright and graphql codegen for local and CI environments ([link](https://github.com/lensterxyz/lenster/pull/2463/files?diff=unified&w=0#diff-2ad9e188678c4f3bef503efff261066b6c9df3a948bcaabe8bc10bdd2f45404aL30-R37))
*  Add constant for metadata base URL to `tests/constants.ts` file ([link](https://github.com/lensterxyz/lenster/pull/2463/files?diff=unified&w=0#diff-7dabe1ac54eca6fa517ae515d90b772ce087aff5e46bac0687c505b298a58e70R3))
*  Update test:e2e script to wait for metadata service on port 8083 ([link](https://github.com/lensterxyz/lenster/pull/2463/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R26))
*  Add end-to-end tests for metadata service using playwright in `tests/scripts/packages/workers/metadata.spec.ts` file ([link](https://github.com/lensterxyz/lenster/pull/2463/files?diff=unified&w=0#diff-ec9cfd19e2fec2560817224e83a2a50124eeed74a89ff3e0949239535018851dR1-R22))

## Emoji

<!--
copilot:emoji
-->

🚀🧪📝

<!--
1.  🚀 - This emoji represents the improvement in the workflow speed and simplicity by using the bootstrap script.
2.  🧪 - This emoji represents the addition of new tests for the metadata service using playwright.
3.  📝 - This emoji represents the creation of a constant for the metadata base URL and the generated code from graphql codegen.
-->
