### PR TITLE
chore: add more and refactor i18n strings

### DIFF
--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -564,9 +564,7 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
             }
             onClick={createPublication}
           >
-            {isComment
-              ? t({ id: '[cta]Comment', message: 'Comment' })
-              : t({ id: '[cta]Post', message: 'Post' })}
+            {isComment ? t`Comment` : t`Post`}
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/Settings/Export/Notifications.tsx
+++ b/apps/web/src/components/Settings/Export/Notifications.tsx
@@ -68,7 +68,9 @@ const Notifications: FC = () => {
       </div>
       {notifications.length > 0 ? (
         <div className="pb-2">
-          Exported <b>{notifications.length}</b> notifications
+          <Trans>
+            Exported <b>{notifications.length}</b> notifications
+          </Trans>
         </div>
       ) : null}
       {fetchCompleted ? (

--- a/apps/web/src/components/Settings/Export/Publications.tsx
+++ b/apps/web/src/components/Settings/Export/Publications.tsx
@@ -67,7 +67,9 @@ const Publications: FC = () => {
       </div>
       {publications.length > 0 ? (
         <div className="pb-2">
-          Exported <b>{publications.length}</b> publications
+          <Trans>
+            Exported <b>{publications.length}</b> publications
+          </Trans>
         </div>
       ) : null}
       {fetchCompleted ? (

--- a/apps/web/src/components/StaffTools/Panels/Profile.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Profile.tsx
@@ -8,6 +8,7 @@ import {
   PhotographIcon
 } from '@heroicons/react/outline';
 import { ShieldCheckIcon } from '@heroicons/react/solid';
+import { t, Trans } from '@lingui/macro';
 import { APP_NAME } from 'data/constants';
 import type { Profile } from 'lens';
 import formatAddress from 'lib/formatAddress';
@@ -29,7 +30,9 @@ const ProfileStaffTool: FC<ProfileStaffToolProps> = ({ profile }) => {
     <Card as="aside" className="mt-5 border-yellow-400 !bg-yellow-300 !bg-opacity-20 p-5">
       <div className="flex items-center space-x-2 text-yellow-600">
         <ShieldCheckIcon className="h-5 w-5" />
-        <div className="text-lg font-bold">Staff tool</div>
+        <div className="text-lg font-bold">
+          <Trans>Staff tool</Trans>
+        </div>
       </div>
       <div className="mt-3 space-y-1.5">
         {getProfileAttribute(profile?.attributes, 'app') === APP_NAME && (
@@ -45,35 +48,35 @@ const ProfileStaffTool: FC<ProfileStaffToolProps> = ({ profile }) => {
             }
             value={formatHandle(profile?.handle)}
           >
-            {APP_NAME} account
+            <Trans>{APP_NAME} account</Trans>
           </MetaDetails>
         )}
         <MetaDetails
           icon={<HashtagIcon className="lt-text-gray-500 h-4 w-4" />}
           value={profile?.id}
-          title="Profile ID"
+          title={t`Profile ID`}
         >
           {profile?.id}
         </MetaDetails>
         <MetaDetails
           icon={<CashIcon className="lt-text-gray-500 h-4 w-4" />}
           value={profile?.ownedBy}
-          title="Address"
+          title={t`Address`}
         >
           {formatAddress(profile?.ownedBy)}
         </MetaDetails>
         <MetaDetails
           icon={<HandIcon className="lt-text-gray-500 h-4 w-4" />}
           value={profile?.dispatcher?.canUseRelay ? 'Yes' : 'No'}
-          title="Dispatcher enabled"
+          title={t`Can use relay`}
         >
           {profile?.dispatcher?.canUseRelay ? 'Yes' : 'No'}
         </MetaDetails>
         {profile?.followNftAddress ? (
           <MetaDetails
             icon={<PhotographIcon className="lt-text-gray-500 h-4 w-4" />}
-            value={profile?.ownedBy}
-            title="NFT address"
+            value={profile?.followNftAddress}
+            title={t`NFT address`}
           >
             {formatAddress(profile?.followNftAddress)}
           </MetaDetails>
@@ -81,24 +84,24 @@ const ProfileStaffTool: FC<ProfileStaffToolProps> = ({ profile }) => {
         <MetaDetails
           icon={<AtSymbolIcon className="lt-text-gray-500 h-4 w-4" />}
           value={formatHandle(profile?.handle)}
-          title="Handle"
+          title={t`Handle`}
         >
           {formatHandle(profile?.handle)}
         </MetaDetails>
         <MetaDetails
           icon={<IdentificationIcon className="lt-text-gray-500 h-4 w-4" />}
           value={formatHandle(profile?.handle)}
-          title="Follow module"
+          title={t`Follow module`}
         >
           {getFollowModule(profile?.followModule?.__typename).description}
         </MetaDetails>
         <MetaDetails
           icon={<LinkIcon className="lt-text-gray-500 h-4 w-4" />}
           value={profile?.metadata}
-          title="Metadata"
+          title={t`Metadata`}
         >
           <a href={profile?.metadata} target="_blank" rel="noreferrer">
-            Open
+            <Trans>Open</Trans>
           </a>
         </MetaDetails>
       </div>

--- a/apps/web/src/components/StaffTools/Panels/Publication.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Publication.tsx
@@ -1,5 +1,6 @@
 import { CollectionIcon, GlobeAltIcon, HashtagIcon, LinkIcon } from '@heroicons/react/outline';
 import { ShieldCheckIcon } from '@heroicons/react/solid';
+import { t, Trans } from '@lingui/macro';
 import type { Publication } from 'lens';
 import sanitizeDStorageUrl from 'lib/sanitizeDStorageUrl';
 import type { FC } from 'react';
@@ -18,13 +19,15 @@ const PublicationStaffTool: FC<PublicationStaffToolProps> = ({ publication }) =>
     <Card as="aside" className="mt-5 border-yellow-400 !bg-yellow-300 !bg-opacity-20 p-5">
       <div className="flex items-center space-x-2 text-yellow-600">
         <ShieldCheckIcon className="h-5 w-5" />
-        <div className="text-lg font-bold">Staff tool</div>
+        <div className="text-lg font-bold">
+          <Trans>Staff tool</Trans>
+        </div>
       </div>
       <div className="mt-3 space-y-1.5">
         <MetaDetails
           icon={<HashtagIcon className="lt-text-gray-500 h-4 w-4" />}
           value={publication?.id}
-          title="Publication ID"
+          title={t`Publication ID`}
         >
           {publication?.id}
         </MetaDetails>
@@ -32,7 +35,7 @@ const PublicationStaffTool: FC<PublicationStaffToolProps> = ({ publication }) =>
           <MetaDetails
             icon={<HashtagIcon className="lt-text-gray-500 h-4 w-4" />}
             value={publication?.commentOn?.id}
-            title="Parent ID"
+            title={t`Comment on`}
           >
             {publication?.commentOn?.id}
           </MetaDetails>
@@ -40,24 +43,24 @@ const PublicationStaffTool: FC<PublicationStaffToolProps> = ({ publication }) =>
         <MetaDetails
           icon={<CollectionIcon className="lt-text-gray-500 h-4 w-4" />}
           value={publication?.collectModule?.type}
-          title="Collect module"
+          title={t`Collect module`}
         >
           {publication?.collectModule?.type}
         </MetaDetails>
         <MetaDetails
           icon={<GlobeAltIcon className="lt-text-gray-500 h-4 w-4" />}
           value={publication?.id}
-          title="Posted via"
+          title={t`App ID`}
         >
           {publication?.appId}
         </MetaDetails>
         <MetaDetails
           icon={<LinkIcon className="lt-text-gray-500 h-4 w-4" />}
           value={sanitizeDStorageUrl(publication?.onChainContentURI)}
-          title="On-chain content URI"
+          title={t`On-chain content URI`}
         >
           <a href={sanitizeDStorageUrl(publication?.onChainContentURI)} target="_blank" rel="noreferrer">
-            Open
+            <Trans>Open</Trans>
           </a>
         </MetaDetails>
       </div>

--- a/apps/web/src/components/StaffTools/RelayQueues.tsx
+++ b/apps/web/src/components/StaffTools/RelayQueues.tsx
@@ -1,7 +1,7 @@
 import MetaTags from '@components/Common/MetaTags';
 import useStaffMode from '@components/utils/hooks/useStaffMode';
 import { Mixpanel } from '@lib/mixpanel';
-import { t } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import { APP_NAME, POLYGONSCAN_URL } from 'data/constants';
 import Errors from 'data/errors';
 import { useRelayQueuesQuery } from 'lens';
@@ -40,7 +40,9 @@ export const Relay: FC<RelayProps> = ({ address, queue, relayer }) => {
       </div>
       <div className="flex flex-col items-center">
         <b className="text-xl">{queue}</b>
-        <span className="lt-text-gray-500">Transactions</span>
+        <span className="lt-text-gray-500">
+          <Trans>Transactions</Trans>
+        </span>
       </div>
     </Card>
   );
@@ -84,7 +86,9 @@ const RelayQueues: NextPage = () => {
             </div>
           ) : (
             <section className="space-y-3">
-              <h1 className="mb-4 text-xl font-bold">Relay queues</h1>
+              <h1 className="mb-4 text-xl font-bold">
+                <Trans>Relay queues</Trans>
+              </h1>
               <div className="space-y-3">
                 {sortedRelays?.map(({ address, queue, relayer }) => (
                   <Relay key={address} address={address} queue={queue} relayer={relayer} />

--- a/apps/web/src/components/StaffTools/Sidebar.tsx
+++ b/apps/web/src/components/StaffTools/Sidebar.tsx
@@ -1,5 +1,6 @@
 import Sidebar from '@components/Shared/Sidebar';
 import { ChartPieIcon, ViewListIcon } from '@heroicons/react/outline';
+import { t } from '@lingui/macro';
 import type { FC } from 'react';
 
 const StaffToolsSidebar: FC = () => {
@@ -7,12 +8,12 @@ const StaffToolsSidebar: FC = () => {
     <Sidebar
       items={[
         {
-          title: 'Stats',
+          title: t`Stats`,
           icon: <ChartPieIcon className="h-4 w-4" />,
           url: '/stafftools'
         },
         {
-          title: 'Relay queues',
+          title: t`Relay queues`,
           icon: <ViewListIcon className="h-4 w-4" />,
           url: '/stafftools/relayqueues'
         }

--- a/apps/web/src/components/StaffTools/Stats/index.tsx
+++ b/apps/web/src/components/StaffTools/Stats/index.tsx
@@ -13,7 +13,7 @@ import {
 import { PencilAltIcon } from '@heroicons/react/solid';
 import { getTimeAddedNDayUnix, getTimeMinusNDayUnix } from '@lib/formatTime';
 import { Mixpanel } from '@lib/mixpanel';
-import { t } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import clsx from 'clsx';
 import { APP_NAME } from 'data/constants';
 import Errors from 'data/errors';
@@ -125,28 +125,30 @@ const Stats: NextPage = () => {
             </div>
           ) : (
             <section className="space-y-3">
-              <h1 className="mb-4 text-xl font-bold">Stats</h1>
+              <h1 className="mb-4 text-xl font-bold">
+                <Trans>Stats</Trans>
+              </h1>
               <div className="block justify-between space-y-3 sm:flex sm:space-x-3 sm:space-y-0">
                 <StatBox
                   icon={<UsersIcon className="h-6 w-6" />}
                   value={stats?.totalProfiles}
                   todayValue={todayStats?.totalProfiles}
                   differenceValue={yesterdayStats?.totalProfiles - todayStats?.totalProfiles}
-                  title="total profiles"
+                  title={t`total profiles`}
                 />
                 <StatBox
                   icon={<FireIcon className="h-6 w-6" />}
                   value={stats?.totalBurntProfiles}
                   todayValue={todayStats?.totalBurntProfiles}
                   differenceValue={yesterdayStats?.totalBurntProfiles - todayStats?.totalBurntProfiles}
-                  title="profiles burnt"
+                  title={t`profiles burnt`}
                 />
                 <StatBox
                   icon={<PencilAltIcon className="h-6 w-6" />}
                   value={stats?.totalPosts}
                   todayValue={todayStats?.totalPosts}
                   differenceValue={yesterdayStats?.totalPosts - todayStats?.totalPosts}
-                  title="total posts"
+                  title={t`total posts`}
                 />
               </div>
               <div className="block justify-between space-y-3 sm:flex sm:space-x-3 sm:space-y-0">
@@ -155,14 +157,14 @@ const Stats: NextPage = () => {
                   value={stats?.totalMirrors}
                   todayValue={todayStats?.totalMirrors}
                   differenceValue={yesterdayStats?.totalMirrors - todayStats?.totalMirrors}
-                  title="total mirrors"
+                  title={t`total mirrors`}
                 />
                 <StatBox
                   icon={<ChatAlt2Icon className="h-6 w-6" />}
                   value={stats?.totalComments}
                   todayValue={todayStats?.totalComments}
                   differenceValue={yesterdayStats?.totalComments - todayStats?.totalComments}
-                  title="total comments"
+                  title={t`total comments`}
                 />
               </div>
               <div className="block justify-between space-y-3 sm:flex sm:space-x-3 sm:space-y-0">
@@ -171,14 +173,14 @@ const Stats: NextPage = () => {
                   value={stats?.totalCollects}
                   todayValue={todayStats?.totalCollects}
                   differenceValue={yesterdayStats?.totalCollects - todayStats?.totalCollects}
-                  title="total collects"
+                  title={t`total collects`}
                 />
                 <StatBox
                   icon={<UserAddIcon className="h-6 w-6" />}
                   value={stats?.totalFollows}
                   todayValue={todayStats?.totalFollows}
                   differenceValue={yesterdayStats?.totalFollows - todayStats?.totalFollows}
-                  title="total follows"
+                  title={t`total follows`}
                 />
               </div>
             </section>

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -252,12 +252,13 @@ msgid "Transaction failed!"
 msgstr ""
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Comment"
-msgstr "Comment"
+msgid "Post"
+msgstr "Post"
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Post"
-msgstr "Post"
+#: src/components/Publication/Actions/Comment.tsx
+msgid "Comment"
+msgstr ""
 
 #: src/components/Composer/Post/New.tsx
 msgid "Create post"
@@ -1421,10 +1422,6 @@ msgstr ""
 msgid "{0} Comments"
 msgstr ""
 
-#: src/components/Publication/Actions/Comment.tsx
-msgid "Comment"
-msgstr ""
-
 #: src/components/Publication/Actions/Like.tsx
 msgid "Dislike"
 msgstr ""
@@ -1853,6 +1850,10 @@ msgid "Export all your notifications to a JSON file."
 msgstr "Export all your notifications to a JSON file."
 
 #: src/components/Settings/Export/Notifications.tsx
+msgid "Exported <0>{0}</0> notifications"
+msgstr "Exported <0>{0}</0> notifications"
+
+#: src/components/Settings/Export/Notifications.tsx
 msgid "Download notifications"
 msgstr "Download notifications"
 
@@ -1889,16 +1890,12 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr "Export all your posts, comments and mirrors to a JSON file."
 
 #: src/components/Settings/Export/Publications.tsx
+msgid "Exported <0>{0}</0> publications"
+msgstr "Exported <0>{0}</0> publications"
+
+#: src/components/Settings/Export/Publications.tsx
 msgid "Download publications"
 msgstr "Download publications"
-
-#: src/components/Settings/Export/Publications.tsx
-#~ msgid "Export Publications"
-#~ msgstr "Export Publications"
-
-#: src/components/Settings/Export/Publications.tsx
-#~ msgid "Download Publication"
-#~ msgstr "Download Publication"
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
@@ -2223,6 +2220,7 @@ msgid "Sign up to {APP_NAME}"
 msgstr ""
 
 #: src/components/Shared/Login/New/index.tsx
+#: src/components/StaffTools/Panels/Profile.tsx
 msgid "Handle"
 msgstr ""
 
@@ -2592,13 +2590,113 @@ msgstr ""
 msgid "Swap in Uniswap"
 msgstr ""
 
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Staff tool"
+msgstr "Staff tool"
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "{APP_NAME} account"
+msgstr "{APP_NAME} account"
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Profile ID"
+msgstr "Profile ID"
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Address"
+msgstr "Address"
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Can use relay"
+msgstr "Can use relay"
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "NFT address"
+msgstr "NFT address"
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Follow module"
+msgstr "Follow module"
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Metadata"
+msgstr "Metadata"
+
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Open"
+msgstr "Open"
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Publication ID"
+msgstr "Publication ID"
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Comment on"
+msgstr "Comment on"
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Collect module"
+msgstr "Collect module"
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "App ID"
+msgstr "App ID"
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "On-chain content URI"
+msgstr "On-chain content URI"
+
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Transactions"
+msgstr "Transactions"
+
 #: src/components/StaffTools/RelayQueues.tsx
 msgid "Stafftools | Relay queues • {APP_NAME}"
 msgstr "Stafftools | Relay queues • {APP_NAME}"
 
+#: src/components/StaffTools/RelayQueues.tsx
+#: src/components/StaffTools/Sidebar.tsx
+msgid "Relay queues"
+msgstr "Relay queues"
+
+#: src/components/StaffTools/Sidebar.tsx
+#: src/components/StaffTools/Stats/index.tsx
+msgid "Stats"
+msgstr "Stats"
+
 #: src/components/StaffTools/Stats/index.tsx
 msgid "Stafftools | Stats • {APP_NAME}"
 msgstr "Stafftools | Stats • {APP_NAME}"
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total profiles"
+msgstr "total profiles"
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "profiles burnt"
+msgstr "profiles burnt"
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total posts"
+msgstr "total posts"
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total mirrors"
+msgstr "total mirrors"
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total comments"
+msgstr "total comments"
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total collects"
+msgstr "total collects"
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total follows"
+msgstr "total follows"
 
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"

--- a/apps/web/src/locales/es/messages.po
+++ b/apps/web/src/locales/es/messages.po
@@ -252,11 +252,12 @@ msgid "Transaction failed!"
 msgstr ""
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Comment"
+msgid "Post"
 msgstr ""
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Post"
+#: src/components/Publication/Actions/Comment.tsx
+msgid "Comment"
 msgstr ""
 
 #: src/components/Composer/Post/New.tsx
@@ -1421,10 +1422,6 @@ msgstr ""
 msgid "{0} Comments"
 msgstr ""
 
-#: src/components/Publication/Actions/Comment.tsx
-msgid "Comment"
-msgstr ""
-
 #: src/components/Publication/Actions/Like.tsx
 msgid "Dislike"
 msgstr ""
@@ -1853,6 +1850,10 @@ msgid "Export all your notifications to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Notifications.tsx
+msgid "Exported <0>{0}</0> notifications"
+msgstr ""
+
+#: src/components/Settings/Export/Notifications.tsx
 msgid "Download notifications"
 msgstr ""
 
@@ -1889,16 +1890,12 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download publications"
+msgid "Exported <0>{0}</0> publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-#~ msgid "Export Publications"
-#~ msgstr ""
-
-#: src/components/Settings/Export/Publications.tsx
-#~ msgid "Download Publication"
-#~ msgstr ""
+msgid "Download publications"
+msgstr ""
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
@@ -2223,6 +2220,7 @@ msgid "Sign up to {APP_NAME}"
 msgstr ""
 
 #: src/components/Shared/Login/New/index.tsx
+#: src/components/StaffTools/Panels/Profile.tsx
 msgid "Handle"
 msgstr ""
 
@@ -2592,12 +2590,112 @@ msgstr ""
 msgid "Swap in Uniswap"
 msgstr ""
 
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Staff tool"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "{APP_NAME} account"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Profile ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Address"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Can use relay"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "NFT address"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Follow module"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Metadata"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Open"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Publication ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Comment on"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Collect module"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "App ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "On-chain content URI"
+msgstr ""
+
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/StaffTools/RelayQueues.tsx
 msgid "Stafftools | Relay queues • {APP_NAME}"
 msgstr ""
 
+#: src/components/StaffTools/RelayQueues.tsx
+#: src/components/StaffTools/Sidebar.tsx
+msgid "Relay queues"
+msgstr ""
+
+#: src/components/StaffTools/Sidebar.tsx
+#: src/components/StaffTools/Stats/index.tsx
+msgid "Stats"
+msgstr ""
+
 #: src/components/StaffTools/Stats/index.tsx
 msgid "Stafftools | Stats • {APP_NAME}"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total profiles"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "profiles burnt"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total posts"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total mirrors"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total comments"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total collects"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total follows"
 msgstr ""
 
 #: src/components/utils/hooks/useUploadAttachments.tsx

--- a/apps/web/src/locales/kn/messages.po
+++ b/apps/web/src/locales/kn/messages.po
@@ -252,12 +252,13 @@ msgid "Transaction failed!"
 msgstr "ವಹಿವಾಟು ವಿಫಲವಾಗಿದೆ!"
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Comment"
-msgstr "[cta]ಟಿಪ್ಪಣಿ"
+msgid "Post"
+msgstr ""
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Post"
-msgstr "[cta]ಪೋಸ್ಟ್"
+#: src/components/Publication/Actions/Comment.tsx
+msgid "Comment"
+msgstr ""
 
 #: src/components/Composer/Post/New.tsx
 msgid "Create post"
@@ -1421,10 +1422,6 @@ msgstr ""
 msgid "{0} Comments"
 msgstr ""
 
-#: src/components/Publication/Actions/Comment.tsx
-msgid "Comment"
-msgstr ""
-
 #: src/components/Publication/Actions/Like.tsx
 msgid "Dislike"
 msgstr ""
@@ -1853,6 +1850,10 @@ msgid "Export all your notifications to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Notifications.tsx
+msgid "Exported <0>{0}</0> notifications"
+msgstr ""
+
+#: src/components/Settings/Export/Notifications.tsx
 msgid "Download notifications"
 msgstr ""
 
@@ -1889,16 +1890,12 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download publications"
+msgid "Exported <0>{0}</0> publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-#~ msgid "Export Publications"
-#~ msgstr ""
-
-#: src/components/Settings/Export/Publications.tsx
-#~ msgid "Download Publication"
-#~ msgstr ""
+msgid "Download publications"
+msgstr ""
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
@@ -2223,6 +2220,7 @@ msgid "Sign up to {APP_NAME}"
 msgstr ""
 
 #: src/components/Shared/Login/New/index.tsx
+#: src/components/StaffTools/Panels/Profile.tsx
 msgid "Handle"
 msgstr ""
 
@@ -2592,12 +2590,112 @@ msgstr ""
 msgid "Swap in Uniswap"
 msgstr ""
 
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Staff tool"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "{APP_NAME} account"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Profile ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Address"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Can use relay"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "NFT address"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Follow module"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Metadata"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Open"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Publication ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Comment on"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Collect module"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "App ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "On-chain content URI"
+msgstr ""
+
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/StaffTools/RelayQueues.tsx
 msgid "Stafftools | Relay queues • {APP_NAME}"
 msgstr ""
 
+#: src/components/StaffTools/RelayQueues.tsx
+#: src/components/StaffTools/Sidebar.tsx
+msgid "Relay queues"
+msgstr ""
+
+#: src/components/StaffTools/Sidebar.tsx
+#: src/components/StaffTools/Stats/index.tsx
+msgid "Stats"
+msgstr ""
+
 #: src/components/StaffTools/Stats/index.tsx
 msgid "Stafftools | Stats • {APP_NAME}"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total profiles"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "profiles burnt"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total posts"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total mirrors"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total comments"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total collects"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total follows"
 msgstr ""
 
 #: src/components/utils/hooks/useUploadAttachments.tsx

--- a/apps/web/src/locales/ta/messages.po
+++ b/apps/web/src/locales/ta/messages.po
@@ -252,12 +252,13 @@ msgid "Transaction failed!"
 msgstr "பணப்பரிமாற்றம் தோல்வி அடைந்தது!"
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Comment"
-msgstr "[cta]கருத்து"
+msgid "Post"
+msgstr ""
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Post"
-msgstr "[cta]பதிவு"
+#: src/components/Publication/Actions/Comment.tsx
+msgid "Comment"
+msgstr "கருத்துரை"
 
 #: src/components/Composer/Post/New.tsx
 msgid "Create post"
@@ -1421,10 +1422,6 @@ msgstr "அறியப்படாத சேகரிப்பு"
 msgid "{0} Comments"
 msgstr "{0} கருத்துகள்"
 
-#: src/components/Publication/Actions/Comment.tsx
-msgid "Comment"
-msgstr "கருத்துரை"
-
 #: src/components/Publication/Actions/Like.tsx
 msgid "Dislike"
 msgstr "விருப்பமில்லை"
@@ -1853,6 +1850,10 @@ msgid "Export all your notifications to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Notifications.tsx
+msgid "Exported <0>{0}</0> notifications"
+msgstr ""
+
+#: src/components/Settings/Export/Notifications.tsx
 msgid "Download notifications"
 msgstr ""
 
@@ -1889,16 +1890,12 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download publications"
+msgid "Exported <0>{0}</0> publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-#~ msgid "Export Publications"
-#~ msgstr ""
-
-#: src/components/Settings/Export/Publications.tsx
-#~ msgid "Download Publication"
-#~ msgstr ""
+msgid "Download publications"
+msgstr ""
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
@@ -2223,6 +2220,7 @@ msgid "Sign up to {APP_NAME}"
 msgstr "{APP_NAME} வரை பதிவு செய்யவும்"
 
 #: src/components/Shared/Login/New/index.tsx
+#: src/components/StaffTools/Panels/Profile.tsx
 msgid "Handle"
 msgstr "பயனர்பெயர்"
 
@@ -2592,13 +2590,113 @@ msgstr "உங்களிடம் போதுமான <0>{0}</0> இல்�
 msgid "Swap in Uniswap"
 msgstr "யூனிஸ்வாப்பில் ஸ்வாப் செய்யுங்கள்"
 
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Staff tool"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "{APP_NAME} account"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Profile ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Address"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Can use relay"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "NFT address"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Follow module"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Metadata"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Open"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Publication ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Comment on"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Collect module"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "App ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "On-chain content URI"
+msgstr ""
+
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/StaffTools/RelayQueues.tsx
 msgid "Stafftools | Relay queues • {APP_NAME}"
 msgstr "பணியாளர் கருவிகள் | ரிலே வரிசைகள் • {APP_NAME}"
 
+#: src/components/StaffTools/RelayQueues.tsx
+#: src/components/StaffTools/Sidebar.tsx
+msgid "Relay queues"
+msgstr ""
+
+#: src/components/StaffTools/Sidebar.tsx
+#: src/components/StaffTools/Stats/index.tsx
+msgid "Stats"
+msgstr ""
+
 #: src/components/StaffTools/Stats/index.tsx
 msgid "Stafftools | Stats • {APP_NAME}"
 msgstr "பணியாளர் கருவிகள் | புள்ளிவிவரங்கள் • {APP_NAME}"
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total profiles"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "profiles burnt"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total posts"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total mirrors"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total comments"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total collects"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total follows"
+msgstr ""
 
 #: src/components/utils/hooks/useUploadAttachments.tsx
 msgid "Image size should be less than 10MB"

--- a/apps/web/src/locales/zh/messages.po
+++ b/apps/web/src/locales/zh/messages.po
@@ -252,12 +252,13 @@ msgid "Transaction failed!"
 msgstr "交易失败！"
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Comment"
-msgstr "评论"
+msgid "Post"
+msgstr ""
 
 #: src/components/Composer/NewPublication.tsx
-msgid "[cta]Post"
-msgstr "发帖"
+#: src/components/Publication/Actions/Comment.tsx
+msgid "Comment"
+msgstr "评论"
 
 #: src/components/Composer/Post/New.tsx
 msgid "Create post"
@@ -1421,10 +1422,6 @@ msgstr "未知收藏"
 msgid "{0} Comments"
 msgstr "{0} 评论"
 
-#: src/components/Publication/Actions/Comment.tsx
-msgid "Comment"
-msgstr "评论"
-
 #: src/components/Publication/Actions/Like.tsx
 msgid "Dislike"
 msgstr "取消点赞"
@@ -1853,6 +1850,10 @@ msgid "Export all your notifications to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Notifications.tsx
+msgid "Exported <0>{0}</0> notifications"
+msgstr ""
+
+#: src/components/Settings/Export/Notifications.tsx
 msgid "Download notifications"
 msgstr ""
 
@@ -1889,16 +1890,12 @@ msgid "Export all your posts, comments and mirrors to a JSON file."
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-msgid "Download publications"
+msgid "Exported <0>{0}</0> publications"
 msgstr ""
 
 #: src/components/Settings/Export/Publications.tsx
-#~ msgid "Export Publications"
-#~ msgstr ""
-
-#: src/components/Settings/Export/Publications.tsx
-#~ msgid "Download Publication"
-#~ msgstr ""
+msgid "Download publications"
+msgstr ""
 
 #: src/components/Settings/Interests/index.tsx
 msgid "Interests settings • {APP_NAME}"
@@ -2223,6 +2220,7 @@ msgid "Sign up to {APP_NAME}"
 msgstr "注册到 {APP_NAME}"
 
 #: src/components/Shared/Login/New/index.tsx
+#: src/components/StaffTools/Panels/Profile.tsx
 msgid "Handle"
 msgstr "用户名"
 
@@ -2592,12 +2590,112 @@ msgstr "您没有足够的 <0>{0}</0>"
 msgid "Swap in Uniswap"
 msgstr "用Uniswap进行代币转换"
 
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Staff tool"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "{APP_NAME} account"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Profile ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Address"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Can use relay"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "NFT address"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Follow module"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+msgid "Metadata"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Profile.tsx
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Open"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Publication ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Comment on"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "Collect module"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "App ID"
+msgstr ""
+
+#: src/components/StaffTools/Panels/Publication.tsx
+msgid "On-chain content URI"
+msgstr ""
+
+#: src/components/StaffTools/RelayQueues.tsx
+msgid "Transactions"
+msgstr ""
+
 #: src/components/StaffTools/RelayQueues.tsx
 msgid "Stafftools | Relay queues • {APP_NAME}"
 msgstr ""
 
+#: src/components/StaffTools/RelayQueues.tsx
+#: src/components/StaffTools/Sidebar.tsx
+msgid "Relay queues"
+msgstr ""
+
+#: src/components/StaffTools/Sidebar.tsx
+#: src/components/StaffTools/Stats/index.tsx
+msgid "Stats"
+msgstr ""
+
 #: src/components/StaffTools/Stats/index.tsx
 msgid "Stafftools | Stats • {APP_NAME}"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total profiles"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "profiles burnt"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total posts"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total mirrors"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total comments"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total collects"
+msgstr ""
+
+#: src/components/StaffTools/Stats/index.tsx
+msgid "total follows"
 msgstr ""
 
 #: src/components/utils/hooks/useUploadAttachments.tsx


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 48f8638</samp>

No summary available (The summary was empty or could not be parsed)

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 48f8638</samp>

*  Simplify the button text in the `NewPublication` component using the `t` template tag ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L567-R567))
*  Use the `t` template tag for the titles of the fields in the `ProfileStaffTool` and `PublicationStaffTool` components, to simplify the code ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871L54-R57), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871L61-R64), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871L68-R71), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871L75-R79), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871L84-R87), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871L91-R94), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871L98-R104), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-3ab4dcc6ca39b36ae7890598cfacc5a2c7c379e92f67705be89cf6a3fe364adfL27-R30), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-3ab4dcc6ca39b36ae7890598cfacc5a2c7c379e92f67705be89cf6a3fe364adfL35-R38), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-3ab4dcc6ca39b36ae7890598cfacc5a2c7c379e92f67705be89cf6a3fe364adfL43-R46), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-3ab4dcc6ca39b36ae7890598cfacc5a2c7c379e92f67705be89cf6a3fe364adfL50-R53), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-3ab4dcc6ca39b36ae7890598cfacc5a2c7c379e92f67705be89cf6a3fe364adfL57-R63))
*  Correct the value of the "NFT address" field in the `ProfileStaffTool` component to use `profile?.followNftAddress` instead of `profile?.ownedBy` ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871L75-R79))
*  Import and use the `t` function for the titles "Stats" and "Relay queues" in the `StaffToolsSidebar` component ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-9ebc468fb11a21b1d6f8995718ccc541b540a56bf6d3e88274b7858cf38b6046R3), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-9ebc468fb11a21b1d6f8995718ccc541b540a56bf6d3e88274b7858cf38b6046L10-R16))
*  Use the `t` template tag for the titles of the statistics in the `Stats` component, to simplify the code ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L135-R137), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L142-R144), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L149-R151), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L158-R160), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L165-R167), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L174-R176), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-fb9aae41a43bf3f44a8f04b966f665c871b7572ee7dab30936d9f857c4cdf4c3L181-R183))
*  Remove the `[cta]` prefix from the message ids "Comment" and "Post" in the locale files, to match the changes in the `NewPublication` component ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365L255-R261), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294L255-R260), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050L255-R261), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48L255-R261), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdL255-R261))
*  Remove the duplicate message id "Comment" in the locale files, since it is already defined in the `NewPublication` component ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365L1424-L1427), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294L1424-L1427), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050L1424-L1427), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48L1424-L1427), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdL1424-L1427))
*  Define the message id "Exported <0>{0}</0> notifications" in the locale files, to match the changes in the `Notifications` component ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365R1853-R1856), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294R1853-R1856), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050R1853-R1856), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48R1853-R1856), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdR1853-R1856))
*  Remove the obsolete message ids "Export Publications" and "Download Publication" in the locale files, and define the message id "Exported <0>{0}</0> publications" in the locale files, to match the changes in the `Publications` component ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365L1892-R1899), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294L1892-R1899), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050L1892-R1899), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48L1892-R1899), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdL1892-R1899))
*  Define the message ids for the `ProfileStaffTool` and `PublicationStaffTool` components in the locale files, to match the changes in the `Profile.tsx` and `Publication.tsx` files ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365R2223), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294R2223), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050R2223), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48R2223), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdR2223))
*  Define the message ids for the `RelayQueues`, `StaffToolsSidebar` and `Stats` components in the locale files, to match the changes in the `RelayQueues.tsx`, `Sidebar.tsx` and `Stats/index.tsx` files ([link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-a91393d1e62c7dd6f423054d58557fdef61bb5a84cc28248690ad03e1b160365L2595-R2700), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-76ad6152acaaf4ecb26eb04e2fbe8c4600e13a691fb974da91db3ebd52ca9294L2595-R2700), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-e9a382fb878a0448e879ea0c6ce896dc933e2743354d2a84d9b15bcc903f5050L2595-R2700), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-74c63dfeab2412f39f5a30f665845db007129732f3c107216bfb25faa66e3a48L2595-R2700), [link](https://github.com/lensterxyz/lenster/pull/2583/files?diff=unified&w=0#diff-be3912a3e9938530b5702e29149c1ee5dc96cd68c54b3691dd9d5eb225630ccdL2595-R2700))

## Emoji

copilot:emoji
