### PR TITLE
feat: add relay queues to staff tools

### DIFF
--- a/apps/web/src/components/StaffTools/RelayQueues.tsx
+++ b/apps/web/src/components/StaffTools/RelayQueues.tsx
@@ -1,0 +1,101 @@
+import MetaTags from '@components/Common/MetaTags';
+import useStaffMode from '@components/utils/hooks/useStaffMode';
+import { Mixpanel } from '@lib/mixpanel';
+import { t } from '@lingui/macro';
+import { APP_NAME, POLYGONSCAN_URL } from 'data/constants';
+import Errors from 'data/errors';
+import { useRelayQueuesQuery } from 'lens';
+import type { NextPage } from 'next';
+import type { FC } from 'react';
+import { useEffect } from 'react';
+import Custom404 from 'src/pages/404';
+import { PAGEVIEW } from 'src/tracking';
+import { Card, GridItemEight, GridItemFour, GridLayout, Spinner } from 'ui';
+
+import StaffToolsSidebar from './Sidebar';
+
+interface RelayProps {
+  address: string;
+  queue: number;
+  relayer: string;
+}
+
+export const Relay: FC<RelayProps> = ({ address, queue, relayer }) => {
+  function getRelayerName(name: string): string {
+    const words = name.split('_');
+    const capitalizedWords = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase());
+
+    return capitalizedWords.join(' ');
+  }
+
+  return (
+    <Card className="flex w-full flex-wrap items-center justify-between p-5" forceRounded>
+      <div>
+        <b>{getRelayerName(relayer)}</b>
+        <div>
+          <a className="text-sm" href={`${POLYGONSCAN_URL}/address/${address}`} target="_blank">
+            {address}
+          </a>
+        </div>
+      </div>
+      <div className="flex flex-col items-center">
+        <b className="text-xl">{queue}</b>
+        <span className="lt-text-gray-500">Transactions</span>
+      </div>
+    </Card>
+  );
+};
+
+const RelayQueues: NextPage = () => {
+  const { allowed } = useStaffMode();
+
+  useEffect(() => {
+    Mixpanel.track(PAGEVIEW, { page: 'stafftools', subpage: 'relayqueues' });
+  }, []);
+
+  const { data, loading, error } = useRelayQueuesQuery({
+    pollInterval: 5000
+  });
+
+  if (!allowed) {
+    return <Custom404 />;
+  }
+
+  const sortedRelays = data?.relayQueues
+    .map((relay) => ({
+      ...relay,
+      queue: relay.queue
+    }))
+    .sort((a, b) => b.queue - a.queue);
+
+  return (
+    <GridLayout>
+      <MetaTags title={t`Stafftools | Relay queues • ${APP_NAME}`} />
+      <GridItemFour>
+        <StaffToolsSidebar />
+      </GridItemFour>
+      <GridItemEight className="space-y-5">
+        <Card className="p-5">
+          {error ? (
+            <b className="text-red-500">{Errors.SomethingWentWrong}</b>
+          ) : loading ? (
+            <div className="flex justify-center">
+              <Spinner size="sm" />
+            </div>
+          ) : (
+            <section className="space-y-3">
+              <h1 className="mb-4 text-xl font-bold">Relay queues</h1>
+              <div className="space-y-3">
+                {sortedRelays?.map(({ address, queue, relayer }) => (
+                  <Relay key={address} address={address} queue={queue} relayer={relayer} />
+                ))}
+              </div>
+            </section>
+          )}
+        </Card>
+      </GridItemEight>
+    </GridLayout>
+  );
+};
+
+export default RelayQueues;

--- a/apps/web/src/components/StaffTools/Sidebar.tsx
+++ b/apps/web/src/components/StaffTools/Sidebar.tsx
@@ -1,5 +1,5 @@
 import Sidebar from '@components/Shared/Sidebar';
-import { ChartPieIcon } from '@heroicons/react/outline';
+import { ChartPieIcon, ViewListIcon } from '@heroicons/react/outline';
 import type { FC } from 'react';
 
 const StaffToolsSidebar: FC = () => {
@@ -10,6 +10,11 @@ const StaffToolsSidebar: FC = () => {
           title: 'Stats',
           icon: <ChartPieIcon className="h-4 w-4" />,
           url: '/stafftools'
+        },
+        {
+          title: 'Relay queues',
+          icon: <ViewListIcon className="h-4 w-4" />,
+          url: '/stafftools/relayqueues'
         }
       ]}
     />

--- a/apps/web/src/components/StaffTools/Stats/index.tsx
+++ b/apps/web/src/components/StaffTools/Stats/index.tsx
@@ -24,7 +24,7 @@ import type { FC, ReactNode } from 'react';
 import { useEffect } from 'react';
 import Custom404 from 'src/pages/404';
 import { PAGEVIEW } from 'src/tracking';
-import { Card, GridItemEight, GridItemFour, GridLayout } from 'ui';
+import { Card, GridItemEight, GridItemFour, GridLayout, Spinner } from 'ui';
 
 import StaffToolsSidebar from '../Sidebar';
 
