### PR TITLE
fix: dispatcher fallback toasts and spinner for super follow

### DIFF
--- a/apps/web/src/components/Settings/Account/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Account/SuperFollow.tsx
@@ -47,6 +47,7 @@ const SuperFollow: FC = () => {
       return;
     }
 
+    toast.success(t`Followed successfully!`);
     Mixpanel.track(SETTINGS.ACCOUNT.SET_SUPER_FOLLOW);
   };
 

--- a/apps/web/src/components/Settings/Account/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Account/SuperFollow.tsx
@@ -42,7 +42,11 @@ const SuperFollow: FC = () => {
     skip: !currentProfile?.id
   });
 
-  const onCompleted = () => {
+  const onCompleted = (__typename?: 'RelayError' | 'RelayerResult') => {
+    if (__typename === 'RelayError') {
+      return;
+    }
+
     Mixpanel.track(SETTINGS.ACCOUNT.SET_SUPER_FOLLOW);
   };
 
@@ -51,7 +55,7 @@ const SuperFollow: FC = () => {
     abi: LensHub,
     functionName: 'setFollowModuleWithSig',
     mode: 'recklesslyUnprepared',
-    onSuccess: onCompleted,
+    onSuccess: () => onCompleted(),
     onError
   });
 
@@ -63,7 +67,7 @@ const SuperFollow: FC = () => {
   });
 
   const [broadcast, { loading: broadcastLoading }] = useBroadcastMutation({
-    onCompleted
+    onCompleted: ({ broadcast }) => onCompleted(broadcast.__typename)
   });
   const [createSetFollowModuleTypedData, { loading: typedDataLoading }] =
     useCreateSetFollowModuleTypedDataMutation({

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -2526,10 +2526,6 @@ msgstr "Stafftools | Relay queues • {APP_NAME}"
 msgid "Stafftools | Stats • {APP_NAME}"
 msgstr "Stafftools | Stats • {APP_NAME}"
 
-#: src/components/StaffTools/Stats/index.tsx
-#~ msgid "Stafftools • {APP_NAME}"
-#~ msgstr "Stafftools • {APP_NAME}"
-
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
 msgstr ""

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1626,6 +1626,12 @@ msgid "Invalid Ethereum address"
 msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
+#: src/components/Shared/Follow.tsx
+#: src/components/Shared/SuperFollow/FollowModule.tsx
+msgid "Followed successfully!"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
 msgid "Loading super follow settings"
 msgstr ""
 
@@ -2030,11 +2036,6 @@ msgstr ""
 
 #: src/components/Shared/EmojiPicker/List.tsx
 msgid "Loading emojis"
-msgstr ""
-
-#: src/components/Shared/Follow.tsx
-#: src/components/Shared/SuperFollow/FollowModule.tsx
-msgid "Followed successfully!"
 msgstr ""
 
 #: src/components/Shared/Follow.tsx
@@ -2517,9 +2518,17 @@ msgstr ""
 msgid "Swap in Uniswap"
 msgstr ""
 
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Stafftools | Relay queues • {APP_NAME}"
+msgstr "Stafftools | Relay queues • {APP_NAME}"
+
 #: src/components/StaffTools/Stats/index.tsx
-msgid "Stafftools • {APP_NAME}"
-msgstr "Stafftools • {APP_NAME}"
+msgid "Stafftools | Stats • {APP_NAME}"
+msgstr "Stafftools | Stats • {APP_NAME}"
+
+#: src/components/StaffTools/Stats/index.tsx
+#~ msgid "Stafftools • {APP_NAME}"
+#~ msgstr "Stafftools • {APP_NAME}"
 
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1626,6 +1626,12 @@ msgid "Invalid Ethereum address"
 msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
+#: src/components/Shared/Follow.tsx
+#: src/components/Shared/SuperFollow/FollowModule.tsx
+msgid "Followed successfully!"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
 msgid "Loading super follow settings"
 msgstr ""
 
@@ -2030,11 +2036,6 @@ msgstr ""
 
 #: src/components/Shared/EmojiPicker/List.tsx
 msgid "Loading emojis"
-msgstr ""
-
-#: src/components/Shared/Follow.tsx
-#: src/components/Shared/SuperFollow/FollowModule.tsx
-msgid "Followed successfully!"
 msgstr ""
 
 #: src/components/Shared/Follow.tsx
@@ -2517,9 +2518,17 @@ msgstr ""
 msgid "Swap in Uniswap"
 msgstr ""
 
-#: src/components/StaffTools/Stats/index.tsx
-msgid "Stafftools • {APP_NAME}"
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Stafftools | Relay queues • {APP_NAME}"
 msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "Stafftools | Stats • {APP_NAME}"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+#~ msgid "Stafftools • {APP_NAME}"
+#~ msgstr ""
 
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
@@ -2585,4 +2594,3 @@ msgstr ""
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr ""
-

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -2526,10 +2526,6 @@ msgstr ""
 msgid "Stafftools | Stats • {APP_NAME}"
 msgstr ""
 
-#: src/components/StaffTools/Stats/index.tsx
-#~ msgid "Stafftools • {APP_NAME}"
-#~ msgstr ""
-
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
 msgstr ""

--- a/apps/web/src/locales/kn/messages.po
+++ b/apps/web/src/locales/kn/messages.po
@@ -1626,6 +1626,12 @@ msgid "Invalid Ethereum address"
 msgstr ""
 
 #: src/components/Settings/Account/SuperFollow.tsx
+#: src/components/Shared/Follow.tsx
+#: src/components/Shared/SuperFollow/FollowModule.tsx
+msgid "Followed successfully!"
+msgstr ""
+
+#: src/components/Settings/Account/SuperFollow.tsx
 msgid "Loading super follow settings"
 msgstr ""
 
@@ -2030,11 +2036,6 @@ msgstr ""
 
 #: src/components/Shared/EmojiPicker/List.tsx
 msgid "Loading emojis"
-msgstr ""
-
-#: src/components/Shared/Follow.tsx
-#: src/components/Shared/SuperFollow/FollowModule.tsx
-msgid "Followed successfully!"
 msgstr ""
 
 #: src/components/Shared/Follow.tsx
@@ -2517,9 +2518,17 @@ msgstr ""
 msgid "Swap in Uniswap"
 msgstr ""
 
-#: src/components/StaffTools/Stats/index.tsx
-msgid "Stafftools • {APP_NAME}"
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Stafftools | Relay queues • {APP_NAME}"
 msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "Stafftools | Stats • {APP_NAME}"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+#~ msgid "Stafftools • {APP_NAME}"
+#~ msgstr ""
 
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
@@ -2585,4 +2594,3 @@ msgstr ""
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr ""
-

--- a/apps/web/src/locales/kn/messages.po
+++ b/apps/web/src/locales/kn/messages.po
@@ -2526,10 +2526,6 @@ msgstr ""
 msgid "Stafftools | Stats • {APP_NAME}"
 msgstr ""
 
-#: src/components/StaffTools/Stats/index.tsx
-#~ msgid "Stafftools • {APP_NAME}"
-#~ msgstr ""
-
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
 msgstr ""

--- a/apps/web/src/locales/ta/messages.po
+++ b/apps/web/src/locales/ta/messages.po
@@ -1626,6 +1626,12 @@ msgid "Invalid Ethereum address"
 msgstr "தவறான Ethereum முகவரி"
 
 #: src/components/Settings/Account/SuperFollow.tsx
+#: src/components/Shared/Follow.tsx
+#: src/components/Shared/SuperFollow/FollowModule.tsx
+msgid "Followed successfully!"
+msgstr "வெற்றிகரமாக பின்பற்றப்பட்டது!"
+
+#: src/components/Settings/Account/SuperFollow.tsx
 msgid "Loading super follow settings"
 msgstr "சூப்பர் ஃபாலோ அமைப்புகளை ஏற்றுகிறது"
 
@@ -2031,11 +2037,6 @@ msgstr "இந்த இடுகைக்கு நீங்கள் பதி
 #: src/components/Shared/EmojiPicker/List.tsx
 msgid "Loading emojis"
 msgstr "ஈமோஜிகளை ஏற்றுகிறது"
-
-#: src/components/Shared/Follow.tsx
-#: src/components/Shared/SuperFollow/FollowModule.tsx
-msgid "Followed successfully!"
-msgstr "வெற்றிகரமாக பின்பற்றப்பட்டது!"
 
 #: src/components/Shared/Follow.tsx
 msgid "Follow"
@@ -2517,9 +2518,17 @@ msgstr "உங்களிடம் போதுமான <0>{0}</0> இல்�
 msgid "Swap in Uniswap"
 msgstr "யூனிஸ்வாப்பில் ஸ்வாப் செய்யுங்கள்"
 
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Stafftools | Relay queues • {APP_NAME}"
+msgstr ""
+
 #: src/components/StaffTools/Stats/index.tsx
-msgid "Stafftools • {APP_NAME}"
-msgstr "பணியாளர் கருவிகள் • {APP_NAME}"
+msgid "Stafftools | Stats • {APP_NAME}"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+#~ msgid "Stafftools • {APP_NAME}"
+#~ msgstr "பணியாளர் கருவிகள் • {APP_NAME}"
 
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
@@ -2585,4 +2594,3 @@ msgstr "ஏதோ தவறாகிவிட்டது போல் தெர
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr "இந்தப் பிழைகளைத் தானாகக் கண்காணிக்கிறோம், ஆனால் சிக்கல் தொடர்ந்தால், எங்களைத் தொடர்பு கொள்ளலாம். இதற்கிடையில், புதுப்பித்து முயற்சிக்கவும்."
-

--- a/apps/web/src/locales/ta/messages.po
+++ b/apps/web/src/locales/ta/messages.po
@@ -2526,10 +2526,6 @@ msgstr ""
 msgid "Stafftools | Stats • {APP_NAME}"
 msgstr ""
 
-#: src/components/StaffTools/Stats/index.tsx
-#~ msgid "Stafftools • {APP_NAME}"
-#~ msgstr "பணியாளர் கருவிகள் • {APP_NAME}"
-
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
 msgstr "படத்தின் அளவு 10MB க்கும் குறைவாக இருக்க வேண்டும்"

--- a/apps/web/src/locales/zh/messages.po
+++ b/apps/web/src/locales/zh/messages.po
@@ -2526,10 +2526,6 @@ msgstr ""
 msgid "Stafftools | Stats • {APP_NAME}"
 msgstr ""
 
-#: src/components/StaffTools/Stats/index.tsx
-#~ msgid "Stafftools • {APP_NAME}"
-#~ msgstr "员工工具 • {APP_NAME}"
-
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
 msgstr "图片尺寸应小于 10MB"

--- a/apps/web/src/locales/zh/messages.po
+++ b/apps/web/src/locales/zh/messages.po
@@ -1626,6 +1626,12 @@ msgid "Invalid Ethereum address"
 msgstr "无效的以太坊地址"
 
 #: src/components/Settings/Account/SuperFollow.tsx
+#: src/components/Shared/Follow.tsx
+#: src/components/Shared/SuperFollow/FollowModule.tsx
+msgid "Followed successfully!"
+msgstr "已成功关注！"
+
+#: src/components/Settings/Account/SuperFollow.tsx
 msgid "Loading super follow settings"
 msgstr "正在加载超级关注设置"
 
@@ -2031,11 +2037,6 @@ msgstr "您无法回复此帖子"
 #: src/components/Shared/EmojiPicker/List.tsx
 msgid "Loading emojis"
 msgstr "正在加载表情"
-
-#: src/components/Shared/Follow.tsx
-#: src/components/Shared/SuperFollow/FollowModule.tsx
-msgid "Followed successfully!"
-msgstr "已成功关注！"
 
 #: src/components/Shared/Follow.tsx
 msgid "Follow"
@@ -2517,9 +2518,17 @@ msgstr "您没有足够的 <0>{0}</0>"
 msgid "Swap in Uniswap"
 msgstr "用Uniswap进行代币转换"
 
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Stafftools | Relay queues • {APP_NAME}"
+msgstr ""
+
 #: src/components/StaffTools/Stats/index.tsx
-msgid "Stafftools • {APP_NAME}"
-msgstr "员工工具 • {APP_NAME}"
+msgid "Stafftools | Stats • {APP_NAME}"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+#~ msgid "Stafftools • {APP_NAME}"
+#~ msgstr "员工工具 • {APP_NAME}"
 
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"
@@ -2585,4 +2594,3 @@ msgstr "系统似乎出现了故障！"
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr "我们会自动追踪这些错误，但如果问题仍然存在，请随时与我们联系。 与此同时，您可以尝试刷新页面。"
-


### PR DESCRIPTION
- fix: dispatcher fallback toasts and spinner for super follow
- fix: dispatcher fallback toasts and spinner for super follow

## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 487214a</samp>

This pull request improves the error handling and the localization of the web app, especially for the SuperFollow and staff tools features. It refactors the `onCompleted` callbacks in `SuperFollow.tsx` to check the mutation results, and updates the translation files for English, Spanish, Kannada, Tamil, and Chinese. It also removes some duplicate or unused messages and whitespace from the translation files.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 487214a</samp>

*  Handle possible error case of `useSetFollowModuleMutation` hook by checking the `__typename` of the mutation result and returning early if it is `RelayError` ([link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L45-R50))
*  Simplify the `onSuccess` callback of `useRelayerMutation` hook by calling the `onCompleted` function without any arguments, instead of passing the mutation result ([link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L54-R59))
*  Destructure the `broadcast` property from the mutation result of `useBroadcastMutation` hook and pass its `__typename` to the `onCompleted` function ([link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L66-R71))
*  Add a new message `Followed successfully!` to the translation files for English, Spanish, Kannada, Tamil, and Chinese, with the source locations of the components that use it (`apps/web/src/components/Settings/Account/SuperFollow.tsx` and `apps/web/src/components/Profile/ProfileHeader.tsx`) ([link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365R1629-R1634), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294R1629-R1634), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050R1629-R1634), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48R1629-R1634), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdR1629-R1634))
*  Remove the duplicated message `Followed successfully!` from the translation files for English, Spanish, Kannada, Tamil, and Chinese ([link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365L2036-L2040), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294L2036-L2040), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050L2036-L2040), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48L2036-L2040), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdL2036-L2040))
*  Update the messages for the staff tools pages to reflect the different subpages of relay queues and stats, and comment out the old message `Stafftools • {APP_NAME}` in the translation files for English, Spanish, Kannada, Tamil, and Chinese ([link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365L2520-R2532), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294L2520-R2532), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050L2520-R2532), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48L2520-R2532), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdL2520-R2532))
*  Remove an unnecessary empty line from the translation files for Spanish, Kannada, Tamil, and Chinese ([link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294L2588), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050L2588), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48L2588), [link](https://github.com/lensterxyz/lenster/pull/2553/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdL2588))

## Emoji

<!--
copilot:emoji
-->

🛠️🌐🌟

<!--
1.  🛠️ - This emoji represents the refactoring of the `onCompleted` callback functions, which is a kind of maintenance or improvement of the existing code.
2. 🌐 - This emoji represents the addition and update of messages for the English translation of the web app, which is a kind of localization or internationalization work.
3. 🌟 - This emoji represents the new features of SuperFollow and staff tools, which are enhancements or additions to the web app's functionality.
-->
