### PR TITLE
feat: add notification settings preference

### DIFF
--- a/apps/web/src/components/Composer/Actions/ReferenceSettings/index.tsx
+++ b/apps/web/src/components/Composer/Actions/ReferenceSettings/index.tsx
@@ -43,7 +43,7 @@ const ReferenceSettings: FC = () => {
     <Menu.Item as="a" className={clsx({ 'dropdown-active': selected }, 'menu-item')} onClick={onClick}>
       <div className="flex items-center justify-between space-x-2">
         <div className="flex items-center space-x-1.5">
-          <div className="text-brand-500">{icon}</div>
+          <div className="text-brand">{icon}</div>
           <div>{title}</div>
         </div>
         {selected && <CheckCircleIcon className="w-5 text-green-500" />}

--- a/apps/web/src/components/Composer/Post/New.tsx
+++ b/apps/web/src/components/Composer/Post/New.tsx
@@ -22,7 +22,7 @@ interface ActionProps {
 const Action: FC<ActionProps> = ({ icon, text, onClick }) => (
   <Tooltip content={text} placement="top">
     <button
-      className="lt-text-gray-500 hover:text-brand-500 flex flex-col items-center"
+      className="lt-text-gray-500 hover:text-brand flex flex-col items-center"
       onClick={onClick}
       type="button"
     >

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -85,7 +85,7 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
           <div
             onClick={() => setSelectedTab('Following')}
             className={clsx(
-              'text-brand-500 tab-bg m-2 ml-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
+              'text-brand tab-bg m-2 ml-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
               selectedTab === 'Following' ? 'bg-brand-100' : ''
             )}
           >
@@ -95,7 +95,7 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
           <div
             onClick={() => setSelectedTab('Requested')}
             className={clsx(
-              'text-brand-500 tab-bg m-2 mr-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
+              'text-brand tab-bg m-2 mr-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
               selectedTab === 'Requested' ? 'bg-brand-100' : ''
             )}
           >

--- a/apps/web/src/components/Notification/List.tsx
+++ b/apps/web/src/components/Notification/List.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import { useInView } from 'react-cool-inview';
 import { NotificationType } from 'src/enums';
 import { useAppStore } from 'src/store/app';
+import { usePreferencesStore } from 'src/store/preferences';
 import { Card, EmptyState, ErrorMessage } from 'ui';
 
 import NotificationShimmer from './Shimmer';
@@ -30,6 +31,7 @@ interface ListProps {
 }
 
 const List: FC<ListProps> = ({ feedType }) => {
+  const highSignalNotificationFilter = usePreferencesStore((state) => state.highSignalNotificationFilter);
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [hasMore, setHasMore] = useState(true);
 
@@ -55,6 +57,7 @@ const List: FC<ListProps> = ({ feedType }) => {
     profileId: currentProfile?.id,
     customFilters: [CustomFiltersTypes.Gardeners],
     notificationTypes: getNotificationType(),
+    highSignalFilter: highSignalNotificationFilter,
     limit: 20
   };
 
@@ -104,7 +107,6 @@ const List: FC<ListProps> = ({ feedType }) => {
     <Card className="divide-y dark:divide-gray-700">
       {notifications?.map((notification, index, items) => {
         const isLast = index === items.length - 1;
-
         return (
           <div
             key={`${notification?.notificationId}_${index}`}

--- a/apps/web/src/components/Notification/Settings.tsx
+++ b/apps/web/src/components/Notification/Settings.tsx
@@ -1,0 +1,48 @@
+import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
+import { BellIcon, CogIcon, ColorSwatchIcon } from '@heroicons/react/outline';
+import { t } from '@lingui/macro';
+import type { FC } from 'react';
+import { useState } from 'react';
+import { usePreferencesStore } from 'src/store/preferences';
+import { Modal, Tooltip } from 'ui';
+
+const Settings: FC = () => {
+  const highSignalNotificationFilter = usePreferencesStore((state) => state.highSignalNotificationFilter);
+  const setHighSignalNotificationFilter = usePreferencesStore(
+    (state) => state.setHighSignalNotificationFilter
+  );
+  const [showNotificationSettings, setShowNotificationSettings] = useState(false);
+
+  return (
+    <>
+      <button
+        className="rounded-md p-1 hover:bg-gray-300 hover:bg-opacity-20"
+        onClick={() => setShowNotificationSettings(true)}
+      >
+        <Tooltip placement="top" content={t`Notification settings`}>
+          <CogIcon className="lt-text-gray-500 h-5 w-5" />
+        </Tooltip>
+      </button>
+      <Modal
+        title="Notification settings"
+        icon={<BellIcon className="text-brand h-5 w-5" />}
+        show={showNotificationSettings}
+        onClose={() => setShowNotificationSettings(false)}
+      >
+        <div className="p-5">
+          <ToggleWithHelper
+            on={highSignalNotificationFilter}
+            setOn={() => {
+              setHighSignalNotificationFilter(!highSignalNotificationFilter);
+            }}
+            heading={t`Quality filter`}
+            description={t`Choose to filter out low-quality notifications`}
+            icon={<ColorSwatchIcon className="h-4 w-4" />}
+          />
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+export default Settings;

--- a/apps/web/src/components/Notification/index.tsx
+++ b/apps/web/src/components/Notification/index.tsx
@@ -11,6 +11,7 @@ import { PAGEVIEW } from 'src/tracking';
 
 import FeedType from './FeedType';
 import List from './List';
+import Settings from './Settings';
 
 const Notification: FC = () => {
   const {
@@ -35,8 +36,9 @@ const Notification: FC = () => {
     <div className="flex flex-grow justify-center px-0 py-8 sm:px-6 lg:px-8">
       <MetaTags title={t`Notifications • ${APP_NAME}`} />
       <div className="w-full max-w-4xl space-y-3">
-        <div className="flex gap-3 pb-2">
+        <div className="flex flex-wrap justify-between gap-3 pb-2">
           <FeedType setFeedType={setFeedType} feedType={feedType} />
+          <Settings />
         </div>
         <List feedType={feedType} />
       </div>

--- a/apps/web/src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
+++ b/apps/web/src/components/Shared/Lexical/Plugins/ToolbarPlugin.tsx
@@ -49,7 +49,7 @@ const ToolbarPlugin: FC = () => {
             activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold');
           }}
         >
-          <i className="toolbar-icon bold text-brand-500" />
+          <i className="toolbar-icon bold text-brand" />
         </button>
         <button
           className={isItalic ? 'bg-brand-100' : ''}

--- a/apps/web/src/components/Shared/Navbar/BottomNavigation.tsx
+++ b/apps/web/src/components/Shared/Navbar/BottomNavigation.tsx
@@ -18,28 +18,28 @@ const BottomNavigation = () => {
       <div className="grid grid-cols-4">
         <Link href="/" className="mx-auto my-3">
           {isActivePath('/') ? (
-            <HomeIconSolid className="text-brand-500 h-6 w-6" />
+            <HomeIconSolid className="text-brand h-6 w-6" />
           ) : (
             <HomeIcon className="h-6 w-6" />
           )}
         </Link>
         <Link href="/explore" className="mx-auto my-3">
           {isActivePath('/explore') ? (
-            <ViewGridIconSolid className="text-brand-500 h-6 w-6" />
+            <ViewGridIconSolid className="text-brand h-6 w-6" />
           ) : (
             <ViewGridIcon className="h-6 w-6" />
           )}
         </Link>
         <Link href="/notifications" className="mx-auto my-3">
           {isActivePath('/notifications') ? (
-            <BellIconSolid className="text-brand-500 h-6 w-6" />
+            <BellIconSolid className="text-brand h-6 w-6" />
           ) : (
             <BellIcon className="h-6 w-6" />
           )}
         </Link>
         <Link href="/messages" className="mx-auto my-3">
           {isActivePath('/messages') ? (
-            <MailIconSolid className="text-brand-500 h-6 w-6" />
+            <MailIconSolid className="text-brand h-6 w-6" />
           ) : (
             <MailIcon className="h-6 w-6" />
           )}

--- a/apps/web/src/components/Shared/ToggleWithHelper.tsx
+++ b/apps/web/src/components/Shared/ToggleWithHelper.tsx
@@ -10,15 +10,12 @@ interface ToggleWithHelperProps {
 }
 
 const ToggleWithHelper: FC<ToggleWithHelperProps> = ({ on, setOn, heading, description, icon }) => {
-  const hasHeadingAndIcon = heading && icon;
   return (
     <div className="space-y-2">
-      {hasHeadingAndIcon && (
-        <div className="flex items-center space-x-2">
-          <span className="text-brand-500">{icon}</span>
-          <span>{heading}</span>
-        </div>
-      )}
+      <div className="flex items-center space-x-2">
+        {icon ? <span className="text-brand">{icon}</span> : null}
+        {heading ? <span>{heading}</span> : null}
+      </div>
       <div className="flex items-center space-x-2">
         <Toggle on={on} setOn={setOn} />
         <div className="lt-text-gray-500 text-sm font-bold">{description}</div>

--- a/apps/web/src/store/preferences.ts
+++ b/apps/web/src/store/preferences.ts
@@ -5,13 +5,18 @@ import { persist } from 'zustand/middleware';
 interface PreferencesState {
   hideLikesCount: boolean;
   setHideLikesCount: (hideLikesCount: boolean) => void;
+  highSignalNotificationFilter: boolean;
+  setHighSignalNotificationFilter: (highSignalNotificationFilter: boolean) => void;
 }
 
 export const usePreferencesStore = create(
   persist<PreferencesState>(
     (set) => ({
       hideLikesCount: false,
-      setHideLikesCount: (hideLikesCount) => set(() => ({ hideLikesCount }))
+      setHideLikesCount: (hideLikesCount) => set(() => ({ hideLikesCount })),
+      highSignalNotificationFilter: true,
+      setHighSignalNotificationFilter: (highSignalNotificationFilter) =>
+        set(() => ({ highSignalNotificationFilter }))
     }),
     { name: Localstorage.PreferencesStore }
   )

--- a/packages/lens/apollo/cache/createNotificationsFieldPolicy.ts
+++ b/packages/lens/apollo/cache/createNotificationsFieldPolicy.ts
@@ -3,7 +3,7 @@ import type { FieldPolicy } from '@apollo/client';
 import { cursorBasedPagination } from '../lib';
 
 const createNotificationsFieldPolicy = (): FieldPolicy => {
-  return cursorBasedPagination(['request', ['profileId', 'notificationTypes']]);
+  return cursorBasedPagination(['request', ['profileId', 'notificationTypes', 'highSignalFilter']]);
 };
 
 export default createNotificationsFieldPolicy;

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -2646,6 +2646,7 @@ export type Notification =
 export type NotificationRequest = {
   cursor?: InputMaybe<Scalars['Cursor']>;
   customFilters?: InputMaybe<Array<CustomFiltersTypes>>;
+  highSignalFilter?: InputMaybe<Scalars['Boolean']>;
   limit?: InputMaybe<Scalars['LimitScalar']>;
   /** The profile id */
   notificationTypes?: InputMaybe<Array<NotificationTypes>>;

--- a/packages/ui/src/Input.tsx
+++ b/packages/ui/src/Input.tsx
@@ -24,7 +24,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   const id = useId();
 
   const iconStyles = [
-    'text-zinc-500 [&>*]:peer-focus:text-brand-500 [&>*]:h-5',
+    'text-zinc-500 [&>*]:peer-focus:text-brand [&>*]:h-5',
     { '!text-red-500 [&>*]:peer-focus:!text-red-500': error }
   ];
 


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b043d2</samp>

This pull request introduces several changes to the web app and the UI package to improve the user experience and the app's design. It adds a notification settings component to allow users to customize their notification preferences and filter out low-quality notifications. It also changes the text color of various icons and buttons to `text-brand` to align with the updated color scheme. Additionally, it simplifies some component logic and updates the notification cache key.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b043d2</samp>

*  Update the text color of various icons and buttons to match the new color scheme of the app ([link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-b1ef21472f66e5fadc0d8fa662ca3e850e175cc765275ae386d1fa666025dc36L46-R46), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-986513742b9905bfc1b3d36b92bd3fca9662260b46e9d8c51045136965ba4a83L25-R25), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778L88-R88), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778L98-R98), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-d83e2228f0565c67066f80ac7f621cea3d2dfea6e1f61380e1315b73ae1fbdebL52-R52), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-d293afaaf97158c60cf56e8bc44636f3e5435e3d774f18feced1198dc4abfe27L21-R21), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-d293afaaf97158c60cf56e8bc44636f3e5435e3d774f18feced1198dc4abfe27L28-R28), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-d293afaaf97158c60cf56e8bc44636f3e5435e3d774f18feced1198dc4abfe27L35-R35), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-d293afaaf97158c60cf56e8bc44636f3e5435e3d774f18feced1198dc4abfe27L42-R42), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-60b46b88e6369bc85b7e73667b17c3ecabb3da9b54545f96a6327b306c4e02b6L27-R27))
*  Add the `highSignalNotificationFilter` state and setter to the `preferences` store to store the user's preference for filtering out low-quality notifications ([link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-1a375bfb322aa332b37803f1d7ae1a19bd7fefab084008b95c410bbe48856f59R8-R9), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-1a375bfb322aa332b37803f1d7ae1a19bd7fefab084008b95c410bbe48856f59L14-R19))
*  Import the `usePreferencesStore` hook to the `Notification/List` component and extract the `highSignalNotificationFilter` state ([link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-290d37d998503d7354bd993bbc2810218395414c7eeda5efbb2e0f438c9f5184R18), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-290d37d998503d7354bd993bbc2810218395414c7eeda5efbb2e0f438c9f5184R34))
*  Pass the `highSignalFilter` parameter to the notification request object and the cache key for the notification query ([link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-290d37d998503d7354bd993bbc2810218395414c7eeda5efbb2e0f438c9f5184R60), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-32fe031dd2aba32b47778e701025a9f382136ee3d0ce6058031610fbef7cc343L6-R6))
*  Import and render the `Notification/Settings` component to the `Notification` component to display it on the notification page ([link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-ff0580afd44dd81a843992b4e02502950f56d630d3d10344a1aba43adccf2e0bR14), [link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-ff0580afd44dd81a843992b4e02502950f56d630d3d10344a1aba43adccf2e0bL38-R41))
*  Simplify the logic for rendering the icon and heading in the `ToggleWithHelper` component using conditional rendering ([link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-d3eeb3ed2bc16fc70276aad835bef4ac629056cda321941a86829e38342f804aL13-R19))
*  Remove the empty line from the `Notification/List` component to improve code readability and formatting ([link](https://github.com/lensterxyz/lenster/pull/2512/files?diff=unified&w=0#diff-290d37d998503d7354bd993bbc2810218395414c7eeda5efbb2e0f438c9f5184L107))

## Emoji

<!--
copilot:emoji
-->

🎨🔔🛠️

<!--
1.  🎨 - This emoji represents the changes related to the color scheme of the app, such as changing the text color of various icons and buttons to match the new brand color.
2. 🔔 - This emoji represents the changes related to the notification feature of the app, such as adding the notification settings component, filtering out low-quality notifications, and adding a new preference state for the high-signal filter.
3. 🛠️ - This emoji represents the changes related to the code logic and structure of the app, such as simplifying the rendering of the toggle with helper component, adding a new parameter to the notification field policy function, and importing a new component from the notification module.
-->
