### PR TITLE
fix: allow only basic and single choice voting

### DIFF
--- a/apps/web/src/components/Shared/Snapshot/Choices.tsx
+++ b/apps/web/src/components/Shared/Snapshot/Choices.tsx
@@ -27,7 +27,7 @@ const Choices: FC<ChoicesProps> = ({ proposal, votes, refetch }) => {
     position: 0
   });
 
-  const { choices, scores, scores_total, state } = proposal;
+  const { choices, scores, scores_total, state, type } = proposal;
   const vote = votes[0];
   const choicesWithVote = choices.map((choice, index) => ({
     position: index + 1,
@@ -48,6 +48,10 @@ const Choices: FC<ChoicesProps> = ({ proposal, votes, refetch }) => {
 
     if (state !== 'active') {
       return toast.error(t`This proposal is closed!`);
+    }
+
+    if (type === 'approval' || type === 'quadratic' || type === 'ranked-choice' || type === 'weighted') {
+      return toast.error(t`${type} voting is not supported yet!`);
     }
 
     setVoteConfig({ show: true, position });

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -29,8 +29,8 @@ export type Scalars = {
   FollowModuleData: any;
   Handle: any;
   HandleClaimIdScalar: any;
-  IfpsCid: any;
   InternalPublicationId: any;
+  IpfsCid: any;
   Jwt: any;
   LimitScalar: any;
   Locale: any;
@@ -3119,7 +3119,7 @@ export type PublicMediaRequest = {
   /** The cover for any video or audio you attached */
   cover?: InputMaybe<Scalars['Url']>;
   /** Pre calculated cid of the file to push */
-  itemCid: Scalars['IfpsCid'];
+  itemCid: Scalars['IpfsCid'];
   /** This is the mime type of media */
   type?: InputMaybe<Scalars['MimeType']>;
 };

--- a/packages/snapshot/Snapshot.graphql
+++ b/packages/snapshot/Snapshot.graphql
@@ -10,6 +10,7 @@ query Snapshot($id: String, $where: VoteWhere) {
     snapshot
     symbol
     network
+    type
     space {
       id
       name

--- a/packages/snapshot/generated.ts
+++ b/packages/snapshot/generated.ts
@@ -522,6 +522,7 @@ export type SnapshotQuery = {
     snapshot?: string | null;
     symbol: string;
     network: string;
+    type?: string | null;
     space?: { __typename?: 'Space'; id: string; name?: string | null } | null;
     strategies: Array<{
       __typename?: 'Strategy';
@@ -556,6 +557,7 @@ export const SnapshotDocument = gql`
       snapshot
       symbol
       network
+      type
       space {
         id
         name


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b706504</samp>

Added a `type` field to snapshots and proposals to support different voting methods. Updated the frontend components, GraphQL schema, and generated code to use the new field.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b706504</samp>

*  Add `type` field to `SnapshotProposal` type to indicate voting method ([link](https://github.com/lensterxyz/lenster/pull/2484/files?diff=unified&w=0#diff-78be225821314405505f7cf069f94d6219cc15c41b53b9f273f1c8f2ac12171fR13))
*  Generate TypeScript types and hooks for `Snapshot` query with `type` field ([link](https://github.com/lensterxyz/lenster/pull/2484/files?diff=unified&w=0#diff-5621065a29dec1dcda1b13a09c157b9f954146ceaee71708bde7c2ae426dfb70R525), [link](https://github.com/lensterxyz/lenster/pull/2484/files?diff=unified&w=0#diff-5621065a29dec1dcda1b13a09c157b9f954146ceaee71708bde7c2ae426dfb70R560))
*  Destructure `type` field from `proposal` object in `Choices` component ([link](https://github.com/lensterxyz/lenster/pull/2484/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3L30-R30))
*  Display error message if `type` is not `single-choice` in `Choices` component ([link](https://github.com/lensterxyz/lenster/pull/2484/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3R53-R56))

## Emoji

<!--
copilot:emoji
-->

🆕🗳️🔧

<!--
1.  🆕 - This emoji represents the addition of a new field to the `SnapshotProposal` type and the `Snapshot` query. It conveys that the changes are introducing something new to the schema and the frontend logic.
2.  🗳️ - This emoji represents the voting-related aspect of the changes. It conveys that the changes are related to the core functionality of Snapshot, which is to enable decentralized governance through voting on proposals.
3.  🔧 - This emoji represents the validation and preparation of the `Choices` component for different voting methods. It conveys that the changes are improving the robustness and flexibility of the component.
-->
