### PR TITLE
fix: prefer to accompany onClick with some elements

### DIFF
--- a/apps/web/src/components/Home/Timeline/EventType/index.tsx
+++ b/apps/web/src/components/Home/Timeline/EventType/index.tsx
@@ -30,7 +30,7 @@ const ActionType: FC<ActionTypeProps> = ({ feedItem }) => {
   ]);
 
   return (
-    <span onClick={stopEventPropagation}>
+    <span onClick={stopEventPropagation} aria-label="">
       {canCombined ? (
         <Combined feedItem={feedItem} />
       ) : (

--- a/apps/web/src/components/Messages/Preview.tsx
+++ b/apps/web/src/components/Messages/Preview.tsx
@@ -34,6 +34,7 @@ const Preview: FC<PreviewProps> = ({ profile, message, conversationKey, isSelect
         isSelected && 'bg-gray-50 dark:bg-gray-800'
       )}
       onClick={() => onConversationSelected(profile.id)}
+      aria-label="Select conversation"
     >
       <div className="flex justify-between space-x-3 px-5">
         <Image

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -88,6 +88,7 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
               'text-brand tab-bg m-2 ml-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
               selectedTab === 'Following' ? 'bg-brand-100' : ''
             )}
+            aria-label="Following"
           >
             <UsersIcon className="mr-2 h-4 w-4" />
             <Trans>Following</Trans>
@@ -98,6 +99,7 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
               'text-brand tab-bg m-2 mr-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
               selectedTab === 'Requested' ? 'bg-brand-100' : ''
             )}
+            aria-label="Requested"
           >
             <Trans>Requested</Trans>
             {requestedCount > 0 && (

--- a/apps/web/src/components/Profile/Following.tsx
+++ b/apps/web/src/components/Profile/Following.tsx
@@ -82,6 +82,7 @@ const Following: FC<FollowingProps> = ({ profile, onProfileSelected }) => {
                   }
                 : undefined
             }
+            aria-label="Select profile"
           >
             <UserProfile
               profile={following?.profile as Profile}

--- a/apps/web/src/components/Profile/MutualFollowers/index.tsx
+++ b/apps/web/src/components/Profile/MutualFollowers/index.tsx
@@ -42,6 +42,7 @@ const MutualFollowers: FC<MutualFollowersProps> = ({
         'text-xs': variant === 'xs'
       })}
       onClick={() => setShowMutualFollowersModal?.(true)}
