### PR TITLE
chore: add nightly mode

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,41 @@
+name: Nightly CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: CI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🚪
+        uses: actions/checkout@v3
+
+      - name: Setup pnpm 🌸
+        uses: pnpm/action-setup@v2.2.4
+
+      - name: Setup node 🍀
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Bootstrap 📦
+        run: script/bootstrap
+
+      - name: Typecheck 🔡
+        run: pnpm typecheck
+
+      - name: Lint 🪩
+        run: pnpm lint
+
+      - name: Prettier ✨
+        run: pnpm prettier
+
+      - name: Build 🎁
+        run: pnpm build
+
+      - name: Run Tests 🧪
+        run: pnpm test:nightly
+        env:
+          NIGHTLY: true

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "husky install",
     "test:dev": "turbo run test:dev",
     "test:e2e": "start-server-and-test start '4783|4784|8083' test:dev",
-    "test:nightly": "turbo run test:dev --nightly"
+    "test:nightly": "turbo run test:dev"
   },
   "devDependencies": {
     "husky": "^8.0.3",

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -1,3 +1,4 @@
-export const WEB_BASE_URL = 'http://localhost:4783';
-export const PRERENDER_BASE_URL = 'http://localhost:4784';
-export const METADATA_BASE_URL = 'http://localhost:8083';
+export const isNightly = process.env.NIGHTLY === 'true';
+export const WEB_BASE_URL = isNightly ? 'https://lenster.xyz' : 'http://localhost:4783';
+export const PRERENDER_BASE_URL = isNightly ? 'https://prerender.lenster.xyz' : 'http://localhost:4784';
+export const METADATA_BASE_URL = isNightly ? 'https://metadata.lenster.xyz' : 'http://localhost:8083';


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0f4095</samp>

This pull request adds a new nightly CI workflow for testing the lenster website against the production servers. It also simplifies the test:nightly script in the `package.json` file and updates the base URLs in the `tests/constants.ts` file based on the `NIGHTLY` environment variable.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0f4095</samp>

* Add a new workflow file for running nightly CI tests on the lenster website ([link](https://github.com/lensterxyz/lenster/pull/2508/files?diff=unified&w=0#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6R1-R41))
* Simplify the test:nightly script in the `package.json` file by removing the --nightly flag ([link](https://github.com/lensterxyz/lenster/pull/2508/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21-R21))
* Adjust the base URLs for the web, prerender, and metadata services in the `tests/constants.ts` file based on the NIGHTLY environment variable ([link](https://github.com/lensterxyz/lenster/pull/2508/files?diff=unified&w=0#diff-7dabe1ac54eca6fa517ae515d90b772ce087aff5e46bac0687c505b298a58e70L1-R4))

## Emoji

<!--
copilot:emoji
-->

🌙🚀🔗

<!--
1.  🌙 - This emoji represents the nightly CI workflow, which runs the tests against the production website every night or on demand. It also conveys the idea of a scheduled or periodic task that happens when most people are asleep.
2.  🚀 - This emoji represents the turbo CLI tool, which runs the tests in parallel and speeds up the execution time. It also conveys the idea of launching or deploying the website to production, which is what the tests are verifying.
3.  🔗 - This emoji represents the base URLs for the web, prerender, and metadata services, which are switched based on the NIGHTLY environment variable. It also conveys the idea of linking or connecting the tests to the correct servers.
-->
