### PR TITLE
Fix duplications in profile feed.

### DIFF
--- a/apps/web/src/components/Profile/Feed.tsx
+++ b/apps/web/src/components/Profile/Feed.tsx
@@ -71,7 +71,7 @@ const Feed: FC<FeedProps> = ({ profile, type }) => {
 
   const { observe } = useInView({
     onChange: async ({ inView }) => {
-      if (!inView || !hasMore) {
+      if (!inView || !hasMore || publications?.length && publications?.length < 10) {
         return;
       }
 


### PR DESCRIPTION
gh-2634

## What does this PR do?

Fixes duplications when toggling tabs in feed with less than 10 items & more than 10 items. Not tested for feeds with exactly 10 items, so may not work there.

This fix is just a suggestion of a possible solution. I think this problem may be present in _all_ `fetchMore` routines application wide, so further testing is required.

## Related issues

Related to #2634 


## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca2bb12</samp>

*  Prevent fetching more publications when initial query is small ([link](https://github.com/lensterxyz/lenster/pull/2635/files?diff=unified&w=0#diff-4f1019d968a6c4b10b6415e98ae00761530df83bd2b1c38c98bf5837dc40393cL74-R74))

## Emoji

<!--
copilot:emoji
-->

📜👀🔄

<!--
1.  📜 This emoji can represent the feed or the publications that are displayed on the screen.
2.  👀 This emoji can represent the use of the `useInView` hook, which tracks the visibility of an element on the screen.
3.  🔄 This emoji can represent the `fetchMore` function, which loads more publications when the user reaches the end of the feed.
-->