@@ -111,7 +111,7 @@ const Stats: NextPage = () => {
 
   return (
     <GridLayout>
-      <MetaTags title={t`Stafftools • ${APP_NAME}`} />
+      <MetaTags title={t`Stafftools | Stats • ${APP_NAME}`} />
       <GridItemFour>
         <StaffToolsSidebar />
       </GridItemFour>
@@ -120,7 +120,9 @@ const Stats: NextPage = () => {
           {error ? (
             <b className="text-red-500">{Errors.SomethingWentWrong}</b>
           ) : loading || todayLoading || yesterdayLoading ? (
-            <div>Loading...</div>
+            <div className="flex justify-center">
+              <Spinner size="sm" />
+            </div>
           ) : (
             <section className="space-y-3">
               <h1 className="mb-4 text-xl font-bold">Stats</h1>

--- a/apps/web/src/pages/stafftools/relayqueues.tsx
+++ b/apps/web/src/pages/stafftools/relayqueues.tsx
@@ -1,0 +1,3 @@
+import RelayQueues from '@components/StaffTools/RelayQueues';
+
+export default RelayQueues;

--- a/packages/lens/documents/queries/RelayQueues.graphql
+++ b/packages/lens/documents/queries/RelayQueues.graphql
@@ -1,0 +1,7 @@
+query RelayQueues {
+  relayQueues {
+    relayer
+    address
+    queue
+  }
+}

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -3494,6 +3494,7 @@ export type Query = {
   publications: PaginatedPublicationResult;
   recommendedProfiles: Array<Profile>;
   rel?: Maybe<Scalars['Void']>;
+  relayQueues: Array<RelayQueueResult>;
   search: SearchResult;
   txIdToTxHash: Scalars['TxHash'];
   unknownEnabledModules: EnabledModules;
@@ -3781,7 +3782,52 @@ export enum RelayErrorReasons {
   WrongWalletSigned = 'WRONG_WALLET_SIGNED'
 }
 
+/** The  */
+export type RelayQueueResult = {
+  __typename?: 'RelayQueueResult';
+  /** The address of the relay */
+  address: Scalars['EthereumAddress'];
+  /** The queue on the relay */
+  queue: Scalars['Float'];
+  /** The relayer name */
+  relayer: RelayRoleKey;
+};
+
 export type RelayResult = RelayError | RelayerResult;
+
+/** The relay role key */
+export enum RelayRoleKey {
+  CreateProfile = 'CREATE_PROFILE',
+  Dispatcher_1 = 'DISPATCHER_1',
+  Dispatcher_2 = 'DISPATCHER_2',
+  Dispatcher_3 = 'DISPATCHER_3',
+  Dispatcher_4 = 'DISPATCHER_4',
+  Dispatcher_5 = 'DISPATCHER_5',
+  Dispatcher_6 = 'DISPATCHER_6',
+  Dispatcher_7 = 'DISPATCHER_7',
+  Dispatcher_8 = 'DISPATCHER_8',
+  Dispatcher_9 = 'DISPATCHER_9',
+  Dispatcher_10 = 'DISPATCHER_10',
+  ProxyActionCollect_1 = 'PROXY_ACTION_COLLECT_1',
+  ProxyActionCollect_2 = 'PROXY_ACTION_COLLECT_2',
+  ProxyActionCollect_3 = 'PROXY_ACTION_COLLECT_3',
+  ProxyActionCollect_4 = 'PROXY_ACTION_COLLECT_4',
+  ProxyActionCollect_5 = 'PROXY_ACTION_COLLECT_5',
+  ProxyActionCollect_6 = 'PROXY_ACTION_COLLECT_6',
+  ProxyActionFollow_1 = 'PROXY_ACTION_FOLLOW_1',
+  ProxyActionFollow_2 = 'PROXY_ACTION_FOLLOW_2',
+  ProxyActionFollow_3 = 'PROXY_ACTION_FOLLOW_3',
+  ProxyActionFollow_4 = 'PROXY_ACTION_FOLLOW_4',
+  ProxyActionFollow_5 = 'PROXY_ACTION_FOLLOW_5',
+  ProxyActionFollow_6 = 'PROXY_ACTION_FOLLOW_6',
+  ProxyActionFollow_7 = 'PROXY_ACTION_FOLLOW_7',
+  ProxyActionFollow_8 = 'PROXY_ACTION_FOLLOW_8',
+  ProxyActionFollow_9 = 'PROXY_ACTION_FOLLOW_9',
+  ProxyActionFollow_10 = 'PROXY_ACTION_FOLLOW_10',
+  WithSig_1 = 'WITH_SIG_1',
+  WithSig_2 = 'WITH_SIG_2',
+  WithSig_3 = 'WITH_SIG_3'
+}
 
 /** The relayer result */
 export type RelayerResult = {
@@ -22311,6 +22357,13 @@ export type RecommendedProfilesQuery = {
   }>;
 };
 
+export type RelayQueuesQueryVariables = Exact<{ [key: string]: never }>;
+
+export type RelayQueuesQuery = {
+  __typename?: 'Query';
+  relayQueues: Array<{ __typename?: 'RelayQueueResult'; relayer: RelayRoleKey; address: any; queue: number }>;
+};
+
 export type RelevantPeopleQueryVariables = Exact<{
   request: ProfileQueryRequest;
 }>;
@@ -33790,6 +33843,46 @@ export type RecommendedProfilesQueryResult = Apollo.QueryResult<
   RecommendedProfilesQuery,
   RecommendedProfilesQueryVariables
 >;
+export const RelayQueuesDocument = gql`
+  query RelayQueues {
+    relayQueues {
+      relayer
+      address
+      queue
+    }
+  }
+`;
+
+/**
+ * __useRelayQueuesQuery__
+ *
+ * To run a query within a React component, call `useRelayQueuesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useRelayQueuesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useRelayQueuesQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useRelayQueuesQuery(
+  baseOptions?: Apollo.QueryHookOptions<RelayQueuesQuery, RelayQueuesQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<RelayQueuesQuery, RelayQueuesQueryVariables>(RelayQueuesDocument, options);
+}
+export function useRelayQueuesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<RelayQueuesQuery, RelayQueuesQueryVariables>
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<RelayQueuesQuery, RelayQueuesQueryVariables>(RelayQueuesDocument, options);
+}
+export type RelayQueuesQueryHookResult = ReturnType<typeof useRelayQueuesQuery>;
+export type RelayQueuesLazyQueryHookResult = ReturnType<typeof useRelayQueuesLazyQuery>;
+export type RelayQueuesQueryResult = Apollo.QueryResult<RelayQueuesQuery, RelayQueuesQueryVariables>;
 export const RelevantPeopleDocument = gql`
   query RelevantPeople($request: ProfileQueryRequest!) {
     profiles(request: $request) {


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a780ee</samp>

This pull request adds a new relay queues page to the staff tools section of the web app. The page allows staff to view and manage the relay messages sent by the app. The pull request also improves the loading and title display of the stats page in the same section.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a780ee</samp>

*  Add a new component `RelayQueues` to render the relay queues page for staff members ([link](https://github.com/lensterxyz/lenster/pull/2522/files?diff=unified&w=0#diff-cd3951ea86aa0d6c03d65b6b9044214c65410909f4bdd379f31832b0ef787fa8R1-R101))
*  Import the `RelayQueues` component in the new file `relayqueues.tsx` and export it as the default export to create a new route for the relay queues page ([link](https://github.com/lensterxyz/lenster/pull/2522/files?diff=unified&w=0#diff-26774a1b64091a31194f80e7fb5b2ebfddab3a31b42094cf8560a848b5078d31R1-R3))
*  Add a new menu item to the `StaffToolsSidebar` component with the title `Relay queues`, the icon `ViewListIcon`, and the url `/stafftools/relayqueues` to link to the new page ([link](https://github.com/lensterxyz/lenster/pull/2522/files?diff=unified&w=0#diff-9ebc468fb11a21b1d6f8995718ccc541b540a56bf6d3e88274b7858cf38b6046L2-R2), [link](https://github.com/lensterxyz/lenster/pull/2522/files?diff=unified&w=0#diff-9ebc468fb11a21b1d6f8995718ccc541b540a56bf6d3e88274b7858cf38b6046R13-R17))
*  Define a new GraphQL query `RelayQueues` in the file `RelayQueues.graphql` to fetch the relayer, address, and queue size of each relay address from the lens API ([link](https://github.com/lensterxyz/lenster/pull/2522/files?diff=unified&w=0#diff-36158ddd171b9204a5ac2b41938fd420ec760b524fb2fe2467f341de88eade3aR1-R7))
*  Update the title of the `MetaTags` component in the `Stats` component to make it more consistent with the other subpages of the staff tools section ([link](https://github.com/lensterxyz/lenster/pull/2522/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L114-R114))
*  Replace the `Loading...` text with the `Spinner` component in the `Stats` component to show a loading indicator when the data for the stats page is being fetched ([link](https://github.com/lensterxyz/lenster/pull/2522/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L27-R27), [link](https://github.com/lensterxyz/lenster/pull/2522/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L123-R125))

## Emoji

<!--
copilot:emoji
-->

📨🛠️📊

<!--
1.  📨 - This emoji represents the relay feature of the app, which allows users to send messages to other users without revealing their email addresses. It also relates to the queue concept, which shows how many messages are waiting to be delivered by the relayer.
2.  🛠️ - This emoji represents the staff tools section of the app, which provides various tools and insights for the staff members to manage the app and its users. It also relates to the improvement of the stats page, which is part of the staff tools.
3.  📊 - This emoji represents the data and statistics that are displayed on the relay queues and stats pages. It also relates to the GraphQL query that fetches the relay queues data from the lens API.
-->
