### PR TITLE
chore: use brovider

### DIFF
--- a/apps/web/src/components/Common/Providers.tsx
+++ b/apps/web/src/components/Common/Providers.tsx
@@ -2,7 +2,7 @@ import { initLocale } from '@lib/i18n';
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ALCHEMY_KEY, IS_MAINNET, WALLETCONNECT_PROJECT_ID } from 'data/constants';
+import { IS_MAINNET, WALLETCONNECT_PROJECT_ID } from 'data/constants';
 import { ApolloProvider, webClient } from 'lens/apollo';
 import { ThemeProvider } from 'next-themes';
 import type { ReactNode } from 'react';
@@ -11,14 +11,18 @@ import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, polygonMumbai } from 'wagmi/chains';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
-import { alchemyProvider } from 'wagmi/providers/alchemy';
+import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 
 import ErrorBoundary from './ErrorBoundary';
 import Layout from './Layout';
 
 const { chains, provider } = configureChains(
   [IS_MAINNET ? polygon : polygonMumbai, mainnet],
-  [alchemyProvider({ apiKey: ALCHEMY_KEY })]
+  [
+    jsonRpcProvider({
+      rpc: (chain) => ({ http: `https://rpc.brovider.xyz/${chain.id}` })
+    })
+  ]
 );
 
 const connectors = () => {


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 707d579</samp>

Switched to a custom JSON-RPC provider for blockchain interactions. Updated `Providers.tsx` to use the `jsonRpcProvider` function from `wagmi/providers`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 707d579</samp>

*  Removed unused `ALCHEMY_KEY` import ([link](https://github.com/lensterxyz/lenster/pull/2612/files?diff=unified&w=0#diff-770888966434e7639aad4ad8b865ab3b7fd09316f081d7346668c352951b7e77L5-R5))
*  Switched provider for JSON-RPC calls to `jsonRpcProvider` from `wagmi/providers` module ([link](https://github.com/lensterxyz/lenster/pull/2612/files?diff=unified&w=0#diff-770888966434e7639aad4ad8b865ab3b7fd09316f081d7346668c352951b7e77L14-R14), [link](https://github.com/lensterxyz/lenster/pull/2612/files?diff=unified&w=0#diff-770888966434e7639aad4ad8b865ab3b7fd09316f081d7346668c352951b7e77L21-R25))
*  Configured chains with custom RPC endpoint using `jsonRpcProvider` function ([link](https://github.com/lensterxyz/lenster/pull/2612/files?diff=unified&w=0#diff-770888966434e7639aad4ad8b865ab3b7fd09316f081d7346668c352951b7e77L21-R25))

## Emoji

<!--
copilot:emoji
-->

🔄🛠️🌐

<!--
1.  🔄 - This emoji represents the change or switch from one thing to another, in this case from Alchemy to a custom JSON-RPC provider. It could also imply a refresh or update of the code.
2.  🛠️ - This emoji represents the tool or function that was used to create the custom JSON-RPC provider, namely the `jsonRpcProvider` function from the `wagmi/providers` module. It could also imply a fix or improvement of the code.
3.  🌐 - This emoji represents the network or web aspect of the blockchain interactions, as JSON-RPC is a protocol for communicating with remote servers. It could also imply a connection or integration of the code.
-->
