### PR TITLE
fix: dispatcher fallback toasts and spinner for toggle dispatcher

### DIFF
--- a/apps/web/src/components/Settings/Dispatcher/ToggleDispatcher.tsx
+++ b/apps/web/src/components/Settings/Dispatcher/ToggleDispatcher.tsx
@@ -29,7 +29,11 @@ const ToggleDispatcher: FC<ToggleDispatcherProps> = ({ buttonSize = 'md' }) => {
   const isOldDispatcherEnabled =
     currentProfile?.dispatcher?.address?.toLocaleLowerCase() === OLD_LENS_RELAYER_ADDRESS.toLocaleLowerCase();
 
-  const onCompleted = () => {
+  const onCompleted = (__typename?: 'RelayError' | 'RelayerResult') => {
+    if (__typename === 'RelayError') {
+      return;
+    }
+
     toast.success(t`Profile updated successfully!`);
     if (isOldDispatcherEnabled) {
       Mixpanel.track(SETTINGS.DISPATCHER.UPDATE);
@@ -49,12 +53,12 @@ const ToggleDispatcher: FC<ToggleDispatcherProps> = ({ buttonSize = 'md' }) => {
     abi: LensHub,
     functionName: 'setDispatcherWithSig',
     mode: 'recklesslyUnprepared',
-    onSuccess: onCompleted,
+    onSuccess: () => onCompleted(),
     onError
   });
 
   const [broadcast, { data: broadcastData, loading: broadcastLoading }] = useBroadcastMutation({
-    onCompleted
+    onCompleted: ({ broadcast }) => onCompleted(broadcast.__typename)
   });
   const [createSetDispatcherTypedData, { loading: typedDataLoading }] =
     useCreateSetDispatcherTypedDataMutation({


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a79cb4f</samp>

Improved error handling for relay and broadcast mutations in the `ToggleDispatcher` component. Added a type check for the mutation responses.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a79cb4f</samp>

*  Refactor error handling for relay service mutations ([link](https://github.com/lensterxyz/lenster/pull/2544/files?diff=unified&w=0#diff-1fa1065ebf72ab9da791b7a0cdc742f6baffa25342dfeb1f99dfefd1c9350fdfL32-R36), [link](https://github.com/lensterxyz/lenster/pull/2544/files?diff=unified&w=0#diff-1fa1065ebf72ab9da791b7a0cdc742f6baffa25342dfeb1f99dfefd1c9350fdfL52-R61))

## Emoji

<!--
copilot:emoji
-->

🔧📡🚀

<!--
1.  🔧 - This emoji represents refactoring or fixing something, and can be used to indicate the changes to the error handling logic of the hooks.
2.  📡 - This emoji represents broadcasting or sending something, and can be used to indicate the changes to the `useBroadcastMutation` hook and the relay service.
3.  🚀 - This emoji represents launching or deploying something, and can be used to indicate the changes to the `onCompleted` callbacks and the `__typename` parameter.
-->
