### PR TITLE
fix: blinking xmtp prompt in sidebar

### DIFF
--- a/apps/web/src/components/Home/EnableMessages.tsx
+++ b/apps/web/src/components/Home/EnableMessages.tsx
@@ -13,7 +13,7 @@ const EnableMessages: FC = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const { push } = useRouter();
   const [canMessage, setCanMessage] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
   const onConversationSelected = () => {
     push('/messages');
@@ -21,15 +21,14 @@ const EnableMessages: FC = () => {
 
   useEffect(() => {
     const fetchCanMessage = async () => {
-      setLoading(true);
       const isMessagesEnabled = await Client.canMessage(currentProfile?.ownedBy, { env: XMTP_ENV });
       setCanMessage(isMessagesEnabled);
-      setLoading(false);
+      setLoaded(true);
     };
     fetchCanMessage();
   }, [currentProfile]);
 
-  if (!currentProfile || loading || canMessage) {
+  if (!currentProfile || !loaded || canMessage) {
     return null;
   }
 


### PR DESCRIPTION
## What does this PR do?

Refactored state variable in `EnableMessages.tsx` to avoid display glitch before the result of canMessage is known.

## Related issues

Fixes #2337

## Screen recording
**Before:**
https://user-images.githubusercontent.com/667227/232821144-7b097a6b-9879-4e24-a3d8-92171bc37c38.mp4

**After:**
https://user-images.githubusercontent.com/667227/232821155-8008d3cb-8175-4df0-a7c4-f85b0b6b9531.mp4


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac91260</samp>

*  Rename `loading` state variable to `loaded` and simplify logic for fetching and setting `canMessage` state ([link](https://github.com/lensterxyz/lenster/pull/2606/files?diff=unified&w=0#diff-0b17ae730645cca1e329c62e6d6f97347015e8ac56c189552e484a198785bcf6L16-R16), [link](https://github.com/lensterxyz/lenster/pull/2606/files?diff=unified&w=0#diff-0b17ae730645cca1e329c62e6d6f97347015e8ac56c189552e484a198785bcf6L24-R31))

## Emoji

<!--
copilot:emoji
-->

🔧🎨🚀

<!--
1.  🔧 - This emoji can be used to indicate that a change was made to fix or improve something, such as a bug or a feature. In this case, the state variable was simplified to make the code more readable and maintainable.
2.  🎨 - This emoji can be used to indicate that a change was made to improve the appearance or style of something, such as a UI component or a design. In this case, the state variable was renamed to better reflect its purpose and avoid confusion with other variables.
3.  🚀 - This emoji can be used to indicate that a change was made to enhance the performance or functionality of something, such as a system or a process. In this case, the state variable was changed to use a boolean value instead of a string, which could potentially improve the efficiency and speed of the component rendering.
-->
