### PR TITLE
feat: add export-data feature flag

### DIFF
--- a/packages/data/feature-flags.ts
+++ b/packages/data/feature-flags.ts
@@ -8,7 +8,8 @@ export enum FeatureFlag {
   NftGallery = 'nft-gallery',
   NftDetail = 'nft-detail',
   GatedLocales = 'gated-locales',
-  PublicationAnalytics = 'publication-analytics'
+  PublicationAnalytics = 'publication-analytics',
+  ExportData = 'export-data'
 }
 
 export const featureFlags = [
@@ -35,6 +36,11 @@ export const featureFlags = [
   {
     key: FeatureFlag.PublicationAnalytics,
     name: 'Publication Analytics',
+    enabledFor: [...mainnetStaffs]
+  },
+  {
+    key: FeatureFlag.ExportData,
+    name: 'Export Data Settings',
     enabledFor: [...mainnetStaffs]
   }
 ];

--- a/packages/data/staffs.ts
+++ b/packages/data/staffs.ts
@@ -1,12 +1,8 @@
+import { aaveMembers } from 'aave-members';
+
 import { lensterMembers } from './lenster-members';
 
-export const mainnetStaffs = [
-  '0x2d', // sasicodes
-  '0x16', // davidev
-  '0x06', // wagmi
-  '0x05', // stani
-  ...lensterMembers
-];
+export const mainnetStaffs = [...lensterMembers, ...aaveMembers];
 
 export const testnetStaffs = [
   '0x15', // yoginth.test

--- a/packages/data/staffs.ts
+++ b/packages/data/staffs.ts
@@ -1,5 +1,4 @@
-import { aaveMembers } from 'aave-members';
-
+import { aaveMembers } from './aave-members';
 import { lensterMembers } from './lenster-members';
 
 export const mainnetStaffs = [...lensterMembers, ...aaveMembers];


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a580439</samp>

Added a feature flag for export data settings and refactored staffs array. The feature flag `ExportData` allows Lenster and Aave staffs to access the export data settings page in the `packages/data` package. The `mainnetStaffs` array in `packages/data/staffs.ts` was simplified by using the `aaveMembers` array from the `aave-members` package.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a580439</samp>

*  Add `ExportData` feature flag to control access to data export settings page ([link](https://github.com/lensterxyz/lenster/pull/2580/files?diff=unified&w=0#diff-e06e181e3ef331e886fe8bfb4b664826e1a3ae2d1f22097dd7273c0e917c566eL11-R12), [link](https://github.com/lensterxyz/lenster/pull/2580/files?diff=unified&w=0#diff-e06e181e3ef331e886fe8bfb4b664826e1a3ae2d1f22097dd7273c0e917c566eR40-R44))
*  Refactor `mainnetStaffs` array to use `aaveMembers` array from `aave-members` package ([link](https://github.com/lensterxyz/lenster/pull/2580/files?diff=unified&w=0#diff-1d00c09528308d0b026cd6fe1a20bc27d560aff8dc368ceff7db46627457a1f6L1-R5))

## Emoji

<!--
copilot:emoji
-->

📦🧑‍🤝‍🧑🚩

<!--
1.  📦 This emoji can be used to indicate that a new package or dependency was added to the project, in this case the `aave-members` package.
2.  🧑‍🤝‍🧑 This emoji can be used to indicate that a collaboration or partnership was established or improved, in this case between Lenster and Aave.
3.  🚩 This emoji can be used to indicate that a new feature flag or configuration option was added or changed, in this case the `ExportData` flag.
-->
