### PR TITLE
fix: test cases by remove tightly coupled publication ids

### DIFF
--- a/apps/web/src/components/Publication/PublicationStats.tsx
+++ b/apps/web/src/components/Publication/PublicationStats.tsx
@@ -39,16 +39,12 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
     <div className="lt-text-gray-500 flex flex-wrap items-center gap-6 py-3 text-sm sm:gap-8">
       {mirrorCount > 0 && (
         <>
-          <span data-testid={`publication-${publication.id}-comment-stats`}>
+          <span data-testid="comment-stats">
             <Trans>
               <b className="text-black dark:text-white">{nFormatter(commentsCount)}</b> Comments
             </Trans>
           </span>
-          <button
-            type="button"
-            onClick={() => setShowMirrorsModal(true)}
-            data-testid={`publication-${publication.id}-mirror-stats`}
-          >
+          <button type="button" onClick={() => setShowMirrorsModal(true)} data-testid="mirror-stats">
             <Trans>
               <b className="text-black dark:text-white">{nFormatter(mirrorCount)}</b> Mirrors
             </Trans>
@@ -65,11 +61,7 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
       )}
       {!hideLikesCount && reactionCount > 0 && (
         <>
-          <button
-            type="button"
-            onClick={() => setShowLikesModal(true)}
-            data-testid={`publication-${publication.id}-like-stats`}
-          >
+          <button type="button" onClick={() => setShowLikesModal(true)} data-testid="like-stats">
             <Trans>
               <b className="text-black dark:text-white">{nFormatter(reactionCount)}</b> Likes
             </Trans>
@@ -86,11 +78,7 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
       )}
       {collectCount > 0 && (
         <>
-          <button
-            type="button"
-            onClick={() => setShowCollectorsModal(true)}
-            data-testid={`publication-${publication.id}-collect-stats`}
-          >
+          <button type="button" onClick={() => setShowCollectorsModal(true)} data-testid="collect-stats">
             <Trans>
               <b className="text-black dark:text-white">{nFormatter(collectCount)}</b> Collects
             </Trans>

--- a/tests/scripts/apps/web/publication.spec.ts
+++ b/tests/scripts/apps/web/publication.spec.ts
@@ -49,12 +49,12 @@ test.describe('Publication', () => {
 
   test.describe('Publication stats', async () => {
     test('should have comment stats', async ({ page }) => {
-      const publicationCommentStats = page.getByTestId('publication-0x0d-0x01-comment-stats');
+      const publicationCommentStats = page.getByTestId('publication-0x0d-0x01').getByTestId('comment-stats');
       await expect(publicationCommentStats).toContainText('Comments');
     });
 
     test('should have mirror stats', async ({ page }) => {
-      const publicationMirrorStats = page.getByTestId('publication-0x0d-0x01-mirror-stats');
+      const publicationMirrorStats = page.getByTestId('publication-0x0d-0x01').getByTestId('mirror-stats');
       await expect(publicationMirrorStats).toContainText('Mirror');
 
       // click mirror stats and check if it opens mirror modal
@@ -64,7 +64,7 @@ test.describe('Publication', () => {
     });
 
     test('should have like stats', async ({ page }) => {
-      const publicationLikeStats = page.getByTestId('publication-0x0d-0x01-like-stats');
+      const publicationLikeStats = page.getByTestId('publication-0x0d-0x01').getByTestId('like-stats');
       await expect(publicationLikeStats).toContainText('Likes');
 
       // click like stats and check if it opens likes modal
@@ -74,7 +74,7 @@ test.describe('Publication', () => {
     });
 
     test('should have collect stats', async ({ page }) => {
-      const publicationCollectStats = page.getByTestId('publication-0x0d-0x01-collect-stats');
+      const publicationCollectStats = page.getByTestId('publication-0x0d-0x01').getByTestId('collect-stats');
       await expect(publicationCollectStats).toContainText('Collects');
 
       // click collect stats and check if it opens collectors modal
@@ -95,10 +95,13 @@ test.describe('Publication', () => {
 
 test.describe('Publication attachments', () => {
   test('should have publication image', async ({ page }) => {
-    await page.goto(`${WEB_BASE_URL}/posts/0x0d-0x037d`);
+    const publicationId = '0x0d-0x037d';
+    await page.goto(`${WEB_BASE_URL}/posts/${publicationId}`);
 
     const imageURL = `${IPFS_GATEWAY}bafybeihztcpkzhzc3fddsc66r22hzsztja6blflygurlft7lmc4l44pnre`;
-    const publicationImage = page.getByTestId(`attachment-image-${imageURL}`);
+    const publicationImage = page
+      .getByTestId(`publication-${publicationId}`)
+      .getByTestId(`attachment-image-${imageURL}`);
     await expect(publicationImage).toBeVisible();
 
     // click image and check if it opens image lightbox and original image
@@ -110,15 +113,19 @@ test.describe('Publication attachments', () => {
   });
 
   test('should have publication video', async ({ page }) => {
-    await page.goto(`${WEB_BASE_URL}/posts/0x01-0x01`);
+    const publicationId = '0x01-0x01';
+    await page.goto(`${WEB_BASE_URL}/posts/${publicationId}`);
 
     const videoURL = 'https://lens.infura-ipfs.io/ipfs/QmSPijepBo81hDLZ54qg3bKC2DpV9VFdaDJ81Y2viPHCRZ';
-    const publicationVideo = page.getByTestId(`attachment-video-${videoURL}`);
+    const publicationVideo = page
+      .getByTestId(`publication-${publicationId}`)
+      .getByTestId(`attachment-video-${videoURL}`);
     await expect(publicationVideo).toBeVisible();
   });
 
   test('should have publication audio', async ({ page }) => {
-    await page.goto(`${WEB_BASE_URL}/posts/0x0d-0x01ec`);
+    const publicationId = '0x0d-0x01ec';
+    await page.goto(`${WEB_BASE_URL}/posts/${publicationId}`);
 
     const audioURL = `${IPFS_GATEWAY}bafybeihabco35vpefrlgzx3rvxccfx4th6ti5ktidw2tf5vjmnmjwx5ki4`;
     const coverURL = `${IPFS_GATEWAY}bafkreibljzow3cbr4kirujjc5ldxbcykgahjuwuc5zmfledisq4sizwhyq`;
@@ -126,7 +133,9 @@ test.describe('Publication attachments', () => {
     await expect(publicationAudio).toBeVisible();
 
     // check if audio cover image is visible
-    const publicationAudioCover = page.getByTestId(`attachment-audio-cover-${coverURL}`);
+    const publicationAudioCover = page
+      .getByTestId(`publication-${publicationId}`)
+      .getByTestId(`attachment-audio-cover-${coverURL}`);
     await expect(publicationAudioCover).toHaveAttribute(
       'src',
       `${USER_CONTENT_URL}/${ATTACHMENT}/${coverURL}`
@@ -135,28 +144,34 @@ test.describe('Publication attachments', () => {
 
   test.describe('Publication oembed', () => {
     test('should have normal oembed', async ({ page }) => {
-      await page.goto(`${WEB_BASE_URL}/posts/0x0d-0x0375`);
+      const publicationId = '0x0d-0x0375';
+      await page.goto(`${WEB_BASE_URL}/posts/${publicationId}`);
 
-      const publicationOembed = page.getByTestId('normal-oembed-https://testflight.apple.com/join/U9YkOlOy');
+      const publicationOembed = page
+        .getByTestId(`publication-${publicationId}`)
+        .getByTestId('normal-oembed-https://testflight.apple.com/join/U9YkOlOy');
       await expect(publicationOembed).toBeVisible();
     });
 
     test('should have rich oembed', async ({ page }) => {
-      await page.goto(`${WEB_BASE_URL}/posts/0x0d-0x02fb`);
+      const publicationId = '0x0d-0x02fb';
+      await page.goto(`${WEB_BASE_URL}/posts/${publicationId}`);
 
-      const publicationOembed = page.getByTestId('rich-oembed-https://lenstube.xyz/watch/0x24-0xe8');
+      const publicationOembed = page
+        .getByTestId(`publication-${publicationId}`)
+        .getByTestId('rich-oembed-https://lenstube.xyz/watch/0x24-0xe8');
       await expect(publicationOembed).toBeVisible();
     });
   });
 
   test.describe('Publication snapshot widget', () => {
-    test('should have normal oembed', async ({ page }) => {
-      await page.goto(`${WEB_BASE_URL}/posts/0x0c-0x2c`);
+    test('should have snapshot oembed', async ({ page }) => {
+      const publicationId = '0x0c-0x2c';
+      await page.goto(`${WEB_BASE_URL}/posts/${publicationId}`);
 
-      const snapshotWidget = page.getByTestId(
-        'snapshot-0x9287c40edcd68c362c7c4139fe3489bbaaa27cf4de68be5c218a82d0f252e718'
-      );
-      await page.waitForTimeout(10000);
+      const snapshotWidget = page
+        .getByTestId(`publication-${publicationId}`)
+        .getByTestId('snapshot-0x9287c40edcd68c362c7c4139fe3489bbaaa27cf4de68be5c218a82d0f252e718');
       await expect(snapshotWidget).toContainText('Do you like the Snapshot integration with Lenster?');
       await expect(snapshotWidget).toContainText('Yes ser 🙌');
     });


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddd5e39</samp>

This pull request refactors the data-testid attributes and the tests for the `PublicationStats` component in the web app. It improves the readability and reliability of the code and the tests by using shorter and more consistent identifiers and avoiding hard-coded values.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ddd5e39</samp>

*  Simplify data-testid attributes of comment, mirror, like, and collect stats elements in `PublicationStats.tsx` ([link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-5826830061471498bb1147c05f83995f283dc9023c80c91b16a0aeb5aebe0702L42-R47), [link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-5826830061471498bb1147c05f83995f283dc9023c80c91b16a0aeb5aebe0702L68-R64), [link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-5826830061471498bb1147c05f83995f283dc9023c80c91b16a0aeb5aebe0702L89-R81))
* Update tests for comment, mirror, like, and collect stats elements in `publication.spec.ts` to use getByTestId method twice with parent and child elements ([link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-2775dea7fc7bbd6b15d61cfd5a12116e8fb8c4c0ebc3bc1c7e87d20fe93f7ea5L52-R57), [link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-2775dea7fc7bbd6b15d61cfd5a12116e8fb8c4c0ebc3bc1c7e87d20fe93f7ea5L67-R67), [link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-2775dea7fc7bbd6b15d61cfd5a12116e8fb8c4c0ebc3bc1c7e87d20fe93f7ea5L77-R77))
* Use variables for publication ids in tests for publication image, video, audio, audio cover, oembeds, and snapshot widget in `publication.spec.ts` to avoid repetition ([link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-2775dea7fc7bbd6b15d61cfd5a12116e8fb8c4c0ebc3bc1c7e87d20fe93f7ea5L98-R104), [link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-2775dea7fc7bbd6b15d61cfd5a12116e8fb8c4c0ebc3bc1c7e87d20fe93f7ea5L113-R128), [link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-2775dea7fc7bbd6b15d61cfd5a12116e8fb8c4c0ebc3bc1c7e87d20fe93f7ea5L129-R138), [link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-2775dea7fc7bbd6b15d61cfd5a12116e8fb8c4c0ebc3bc1c7e87d20fe93f7ea5L138-R162), [link](https://github.com/lensterxyz/lenster/pull/2494/files?diff=unified&w=0#diff-2775dea7fc7bbd6b15d61cfd5a12116e8fb8c4c0ebc3bc1c7e87d20fe93f7ea5L153-R174))

## Emoji

<!--
copilot:emoji
-->

🧹🧪🚀

<!--
1.  🧹 for simplifying the data-testid attributes and making them more consistent.
2.  🧪 for updating the tests to use the `getByTestId` method more consistently and avoid hard-coding publication ids.
3.  🚀 for making the tests more robust and maintainable.
-->