+      aria-label="Show mutual followers"
     >
       <div className="contents -space-x-2">
         {profiles?.map((profile) => (

--- a/apps/web/src/components/Publication/Actions/ModAction/index.tsx
+++ b/apps/web/src/components/Publication/Actions/ModAction/index.tsx
@@ -100,6 +100,7 @@ const ModAction: FC<ModActionProps> = ({ publication, className = '' }) => {
     <span
       className={clsx('flex flex-wrap items-center gap-3 text-sm', className)}
       onClick={stopEventPropagation}
+      aria-label="Report publication"
     >
       <ReportButton
         type="spamReason"

--- a/apps/web/src/components/Publication/Actions/index.tsx
+++ b/apps/web/src/components/Publication/Actions/index.tsx
@@ -31,6 +31,7 @@ const PublicationActions: FC<PublicationActionsProps> = ({
     <span
       className="-ml-2 flex flex-wrap items-center gap-x-6 gap-y-1 pt-3 sm:gap-8"
       onClick={stopEventPropagation}
+      aria-label="Publication actions"
     >
       <Comment publication={publication} showCount={showCount} />
       {canMirror && <Mirror publication={publication} showCount={showCount} />}

--- a/apps/web/src/components/Publication/PublicationHeader.tsx
+++ b/apps/web/src/components/Publication/PublicationHeader.tsx
@@ -33,7 +33,7 @@ const PublicationHeader: FC<PublicationHeaderProps> = ({ publication, feedItem }
       className="relative flex justify-between space-x-1.5 pb-4"
       data-testid={`publication-${publication.id}-header`}
     >
-      <span onClick={stopEventPropagation}>
+      <span onClick={stopEventPropagation} aria-label="Open profile">
         <UserProfile profile={profile} timestamp={timestamp} showStatus />
       </span>
       <div className="!-mr-[7px] flex items-center space-x-1">

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -41,6 +41,7 @@ const SinglePublication: FC<SinglePublicationProps> = ({
         }
       }}
       data-testid={`publication-${publication.id}`}
+      aria-label="Open publication"
     >
       {feedItem ? (
         <ActionType feedItem={feedItem} />

--- a/apps/web/src/components/Publication/ThreadBody.tsx
+++ b/apps/web/src/components/Publication/ThreadBody.tsx
@@ -22,6 +22,7 @@ const ThreadBody: FC<ThreadBodyProps> = ({ publication }) => {
           push(`/posts/${publication?.id}`);
         }
       }}
+      aria-label="Open publication"
     >
       <PublicationHeader publication={publication} />
       <div className="flex">

--- a/apps/web/src/components/Publication/Type/index.tsx
+++ b/apps/web/src/components/Publication/Type/index.tsx
@@ -21,7 +21,7 @@ const PublicationType: FC<PublicationTypeProps> = ({ publication, showType, show
   }
 
   return (
-    <span onClick={stopEventPropagation}>
+    <span onClick={stopEventPropagation} aria-label="">
       {type === 'Mirror' && <Mirrored publication={publication} />}
       {type === 'Comment' && (showThread || pathname === '/posts/[id]') && (
         <Commented publication={publication} />

--- a/apps/web/src/components/Shared/Attachments.tsx
+++ b/apps/web/src/components/Shared/Attachments.tsx
@@ -100,6 +100,7 @@ const Attachments: FC<AttachmentsProps> = ({
               )}
               key={index + url}
               onClick={stopEventPropagation}
+              aria-label="Attachment"
             >
               {type === 'image/svg+xml' ? (
                 <Button

--- a/apps/web/src/components/Shared/Lexical/Plugins/AtMentionsPlugin.tsx
+++ b/apps/web/src/components/Shared/Lexical/Plugins/AtMentionsPlugin.tsx
@@ -119,9 +119,10 @@ const MentionsTypeaheadMenuItem: FC<MentionsTypeaheadMenuItemProps> = ({
       className="cursor-pointer"
       ref={option.setRefElement}
       role="option"
-      aria-selected={isSelected}
       onMouseEnter={onMouseEnter}
       onClick={onClick}
+      aria-selected={isSelected}
+      aria-label={option.name}
     >
       <div
         className={clsx(

--- a/apps/web/src/components/Shared/Lexical/Plugins/EmojiPicker.tsx
+++ b/apps/web/src/components/Shared/Lexical/Plugins/EmojiPicker.tsx
@@ -50,10 +50,11 @@ const EmojiMenuItem: FC<EmojiMenuItemProps> = ({ index, isSelected, onClick, onM
       className={clsx({ 'dropdown-active': isSelected }, 'm-2 cursor-pointer rounded-lg p-2 outline-none')}
       ref={setRefElement}
       role="option"
-      aria-selected={isSelected}
       id={'typeahead-item-' + index}
       onMouseEnter={onMouseEnter}
       onClick={onClick}
+      aria-selected={isSelected}
+      aria-label={title}
     >
       <div className="flex items-center space-x-2">
         <span className="text-base">{emoji}</span>

--- a/apps/web/src/components/Shared/Modal/Report/index.tsx
+++ b/apps/web/src/components/Shared/Modal/Report/index.tsx
@@ -64,7 +64,7 @@ const Report: FC<ReportProps> = ({ publication }) => {
   };
 
   return (
-    <div onClick={stopEventPropagation}>
+    <div onClick={stopEventPropagation} aria-label="Report">
       {submitData?.reportPublication === null ? (
         <EmptyState
           message={t`Publication reported successfully!`}

--- a/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
+++ b/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
@@ -121,7 +121,7 @@ const MobileDrawerMenu: FC = () => {
               <div
                 onClick={closeDrawer}
                 className="hover:bg-gray-200 dark:hover:bg-gray-800"
-                aria-label="Staff Mode"
+                aria-label="Staff mode"
               >
                 <StaffMode className="py-3" />
               </div>

--- a/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
+++ b/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
@@ -106,7 +106,11 @@ const MobileDrawerMenu: FC = () => {
           <div className="divider" />
           {isGardener(currentProfile?.id) && (
             <>
-              <div onClick={closeDrawer} className="hover:bg-gray-200 dark:hover:bg-gray-800">
+              <div
+                onClick={closeDrawer}
+                className="hover:bg-gray-200 dark:hover:bg-gray-800"
+                aria-label="Mod Mode"
+              >
                 <ModMode className="py-3" />
               </div>
               <div className="divider" />
@@ -114,7 +118,11 @@ const MobileDrawerMenu: FC = () => {
           )}
           {isStaff(currentProfile?.id) && (
             <>
-              <div onClick={closeDrawer} className="hover:bg-gray-200 dark:hover:bg-gray-800">
+              <div
+                onClick={closeDrawer}
+                className="hover:bg-gray-200 dark:hover:bg-gray-800"
+                aria-label="Staff Mode"
+              >
                 <StaffMode className="py-3" />
               </div>
               <div className="divider" />

--- a/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
+++ b/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
@@ -109,7 +109,7 @@ const MobileDrawerMenu: FC = () => {
               <div
                 onClick={closeDrawer}
                 className="hover:bg-gray-200 dark:hover:bg-gray-800"
-                aria-label="Mod Mode"
+                aria-label="Mod mode"
               >
                 <ModMode className="py-3" />
               </div>

--- a/apps/web/src/components/Shared/Navbar/Search.tsx
+++ b/apps/web/src/components/Shared/Navbar/Search.tsx
@@ -109,6 +109,7 @@ const Search: FC<SearchProps> = ({
                       setSearchText('');
                     }}
                     data-testid={`search-profile-${formatHandle(profile?.handle)}`}
+                    aria-label="Open profile"
                   >
                     <UserProfile
                       linkToProfile={!onProfileSelected}

--- a/apps/web/src/components/Shared/UserPreview.tsx
+++ b/apps/web/src/components/Shared/UserPreview.tsx
@@ -73,7 +73,7 @@ const UserPreview: FC<UserPreviewProps> = ({
     <>
       <div className="flex items-center justify-between">
         <UserAvatar />
-        <div onClick={stopEventPropagation} aria-label="Follow user">
+        <div onClick={stopEventPropagation} aria-label="Follow profile">
           {!lazyProfile.isFollowedByMe &&
             (followStatusLoading ? (
               <div className="shimmer h-8 w-10 rounded-lg" />

--- a/apps/web/src/components/Shared/UserPreview.tsx
+++ b/apps/web/src/components/Shared/UserPreview.tsx
@@ -7,6 +7,7 @@ import formatHandle from 'lib/formatHandle';
 import getAvatar from 'lib/getAvatar';
 import isVerified from 'lib/isVerified';
 import nFormatter from 'lib/nFormatter';
+import { stopEventPropagation } from 'lib/stopEventPropagation';
 import type { FC, ReactNode } from 'react';
 import { useState } from 'react';
 import { FollowSource } from 'src/tracking';
@@ -72,7 +73,7 @@ const UserPreview: FC<UserPreviewProps> = ({
     <>
       <div className="flex items-center justify-between">
         <UserAvatar />
-        <div onClick={(e) => e.preventDefault()}>
+        <div onClick={stopEventPropagation} aria-label="Follow user">
           {!lazyProfile.isFollowedByMe &&
             (followStatusLoading ? (
               <div className="shimmer h-8 w-10 rounded-lg" />

--- a/apps/web/src/components/StaffTools/Panels/MetaDetails.tsx
+++ b/apps/web/src/components/StaffTools/Panels/MetaDetails.tsx
@@ -16,6 +16,7 @@ const MetaDetails: FC<MetaDetailsProps> = ({ children, title, value, icon }) => 
       navigator.clipboard.writeText(value);
       toast.success(t`Copied to clipboard!`);
     }}
+    aria-label="Copy to clipboard"
   >
     {icon}
     {title ? <div className="lt-text-gray-500 text-sm">{title}:</div> : null}

--- a/packages/ui/src/LightBox.tsx
+++ b/packages/ui/src/LightBox.tsx
@@ -43,6 +43,7 @@ export const LightBox: FC<LightBoxProps> = ({ show, url, onClose }) => {
               src={url ?? ''}
               alt={url ?? ''}
               onClick={onClose}
+              aria-label="Close"
             />
             {url ? (
               <div className="mt-1">


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf202b7</samp>

This pull request adds `aria-label` attributes to various elements in the web app that lack semantic roles or labels for screen readers. This improves the accessibility of the app for users who rely on assistive technologies. The pull request affects several components and files in the `apps/web` and `packages/ui` directories.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf202b7</samp>

*  Add `aria-label` attributes to various elements that lack semantic roles or labels for screen readers ([link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-2fb7f5a4989580a7152f0c9b3d17b1b58785726241b5308c3c7025f656f735f6L33-R33), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-86a42fd57d0cd5557caf0ba432c3f36f048b7f3098460771c3f65de779dd14a4R37), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778R91), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778R102), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-26b930a1517cdb6b85350e7d2aec8b151c8bde2181a998c5f71f82cca6e70903R85), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-fcbb27dff6a6f5bbc88ade09f3d01e120dbd6d11c9ffd853e37e0dd17c72024fR45), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-7a5caf1e15c1ed5997ca02f9327b303f68964f33a31287e81c54eacb72714113R103), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-62afa772382218b438f99bec5d9a172fc9beafa2de0ef1f667ca3cc06be8d699R34), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-304317c7f5fed29770b350821011cbdd05d8db8db6417978340dc3f66a273d6bL36-R36), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9R44), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-0146436c6a0afc8ae788c3e1abf1ab6c37ad5d2fe2a0ca6e448f8f21f3f0df27R25), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-f50c545318b23bbf4057dfc41ff169357e45c36723630583bb913e2075183502L24-R24), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-2e5f548614ad2d3ac2c9a19db89a67ae351e1b12b689ba5857fad457f54d773bR103), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-047c8c7a24c0690a4c7dc5539d56b588f13ef88bf1ce0c786f90e33b9907f3b1L122-R125), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-bcc165557759c18c2de526a3738a5e4104da1749627a6532fadda76738ebdaf6L53-R57), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-442ac1e57f4e3ab8713ebe52f8df2563d1b145b8f8fe7758aca6528d3ddf6de9L67-R67), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-aa951beb126e1aeec7697f40760aa20baa2adeafa09adf263a9524b3434e0417L109-R113), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-aa951beb126e1aeec7697f40760aa20baa2adeafa09adf263a9524b3434e0417L117-R125), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-d7dc8d3d6cab8c731b6a654412b168f27f24f7abe1a920511df72e772ec19b61R112), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-4cdf48abc8f0279e8ce53beea7dd66d71d57065e549bdf126de7bf715de38567L75-R76), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-553dd43eb665bb3636657a88a3df3373e9f24009d2a5013d22cdfddd2d2f0839R19), [link](https://github.com/lensterxyz/lenster/pull/2599/files?diff=unified&w=0#diff-e96ceae4bdfc3754b28fea0da4402b6b48afca1418e83533a4eafdb0c6d9d6bcR46)). These changes improve the accessibility and usability of the web app for users who rely on assistive technologies.

## Emoji

<!--
copilot:emoji
-->

🏷️🛠️🖱️

<!--
1.  🏷️ - This emoji represents the addition of `aria-label` attributes to various elements, which improves the accessibility of the app for screen reader users. The emoji is also known as the label emoji, which is fitting for this change.
2.  🛠️ - This emoji represents the fixing of some warnings and errors from the `jsx-a11y` plugin, which enforces best practices for accessibility in JSX. The emoji is also known as the wrench emoji, which is fitting for this change.
3.  🖱️ - This emoji represents the improvement of the interactivity and usability of some elements, such as the follow button and the tabs, by preventing unwanted event propagation and adding labels for screen readers. The emoji is also known as the computer mouse emoji, which is fitting for this change.
-->
