### PR TITLE
fix: dispatcher fallback toasts and spinner for save avatar

### DIFF
--- a/apps/web/src/components/Settings/Profile/Picture.tsx
+++ b/apps/web/src/components/Settings/Profile/Picture.tsx
@@ -44,7 +44,11 @@ const Picture: FC<PictureProps> = ({ profile }) => {
   const [imageSrc, setImageSrc] = useState('');
   const [showCropModal, setShowCropModal] = useState(false);
 
-  const onCompleted = () => {
+  const onCompleted = (__typename?: 'RelayError' | 'RelayerResult') => {
+    if (__typename === 'RelayError') {
+      return;
+    }
+
     toast.success(t`Avatar updated successfully!`);
     Mixpanel.track(SETTINGS.PROFILE.SET_PICTURE);
   };
@@ -58,12 +62,12 @@ const Picture: FC<PictureProps> = ({ profile }) => {
     abi: LensHub,
     functionName: 'setProfileImageURIWithSig',
     mode: 'recklesslyUnprepared',
-    onSuccess: onCompleted,
+    onSuccess: () => onCompleted(),
     onError
   });
 
   const [broadcast, { loading: broadcastLoading }] = useBroadcastMutation({
-    onCompleted
+    onCompleted: ({ broadcast }) => onCompleted(broadcast.__typename)
   });
   const [createSetProfileImageURITypedData, { loading: typedDataLoading }] =
     useCreateSetProfileImageUriTypedDataMutation({
@@ -88,7 +92,11 @@ const Picture: FC<PictureProps> = ({ profile }) => {
     });
 
   const [createSetProfileImageURIViaDispatcher, { loading: dispatcherLoading }] =
-    useCreateSetProfileImageUriViaDispatcherMutation({ onCompleted, onError });
+    useCreateSetProfileImageUriViaDispatcherMutation({
+      onCompleted: ({ createSetProfileImageURIViaDispatcher }) =>
+        onCompleted(createSetProfileImageURIViaDispatcher.__typename),
+      onError
+    });
 
   const createViaDispatcher = async (request: UpdateProfileImageRequest) => {
     const { data } = await createSetProfileImageURIViaDispatcher({


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87c7d28</samp>

Improved error handling for avatar updates in the web app. Added `__typename` parameter to `onCompleted` callback in `Picture.tsx`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87c7d28</samp>

*  Modify `onCompleted` callback function to handle possible errors from relay or dispatcher contracts ([link](https://github.com/lensterxyz/lenster/pull/2542/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L47-R51))
*  Pass `__typename` property from mutation result to `onCompleted` function using arrow functions in `useBroadcastMutation` and `useCreateSetProfileImageURITypedData` hooks in `Picture.tsx` ([link](https://github.com/lensterxyz/lenster/pull/2542/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L61-R70), [link](https://github.com/lensterxyz/lenster/pull/2542/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L91-R99))

## Emoji

<!--
copilot:emoji
-->

🛠️🚨➡️

<!--
1.  🛠️ - This emoji represents the modification of the `onCompleted` callback function, which is a fix or improvement to the existing code.
2.  🚨 - This emoji represents the handling of possible errors from the relay or the dispatcher contracts, which is a precaution or safeguard against potential failures or issues.
3.  ➡️ - This emoji represents the passing of the `__typename` parameter from the mutation result to the callback function using arrow functions, which is a direction or indication of the flow of data or logic.
-->
