### PR TITLE
feat: add isProfileOwnByAddress check

### DIFF
--- a/apps/api/src/graphql/helpers/isProfileOwnByAddress.ts
+++ b/apps/api/src/graphql/helpers/isProfileOwnByAddress.ts
@@ -1,0 +1,17 @@
+import type { Profile } from 'lens';
+import { ProfilesDocument } from 'lens';
+import { nodeClient } from 'lens/apollo';
+
+const isProfileOwnByAddress = async (id: string, address: string) => {
+  const { data } = await nodeClient.query({
+    query: ProfilesDocument,
+    variables: { request: { ownedBy: address } }
+  });
+  const ids = data.profiles.items.map((item: Profile) => item.id);
+
+  if (!ids.includes(id)) {
+    throw new Error('Profile is not owned by address');
+  }
+};
+
+export default isProfileOwnByAddress;

--- a/apps/api/src/graphql/resolvers/StaffResolver.ts
+++ b/apps/api/src/graphql/resolvers/StaffResolver.ts
@@ -32,13 +32,17 @@ builder.mutationField('makeStaff', (t) =>
       await isStaff(request.id);
       isSuperStaff(getAddressFromJwt(context));
 
-      return db.staff.create({
-        ...query,
-        data: {
-          user: { connect: { id: request.id } },
-          staffMode: true
-        }
-      });
+      try {
+        return db.staff.create({
+          ...query,
+          data: {
+            user: { connect: { id: request.id } },
+            staffMode: true
+          }
+        });
+      } catch (error: any) {
+        throw new Error(error.code);
+      }
     }
   })
 );
@@ -64,10 +68,14 @@ builder.mutationField('removeStaff', (t) =>
         where: { user: { id: request.id } }
       });
 
-      return db.staff.delete({
-        ...query,
-        where: { id: data?.id }
-      });
+      try {
+        return db.staff.delete({
+          ...query,
+          where: { id: data?.id }
+        });
+      } catch (error: any) {
+        throw new Error(error.code);
+      }
     }
   })
 );
@@ -89,11 +97,15 @@ builder.mutationField('toggleStaffMode', (t) =>
       await isAuthenticated(context);
       await isStaff(request.id);
 
-      return db.staff.update({
-        ...query,
-        where: { id: request.id },
-        data: { staffMode: request.enabled }
-      });
+      try {
+        return db.staff.update({
+          ...query,
+          where: { id: request.id },
+          data: { staffMode: request.enabled }
+        });
+      } catch (error: any) {
+        throw new Error(error.code);
+      }
     }
   })
 );

--- a/apps/api/src/graphql/resolvers/UserResolver.ts
+++ b/apps/api/src/graphql/resolvers/UserResolver.ts
@@ -70,10 +70,14 @@ builder.mutationField('createUser', (t) =>
       const address = getAddressFromJwt(context);
       await isProfileOwnByAddress(request.id, address);
 
-      return db.user.create({
-        ...query,
-        data: { id: request.id, address }
-      });
+      try {
+        return await db.user.create({
+          ...query,
+          data: { id: request.id, address }
+        });
+      } catch (error: any) {
+        throw new Error(error.code);
+      }
     }
   })
 );

--- a/apps/api/src/graphql/resolvers/UserResolver.ts
+++ b/apps/api/src/graphql/resolvers/UserResolver.ts
@@ -1,4 +1,5 @@
 import getAddressFromJwt from '@gql/helpers/getAddressFromJwt';
+import isProfileOwnByAddress from '@gql/helpers/isProfileOwnByAddress';
 import isAuthenticated from '@gql/middlewares/isAuthenticated';
 import isStaff from '@gql/middlewares/isStaff';
 import { db } from '@lib/prisma';
@@ -67,6 +68,7 @@ builder.mutationField('createUser', (t) =>
     resolve: async (query, _root, { request }, context) => {
       await isAuthenticated(context);
       const address = getAddressFromJwt(context);
+      await isProfileOwnByAddress(request.id, address);
 
       return db.user.create({
         ...query,


### PR DESCRIPTION
- feat: add isProfileOwnByAddress check
- chore: add try catch

## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2be901</samp>

This pull request enhances the error handling and security of the GraphQL resolvers for users and staffs. It adds custom error messages, checks the ownership of profiles, and handles database errors in the `createUser` and staff-related mutations. It also introduces a new helper function `isProfileOwnByAddress` in the `helpers` module.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2be901</samp>

*  Add a helper function `isProfileOwnByAddress` to check profile ownership by address ([link](https://github.com/lensterxyz/lenster/pull/2594/files?diff=unified&w=0#diff-56477fc7c70d56b1c02326791aa94ffe7ed9720a6b1db289a3f5cac71ae8234eR1-R17))
*  Import and use `isProfileOwnByAddress` in `createUser` mutation to validate profile id ([link](https://github.com/lensterxyz/lenster/pull/2594/files?diff=unified&w=0#diff-09486b78b47c1f6dfb81980f4e2acb9c68c38c00fb47cb94380b7ff4495ad31cR2), [link](https://github.com/lensterxyz/lenster/pull/2594/files?diff=unified&w=0#diff-09486b78b47c1f6dfb81980f4e2acb9c68c38c00fb47cb94380b7ff4495ad31cL70-R80))
*  Add try-catch blocks and custom error messages to handle database errors in `createUser`, `createStaff`, `deleteStaff`, and `updateStaffMode` mutations in `UserResolver.ts` and `StaffResolver.ts` ([link](https://github.com/lensterxyz/lenster/pull/2594/files?diff=unified&w=0#diff-09486b78b47c1f6dfb81980f4e2acb9c68c38c00fb47cb94380b7ff4495ad31cL70-R80), [link](https://github.com/lensterxyz/lenster/pull/2594/files?diff=unified&w=0#diff-462239f8377dc2431528cae05c0bb2bd6cc83ac9f0f10f3007e4771fadaa4c93L35-R45), [link](https://github.com/lensterxyz/lenster/pull/2594/files?diff=unified&w=0#diff-462239f8377dc2431528cae05c0bb2bd6cc83ac9f0f10f3007e4771fadaa4c93L67-R78), [link](https://github.com/lensterxyz/lenster/pull/2594/files?diff=unified&w=0#diff-462239f8377dc2431528cae05c0bb2bd6cc83ac9f0f10f3007e4771fadaa4c93L92-R108))

## Emoji

<!--
copilot:emoji
-->

🛡️🧑‍💼🆕

<!--
1.  🛡️ - This emoji represents security and protection, which relates to the ownership validation of profiles and the error handling of database operations.
2.  🧑‍💼 - This emoji represents a staff member or a professional, which relates to the staff-related mutations that are improved by the error handling.
3.  🆕 - This emoji represents something new or fresh, which relates to the new helper function and the user creation process.
-->
