### PR TITLE
revert: to WC v1

### DIFF
--- a/apps/web/src/components/Common/Providers.tsx
+++ b/apps/web/src/components/Common/Providers.tsx
@@ -2,7 +2,7 @@ import { initLocale } from '@lib/i18n';
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { IS_MAINNET, WALLETCONNECT_PROJECT_ID } from 'data/constants';
+import { IS_MAINNET } from 'data/constants';
 import { ApolloProvider, webClient } from 'lens/apollo';
 import { ThemeProvider } from 'next-themes';
 import type { ReactNode } from 'react';
@@ -10,7 +10,7 @@ import { useEffect } from 'react';
 import { configureChains, createClient, WagmiConfig } from 'wagmi';
 import { mainnet, polygon, polygonMumbai } from 'wagmi/chains';
 import { InjectedConnector } from 'wagmi/connectors/injected';
-import { WalletConnectConnector } from 'wagmi/connectors/walletConnect';
+import { WalletConnectLegacyConnector } from 'wagmi/connectors/walletConnectLegacy';
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 
 import ErrorBoundary from './ErrorBoundary';
@@ -28,12 +28,7 @@ const { chains, provider } = configureChains(
 const connectors = () => {
   return [
     new InjectedConnector({ chains, options: { shimDisconnect: true } }),
-    new WalletConnectConnector({
-      options: {
-        projectId: WALLETCONNECT_PROJECT_ID,
-        showQrModal: true
-      }
-    })
+    new WalletConnectLegacyConnector({ chains, options: {} })
   ];
 };
 

--- a/packages/lib/getWalletDetails.ts
+++ b/packages/lib/getWalletDetails.ts
@@ -13,7 +13,7 @@ interface WalletDetails {
  */
 const getWalletDetails = (name: string): WalletDetails => {
   const walletDetails: Record<string, WalletDetails> = {
-    WalletConnect: {
+    WalletConnectLegacy: {
       name: 'Wallet Connect',
       logo: `${STATIC_IMAGES_URL}/wallets/walletconnect.svg`
     }

--- a/tests/packages/lib/getWalletDetails.spec.ts
+++ b/tests/packages/lib/getWalletDetails.spec.ts
@@ -4,7 +4,7 @@ import getWalletDetails from 'lib/getWalletDetails';
 
 test.describe('getWalletDetails', () => {
   test('should return correct details for WalletConnect', () => {
-    const walletDetails = getWalletDetails('WalletConnect');
+    const walletDetails = getWalletDetails('WalletConnectLegacy');
     expect(walletDetails.name).toBe('Wallet Connect');
     expect(walletDetails.logo).toBe(`${STATIC_IMAGES_URL}/wallets/walletconnect.svg`);
   });


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec5e448</samp>

Updated the web app and the lib package to use a custom WalletConnect connector that supports legacy wallets. Renamed `getWalletDetails` to `WalletConnectLegacy` to avoid confusion.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec5e448</samp>

* Replace `WalletConnectConnector` with `WalletConnectLegacyConnector` to support older wallets using the legacy WalletConnect protocol ([link](https://github.com/lensterxyz/lenster/pull/2629/files?diff=unified&w=0#diff-770888966434e7639aad4ad8b865ab3b7fd09316f081d7346668c352951b7e77L5-R5), [link](https://github.com/lensterxyz/lenster/pull/2629/files?diff=unified&w=0#diff-770888966434e7639aad4ad8b865ab3b7fd09316f081d7346668c352951b7e77L13-R13), [link](https://github.com/lensterxyz/lenster/pull/2629/files?diff=unified&w=0#diff-770888966434e7639aad4ad8b865ab3b7fd09316f081d7346668c352951b7e77L31-R31), [link](https://github.com/lensterxyz/lenster/pull/2629/files?diff=unified&w=0#diff-6027b3b90daf9163b816cc09e412835e049d09b9df0d980cb774632f6b294ef3L16-R16))

## Emoji

<!--
copilot:emoji
-->

🔧🆕🗑️

<!--
1.  🔧 - This emoji can be used to indicate a configuration or adjustment, such as changing the name of a value or function to match a different connector.
2.  🆕 - This emoji can be used to indicate a new feature or addition, such as using a custom WalletConnect connector that supports legacy wallets.
3.  🗑️ - This emoji can be used to indicate a removal or deletion, such as removing unused code and imports related to the old connector.
-->
