### PR TITLE
chore: remove snapshot url from the pub content

### DIFF
--- a/apps/web/src/components/Publication/PublicationBody.tsx
+++ b/apps/web/src/components/Publication/PublicationBody.tsx
@@ -23,6 +23,10 @@ const PublicationBody: FC<PublicationBodyProps> = ({ publication }) => {
   const showMore = publication?.metadata?.content?.length > 450 && pathname !== '/posts/[id]';
   const hasURLs = getURLs(publication?.metadata?.content)?.length > 0;
   const snapshotProposalId = hasURLs && getSnapshotProposalId(getURLs(publication?.metadata?.content)[0]);
+  let content = publication?.metadata?.content;
+  if (snapshotProposalId) {
+    content = content?.replace(getURLs(publication?.metadata?.content)[0], '');
+  }
 
   if (publication?.metadata?.encryptionParams) {
     return <DecryptedPublicationBody encryptedPublication={publication} />;
@@ -31,7 +35,7 @@ const PublicationBody: FC<PublicationBodyProps> = ({ publication }) => {
   return (
     <div className="break-words">
       <Markup className={clsx({ 'line-clamp-5': showMore }, 'markup linkify text-md break-words')}>
-        {publication?.metadata?.content}
+        {content}
       </Markup>
       {showMore && (
         <div className="lt-text-gray-500 mt-4 flex items-center space-x-1 text-sm font-bold">


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 165fef4</samp>

Refactor publication content rendering to support snapshot proposals. Extract `content` variable from `props.content` and strip snapshot link if present.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 165fef4</samp>

*  Add `content` variable to store publication content and remove snapshot link if present ([link](https://github.com/lensterxyz/lenster/pull/2488/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1R26-R29))
*  Use `content` variable instead of `publication?.metadata?.content` in `Markup` component to display publication body ([link](https://github.com/lensterxyz/lenster/pull/2488/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1L34-R38))

## Emoji

<!--
copilot:emoji
-->

🔄🆕🖼️

<!--
1.  🔄 - This emoji represents the refactoring aspect of the change, which modifies existing code to improve its structure or performance without altering its functionality or behavior.
2.  🆕 - This emoji represents the new feature aspect of the change, which adds support for snapshot proposals that have a different content format than regular proposals.
3.  🖼️ - This emoji represents the visual aspect of the change, which affects how the publication content is displayed on the UI with or without the snapshot link.
-->
