### PR TITLE
feat: add export page and export publications feature

### DIFF
--- a/apps/web/src/components/Settings/Export/Publications.tsx
+++ b/apps/web/src/components/Settings/Export/Publications.tsx
@@ -69,7 +69,7 @@ const Publications: FC = () => {
         <Trans>Export Publications</Trans>
       </div>
       <div className="pb-2">
-        <Trans>Export all your publications to a JSON file.</Trans>
+        <Trans>Export all your posts, comments and mirrors to a JSON file.</Trans>
       </div>
       {publications.length > 0 ? (
         <div className="pb-2">

--- a/apps/web/src/components/Settings/Export/Publications.tsx
+++ b/apps/web/src/components/Settings/Export/Publications.tsx
@@ -66,7 +66,7 @@ const Publications: FC = () => {
   return (
     <Card className="space-y-2 p-5">
       <div className="text-lg font-bold">
-        <Trans>Export Publications</Trans>
+        <Trans>Export publications</Trans>
       </div>
       <div className="pb-2">
         <Trans>Export all your posts, comments and mirrors to a JSON file.</Trans>
@@ -78,7 +78,7 @@ const Publications: FC = () => {
       ) : null}
       {fetchCompleted ? (
         <Button onClick={downloadPublications}>
-          <Trans>Download Publication</Trans>
+          <Trans>Download publications</Trans>
         </Button>
       ) : (
         <Button onClick={handleExportClick} disabled={exporting}>

--- a/apps/web/src/components/Settings/Export/Publications.tsx
+++ b/apps/web/src/components/Settings/Export/Publications.tsx
@@ -1,0 +1,92 @@
+import { Trans } from '@lingui/macro';
+import type { PublicationsQueryRequest } from 'lens';
+import { PublicationTypes, useProfileFeedLazyQuery } from 'lens';
+import type { FC } from 'react';
+import { useState } from 'react';
+import { useAppStore } from 'src/store/app';
+import { Button, Card } from 'ui';
+
+const Publications: FC = () => {
+  const currentProfile = useAppStore((state) => state.currentProfile);
+  const [publications, setPublications] = useState<any[]>([]);
+  const [exporting, setExporting] = useState(false);
+  const [fetchCompleted, setFetchCompleted] = useState(false);
+
+  const request: PublicationsQueryRequest = {
+    profileId: currentProfile?.id,
+    publicationTypes: [PublicationTypes.Post, PublicationTypes.Comment, PublicationTypes.Mirror],
+    limit: 50
+  };
+
+  const [exportPublications] = useProfileFeedLazyQuery({
+    fetchPolicy: 'network-only'
+  });
+
+  const handleExportClick = async () => {
+    setExporting(true);
+    const fetchPublications = async (cursor?: string) => {
+      const { data } = await exportPublications({
+        variables: { request: { ...request, cursor } },
+        onCompleted: (data) => {
+          setPublications((prev) => {
+            const newPublications = data.publications.items.filter((newPublication) => {
+              return !prev.some((publication) => publication.id === newPublication.id);
+            });
+
+            return [...prev, ...newPublications];
+          });
+        }
+      });
+
+      if (data?.publications.pageInfo.next) {
+        await fetchPublications(data?.publications.pageInfo.next);
+      } else {
+        if (cursor) {
+          setFetchCompleted(true);
+          setExporting(false);
+        }
+      }
+    };
+
+    await fetchPublications();
+  };
+
+  const downloadPublications = () => {
+    const element = document.createElement('a');
+    const file = new Blob([JSON.stringify(publications)], { type: 'application/json' });
+    element.href = URL.createObjectURL(file);
+    element.download = 'publications.json';
+    document.body.appendChild(element);
+    element.click();
+
+    setPublications([]);
+    setFetchCompleted(false);
+  };
+
+  return (
+    <Card className="space-y-2 p-5">
+      <div className="text-lg font-bold">
+        <Trans>Export Publications</Trans>
+      </div>
+      <div className="pb-2">
+        <Trans>Export all your publications to a JSON file.</Trans>
+      </div>
+      {publications.length > 0 ? (
+        <div className="pb-2">
+          Exported <b>{publications.length}</b> publications
+        </div>
+      ) : null}
+      {fetchCompleted ? (
+        <Button onClick={downloadPublications}>
+          <Trans>Download Publication</Trans>
+        </Button>
+      ) : (
+        <Button onClick={handleExportClick} disabled={exporting}>
+          <Trans>Export now</Trans>
+        </Button>
+      )}
+    </Card>
+  );
+};
+
+export default Publications;

--- a/apps/web/src/components/Settings/Export/index.tsx
+++ b/apps/web/src/components/Settings/Export/index.tsx
@@ -1,0 +1,45 @@
+import MetaTags from '@components/Common/MetaTags';
+import { Mixpanel } from '@lib/mixpanel';
+import { t } from '@lingui/macro';
+import { FeatureFlag } from 'data';
+import { APP_NAME } from 'data/constants';
+import isFeatureEnabled from 'lib/isFeatureEnabled';
+import type { NextPage } from 'next';
+import { useEffect } from 'react';
+import Custom404 from 'src/pages/404';
+import { useAppStore } from 'src/store/app';
+import { PAGEVIEW } from 'src/tracking';
+import { GridItemEight, GridItemFour, GridLayout } from 'ui';
+
+import SettingsSidebar from '../Sidebar';
+import Publications from './Publications';
+
+const ExportSettings: NextPage = () => {
+  const currentProfile = useAppStore((state) => state.currentProfile);
+
+  useEffect(() => {
+    Mixpanel.track(PAGEVIEW, { page: 'settings', subpage: 'export' });
+  }, []);
+
+  if (!isFeatureEnabled(FeatureFlag.ExportData, currentProfile?.id)) {
+    return <Custom404 />;
+  }
+
+  if (!currentProfile) {
+    return <Custom404 />;
+  }
+
+  return (
+    <GridLayout>
+      <MetaTags title={t`Account settings • ${APP_NAME}`} />
+      <GridItemFour>
+        <SettingsSidebar />
+      </GridItemFour>
+      <GridItemEight className="space-y-5">
+        <Publications />
+      </GridItemEight>
+    </GridLayout>
+  );
+};
+
+export default ExportSettings;

--- a/apps/web/src/components/Settings/Sidebar.tsx
+++ b/apps/web/src/components/Settings/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   AdjustmentsIcon,
   BookmarkIcon,
   ChipIcon,
+  DatabaseIcon,
   ExclamationIcon,
   FingerPrintIcon,
   ShareIcon,
@@ -11,7 +12,9 @@ import {
   UserIcon
 } from '@heroicons/react/outline';
 import { t, Trans } from '@lingui/macro';
+import { FeatureFlag } from 'data';
 import type { Profile } from 'lens';
+import isFeatureEnabled from 'lib/isFeatureEnabled';
 import type { FC } from 'react';
 import { useAppStore } from 'src/store/app';
 
@@ -59,6 +62,12 @@ const SettingsSidebar: FC = () => {
             title: t`Cleanup`,
             icon: <SparklesIcon className="h-4 w-4" />,
             url: '/settings/cleanup'
+          },
+          {
+            title: t`Export`,
+            icon: <DatabaseIcon className="h-4 w-4" />,
+            url: '/settings/export',
+            enabled: isFeatureEnabled(FeatureFlag.ExportData, currentProfile?.id)
           },
           {
             title: (

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1670,6 +1670,7 @@ msgid "Request Verification"
 msgstr ""
 
 #: src/components/Settings/Account/index.tsx
+#: src/components/Settings/Export/index.tsx
 msgid "Account settings • {APP_NAME}"
 msgstr "Account settings • {APP_NAME}"
 
@@ -1843,6 +1844,22 @@ msgstr "Disable Signless Transactions"
 msgid "Dispatcher • {APP_NAME}"
 msgstr "Dispatcher • {APP_NAME}"
 
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export Publications"
+msgstr "Export Publications"
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export all your posts, comments and mirrors to a JSON file."
+msgstr "Export all your posts, comments and mirrors to a JSON file."
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Download Publication"
+msgstr "Download Publication"
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export now"
+msgstr "Export now"
+
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
 msgstr "Interests settings • {APP_NAME}"
@@ -1983,6 +2000,10 @@ msgstr ""
 #: src/components/Settings/Sidebar.tsx
 msgid "Allowance"
 msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Export"
+msgstr "Export"
 
 #: src/components/Shared/Alert/DeletePublication.tsx
 msgid "Publication deleted successfully"

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -1845,20 +1845,28 @@ msgid "Dispatcher • {APP_NAME}"
 msgstr "Dispatcher • {APP_NAME}"
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Export Publications"
-msgstr "Export Publications"
+msgid "Export publications"
+msgstr "Export publications"
 
 #: src/components/Settings/Export/Publications.tsx
 msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr "Export all your posts, comments and mirrors to a JSON file."
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download Publication"
-msgstr "Download Publication"
+msgid "Download publications"
+msgstr "Download publications"
 
 #: src/components/Settings/Export/Publications.tsx
 msgid "Export now"
 msgstr "Export now"
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Export Publications"
+#~ msgstr "Export Publications"
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Download Publication"
+#~ msgstr "Download Publication"
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1845,7 +1845,7 @@ msgid "Dispatcher • {APP_NAME}"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Export Publications"
+msgid "Export publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
@@ -1853,12 +1853,20 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download Publication"
+msgid "Download publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
 msgid "Export now"
 msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Export Publications"
+#~ msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Download Publication"
+#~ msgstr ""
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -1670,6 +1670,7 @@ msgid "Request Verification"
 msgstr ""
 
 #: src/components/Settings/Account/index.tsx
+#: src/components/Settings/Export/index.tsx
 msgid "Account settings • {APP_NAME}"
 msgstr ""
 
@@ -1843,6 +1844,22 @@ msgstr ""
 msgid "Dispatcher • {APP_NAME}"
 msgstr ""
 
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export Publications"
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export all your posts, comments and mirrors to a JSON file."
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Download Publication"
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export now"
+msgstr ""
+
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
 msgstr ""
@@ -1982,6 +1999,10 @@ msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Allowance"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Export"
 msgstr ""
 
 #: src/components/Shared/Alert/DeletePublication.tsx
@@ -2593,4 +2614,3 @@ msgstr ""
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr ""
-

--- a/apps/web/src/locales/kn/messages.po
+++ b/apps/web/src/locales/kn/messages.po
@@ -1845,7 +1845,7 @@ msgid "Dispatcher • {APP_NAME}"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Export Publications"
+msgid "Export publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
@@ -1853,12 +1853,20 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download Publication"
+msgid "Download publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
 msgid "Export now"
 msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Export Publications"
+#~ msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Download Publication"
+#~ msgstr ""
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"

--- a/apps/web/src/locales/kn/messages.po
+++ b/apps/web/src/locales/kn/messages.po
@@ -1670,6 +1670,7 @@ msgid "Request Verification"
 msgstr ""
 
 #: src/components/Settings/Account/index.tsx
+#: src/components/Settings/Export/index.tsx
 msgid "Account settings • {APP_NAME}"
 msgstr ""
 
@@ -1843,6 +1844,22 @@ msgstr ""
 msgid "Dispatcher • {APP_NAME}"
 msgstr ""
 
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export Publications"
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export all your posts, comments and mirrors to a JSON file."
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Download Publication"
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export now"
+msgstr ""
+
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
 msgstr ""
@@ -1982,6 +1999,10 @@ msgstr ""
 
 #: src/components/Settings/Sidebar.tsx
 msgid "Allowance"
+msgstr ""
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Export"
 msgstr ""
 
 #: src/components/Shared/Alert/DeletePublication.tsx
@@ -2593,4 +2614,3 @@ msgstr ""
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr ""
-

--- a/apps/web/src/locales/ta/messages.po
+++ b/apps/web/src/locales/ta/messages.po
@@ -1670,6 +1670,7 @@ msgid "Request Verification"
 msgstr "சரிபார்ப்பு கோரிக்கை"
 
 #: src/components/Settings/Account/index.tsx
+#: src/components/Settings/Export/index.tsx
 msgid "Account settings • {APP_NAME}"
 msgstr "கணக்கு அமைப்புகள் • {APP_NAME}"
 
@@ -1843,6 +1844,22 @@ msgstr ""
 msgid "Dispatcher • {APP_NAME}"
 msgstr ""
 
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export Publications"
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export all your posts, comments and mirrors to a JSON file."
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Download Publication"
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export now"
+msgstr ""
+
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
 msgstr "ஆர்வங்கள் அமைப்புகள் • {APP_NAME}"
@@ -1983,6 +2000,10 @@ msgstr "டிஸ்பெட்சேர்"
 #: src/components/Settings/Sidebar.tsx
 msgid "Allowance"
 msgstr "கொடுப்பனவு"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Export"
+msgstr ""
 
 #: src/components/Shared/Alert/DeletePublication.tsx
 msgid "Publication deleted successfully"
@@ -2593,4 +2614,3 @@ msgstr "ஏதோ தவறாகிவிட்டது போல் தெர
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr "இந்தப் பிழைகளைத் தானாகக் கண்காணிக்கிறோம், ஆனால் சிக்கல் தொடர்ந்தால், எங்களைத் தொடர்பு கொள்ளலாம். இதற்கிடையில், புதுப்பித்து முயற்சிக்கவும்."
-

--- a/apps/web/src/locales/ta/messages.po
+++ b/apps/web/src/locales/ta/messages.po
@@ -1845,7 +1845,7 @@ msgid "Dispatcher • {APP_NAME}"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Export Publications"
+msgid "Export publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
@@ -1853,12 +1853,20 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download Publication"
+msgid "Download publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
 msgid "Export now"
 msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Export Publications"
+#~ msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Download Publication"
+#~ msgstr ""
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"

--- a/apps/web/src/locales/zh/messages.po
+++ b/apps/web/src/locales/zh/messages.po
@@ -1670,6 +1670,7 @@ msgid "Request Verification"
 msgstr "请求验证"
 
 #: src/components/Settings/Account/index.tsx
+#: src/components/Settings/Export/index.tsx
 msgid "Account settings • {APP_NAME}"
 msgstr "帐户设置 • {APP_NAME}"
 
@@ -1843,6 +1844,22 @@ msgstr ""
 msgid "Dispatcher • {APP_NAME}"
 msgstr "调度员 • {APP_NAME}"
 
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export Publications"
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export all your posts, comments and mirrors to a JSON file."
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Download Publication"
+msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+msgid "Export now"
+msgstr ""
+
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
 msgstr "兴趣设置 • {APP_NAME}"
@@ -1983,6 +2000,10 @@ msgstr "调度员"
 #: src/components/Settings/Sidebar.tsx
 msgid "Allowance"
 msgstr "授权设置"
+
+#: src/components/Settings/Sidebar.tsx
+msgid "Export"
+msgstr ""
 
 #: src/components/Shared/Alert/DeletePublication.tsx
 msgid "Publication deleted successfully"
@@ -2593,4 +2614,3 @@ msgstr "系统似乎出现了故障！"
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr "我们会自动追踪这些错误，但如果问题仍然存在，请随时与我们联系。 与此同时，您可以尝试刷新页面。"
-

--- a/apps/web/src/locales/zh/messages.po
+++ b/apps/web/src/locales/zh/messages.po
@@ -1845,7 +1845,7 @@ msgid "Dispatcher • {APP_NAME}"
 msgstr "调度员 • {APP_NAME}"
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Export Publications"
+msgid "Export publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
@@ -1853,12 +1853,20 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download Publication"
+msgid "Download publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
 msgid "Export now"
 msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Export Publications"
+#~ msgstr ""
+
+#: src/components/Settings/Export/Publications.tsx
+#~ msgid "Download Publication"
+#~ msgstr ""
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"

--- a/apps/web/src/pages/settings/export.tsx
+++ b/apps/web/src/pages/settings/export.tsx
@@ -1,0 +1,3 @@
+import ExportSettings from '@components/Settings/Export';
+
+export default ExportSettings;


### PR DESCRIPTION
- feat: able to export publications
- chore: update translations

## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aec9c72</samp>

This pull request adds a new feature to the web app that allows users to export their publications to a JSON file. It creates a new page `/settings/export` that renders a sidebar with an export option and a component that fetches and downloads the publications. It also updates the localization files for several languages with new messages and comments.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aec9c72</samp>

*  Add a new page `ExportSettings` that allows users to export their publications to a JSON file ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-bd751d5d25e52b16b1689f54120579264ff020ea751f1ce239a8f4ffbbcc797fR1-R45), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-e5b70c087dbac74226ca45b33a014106f1ebd2659c9efb586535f36f76718b29R1-R3))
*  Check the feature flag `ExportData` for the current profile and return a custom 404 page if not enabled ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-bd751d5d25e52b16b1689f54120579264ff020ea751f1ce239a8f4ffbbcc797fR1-R45), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-464cfc03ff20f2199bbff2659eece544d3cf9463d6e5405ae54e345f3ad469a1L14-R17))
*  Use the `MetaTags` component to set the page title and the `Mixpanel` library to track the page view event ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-bd751d5d25e52b16b1689f54120579264ff020ea751f1ce239a8f4ffbbcc797fR1-R45))
*  Render the `Publications` component inside a `GridLayout` with a `SettingsSidebar` ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-bd751d5d25e52b16b1689f54120579264ff020ea751f1ce239a8f4ffbbcc797fR1-R45), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-464cfc03ff20f2199bbff2659eece544d3cf9463d6e5405ae54e345f3ad469a1R67-R72))
*  Add a new component `Publications` that fetches the publications from the `lens` API and stores them in a state hook ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-1263fa8cf102e393728bd7ee4c79e2b5ffcce8a0da95df700ed4b8be46efa99bR1-R92))
*  Add a button to trigger the export and another button to download the file when the export is completed ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-1263fa8cf102e393728bd7ee4c79e2b5ffcce8a0da95df700ed4b8be46efa99bR1-R92))
*  Add the `DatabaseIcon` to the `SettingsSidebar` as the icon for the export option ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-464cfc03ff20f2199bbff2659eece544d3cf9463d6e5405ae54e345f3ad469a1R7))
*  Add the messages for the `Publications` component and the `Export` option to the `messages.po` files for different locales ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365R1847-R1862), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365R2004-R2007), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294R1847-R1862), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294R2004-R2007), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050R1847-R1862), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050R2004-R2007), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48R1847-R1862), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48R2004-R2007), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdR1847-R1862), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdR2004-R2007))
*  Remove empty lines from the `messages.po` files for some locales ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294L2596), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050L2596), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48L2596), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdL2596))
*  Add comments to the `messages.po` files indicating the source file of the messages ([link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365R1673), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294R1673), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050R1673), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48R1673), [link](https://github.com/lensterxyz/lenster/pull/2581/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdR1673))

## Emoji

<!--
copilot:emoji
-->

📥🌐⚙️

<!--
1.  📥 This emoji represents the export functionality that allows users to download their publications as a JSON file. It conveys the idea of saving or transferring data from the web app to the local device.
2. 🌐 This emoji represents the internationalization and localization of the web app interface. It conveys the idea of supporting multiple languages and cultures for the users.
3. ⚙️ This emoji represents the settings page where users can access the export option and other preferences. It conveys the idea of customization and configuration of the web app.
-->
