### PR TITLE
chore: add publication prerender test cases

### DIFF
--- a/apps/prerender/src/components/Publication.tsx
+++ b/apps/prerender/src/components/Publication.tsx
@@ -49,7 +49,7 @@ const Publication: FC<PublicationProps> = ({ publication, comments }) => {
       <header>
         <SinglePublication publication={publication} h1Content />
       </header>
-      <div data-testid="publication-comment-feed">
+      <div data-testid="comment-feed">
         {comments?.map((comment) => {
           const { id } = comment;
           return (

--- a/apps/prerender/src/components/Shared/SinglePublication.tsx
+++ b/apps/prerender/src/components/Shared/SinglePublication.tsx
@@ -43,7 +43,7 @@ const SinglePublication: FC<PublicationProps> = ({ publication, h1Content = fals
           <img alt={`@${formatHandle(profile.handle)}'s avatar`} src={avatar} width="64" />
         </a>
       </div>
-      <div>
+      <div data-testid={`publication-${publicationId}`}>
         <div>
           <a href={`${BASE_URL}/u/${formatHandle(profile.handle)}`}>{profile.name ?? profile.handle}</a>
         </div>

--- a/tests/scripts/apps/prerender/publication.spec.ts
+++ b/tests/scripts/apps/prerender/publication.spec.ts
@@ -9,3 +9,11 @@ test.beforeEach(async ({ page }) => {
 test('should have page title', async ({ page }) => {
   await expect(page).toHaveTitle(`Post by @yoginth.lens • ${APP_NAME}`);
 });
+
+test('should have publication', async ({ page }) => {
+  await expect(page.getByTestId('publication-0x0d-0x01')).toContainText('gm frens 👋');
+});
+
+test('should have comment feed', async ({ page }) => {
+  await expect(page.getByTestId('comment-feed')).toBeVisible();
+});


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2989e4</samp>

The pull request adds data-testid attributes to some elements in the `Publication` and `SinglePublication` components to improve testing. It also updates the `publication.spec.ts` file to include tests that use these attributes.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e2989e4</samp>

*  Add data-testid attributes to publication and comment feed elements to enable testing ([link](https://github.com/lensterxyz/lenster/pull/2480/files?diff=unified&w=0#diff-46fab1c139f7ed9605d595a0721066c04b669efbf4a296c1aa257da9eea0d9b6L52-R52), [link](https://github.com/lensterxyz/lenster/pull/2480/files?diff=unified&w=0#diff-6e795da8cb06fb5316f3c91b8cc21cb973029f189395f24ea074b55ba5ada4bdL46-R46))
*  Write tests to verify publication and comment feed rendering using data-testid attributes ([link](https://github.com/lensterxyz/lenster/pull/2480/files?diff=unified&w=0#diff-1c01441b50b7323115c077884dbe4f4884556d3b52388ba3c2864359d295fdccR12-R19))

## Emoji

<!--
copilot:emoji
-->

🔄➕✅

<!--
1.  🔄 - This emoji represents the change of the data-testid attribute of the comment feed, which is a refactoring or improvement of the existing code.
2.  ➕ - This emoji represents the addition of the data-testid attribute of the publication content, which is a new feature or enhancement of the component.
3.  ✅ - This emoji represents the addition of the two tests, which is a verification or validation of the component's functionality.
-->
