### PR TITLE
feat: add main content focus filter

### DIFF
--- a/apps/web/src/components/Mod/Feed.tsx
+++ b/apps/web/src/components/Mod/Feed.tsx
@@ -2,7 +2,13 @@ import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
 import { CollectionIcon } from '@heroicons/react/outline';
 import { t } from '@lingui/macro';
-import type { CustomFiltersTypes, ExplorePublicationRequest, Publication, PublicationTypes } from 'lens';
+import type {
+  CustomFiltersTypes,
+  ExplorePublicationRequest,
+  Publication,
+  PublicationMainFocus,
+  PublicationTypes
+} from 'lens';
 import { PublicationSortCriteria, useExploreFeedQuery } from 'lens';
 import type { FC } from 'react';
 import { useEffect, useState } from 'react';
@@ -14,10 +20,17 @@ interface FeedProps {
   refresh: boolean;
   setRefreshing: (refreshing: boolean) => void;
   publicationTypes: PublicationTypes[];
+  mainContentFocus: PublicationMainFocus[];
   customFilters: CustomFiltersTypes[];
 }
 
-const Feed: FC<FeedProps> = ({ refresh, setRefreshing, publicationTypes, customFilters }) => {
+const Feed: FC<FeedProps> = ({
+  refresh,
+  setRefreshing,
+  publicationTypes,
+  mainContentFocus,
+  customFilters
+}) => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [hasMore, setHasMore] = useState(true);
 
@@ -26,6 +39,9 @@ const Feed: FC<FeedProps> = ({ refresh, setRefreshing, publicationTypes, customF
     sortCriteria: PublicationSortCriteria.Latest,
     noRandomize: true,
     publicationTypes,
+    metadata: {
+      mainContentFocus
+    },
     customFilters,
     limit: 50
   };
@@ -43,7 +59,7 @@ const Feed: FC<FeedProps> = ({ refresh, setRefreshing, publicationTypes, customF
     setRefreshing(true);
     refetch().finally(() => setRefreshing(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refresh, publicationTypes, customFilters]);
+  }, [refresh, publicationTypes, mainContentFocus, customFilters]);
 
   const { observe } = useInView({
     onChange: async ({ inView }) => {

--- a/apps/web/src/components/Mod/index.tsx
+++ b/apps/web/src/components/Mod/index.tsx
@@ -3,7 +3,7 @@ import Footer from '@components/Shared/Footer';
 import { Mixpanel } from '@lib/mixpanel';
 import { t, Trans } from '@lingui/macro';
 import { APP_NAME } from 'data/constants';
-import { CustomFiltersTypes, PublicationTypes } from 'lens';
+import { CustomFiltersTypes, PublicationMainFocus, PublicationTypes } from 'lens';
 import isGardener from 'lib/isGardener';
 import type { NextPage } from 'next';
 import { useEffect, useState } from 'react';
@@ -19,6 +19,15 @@ const Mod: NextPage = () => {
   const [refresing, setRefreshing] = useState(false);
   const [refresh, setRefresh] = useState(false);
   const [publicationTypes, setPublicationTypes] = useState([PublicationTypes.Post, PublicationTypes.Comment]);
+  const [mainContentFocus, setMainContentFocus] = useState<PublicationMainFocus[]>([
+    PublicationMainFocus.Article,
+    PublicationMainFocus.Audio,
+    PublicationMainFocus.Embed,
+    PublicationMainFocus.Image,
+    PublicationMainFocus.Link,
+    PublicationMainFocus.TextOnly,
+    PublicationMainFocus.Video
+  ]);
   const [customFilters, setCustomFilters] = useState([CustomFiltersTypes.Gardeners]);
 
   useEffect(() => {
@@ -29,6 +38,22 @@ const Mod: NextPage = () => {
     return <Custom404 />;
   }
 
+  const toggleMainContentFocus = (focus: PublicationMainFocus) => {
+    if (mainContentFocus.includes(focus)) {
+      setMainContentFocus(mainContentFocus.filter((type) => type !== focus));
+    } else {
+      setMainContentFocus([...mainContentFocus, focus]);
+    }
+  };
+
+  const togglePublicationType = (publicationType: PublicationTypes) => {
+    if (publicationTypes.includes(publicationType)) {
+      setPublicationTypes(publicationTypes.filter((type) => type !== publicationType));
+    } else {
+      setPublicationTypes([...publicationTypes, publicationType]);
+    }
+  };
+
   return (
     <GridLayout>
       <MetaTags title={t`Mod Center • ${APP_NAME}`} />
@@ -37,6 +62,7 @@ const Mod: NextPage = () => {
           refresh={refresh}
           setRefreshing={setRefreshing}
           publicationTypes={publicationTypes}
+          mainContentFocus={mainContentFocus}
           customFilters={customFilters}
         />
       </GridItemEight>
@@ -50,27 +76,15 @@ const Mod: NextPage = () => {
             <span className="font-bold">
               <Trans>Publication filters</Trans>
             </span>
-            <div className="flex items-center space-x-5">
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
               <Checkbox
-                onChange={() => {
-                  if (publicationTypes.includes(PublicationTypes.Post)) {
-                    setPublicationTypes(publicationTypes.filter((type) => type !== PublicationTypes.Post));
-                  } else {
-                    setPublicationTypes([...publicationTypes, PublicationTypes.Post]);
-                  }
-                }}
+                onChange={() => togglePublicationType(PublicationTypes.Post)}
                 checked={publicationTypes.includes(PublicationTypes.Post)}
                 name="posts"
                 label={t`Posts`}
               />
               <Checkbox
-                onChange={() => {
-                  if (publicationTypes.includes(PublicationTypes.Comment)) {
-                    setPublicationTypes(publicationTypes.filter((type) => type !== PublicationTypes.Comment));
-                  } else {
-                    setPublicationTypes([...publicationTypes, PublicationTypes.Comment]);
-                  }
-                }}
+                onChange={() => togglePublicationType(PublicationTypes.Comment)}
                 checked={publicationTypes.includes(PublicationTypes.Comment)}
                 name="comments"
                 label={t`Comments`}
@@ -80,9 +94,59 @@ const Mod: NextPage = () => {
           <div className="divider my-3" />
           <div className="space-y-2">
             <span className="font-bold">
+              <Trans>Media filters</Trans>
+            </span>
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
+              <Checkbox
+                onChange={() => toggleMainContentFocus(PublicationMainFocus.Article)}
+                checked={mainContentFocus.includes(PublicationMainFocus.Article)}
+                name="articles"
+                label={t`Articles`}
+              />
+              <Checkbox
+                onChange={() => toggleMainContentFocus(PublicationMainFocus.Audio)}
+                checked={mainContentFocus.includes(PublicationMainFocus.Audio)}
+                name="audio"
+                label={t`Audio`}
+              />
+              <Checkbox
+                onChange={() => toggleMainContentFocus(PublicationMainFocus.Embed)}
+                checked={mainContentFocus.includes(PublicationMainFocus.Embed)}
+                name="embeds"
+                label={t`Embeds`}
+              />
+              <Checkbox
+                onChange={() => toggleMainContentFocus(PublicationMainFocus.Image)}
+                checked={mainContentFocus.includes(PublicationMainFocus.Image)}
+                name="images"
+                label={t`Images`}
+              />
+              <Checkbox
+                onChange={() => toggleMainContentFocus(PublicationMainFocus.Link)}
+                checked={mainContentFocus.includes(PublicationMainFocus.Link)}
+                name="links"
+                label={t`Links`}
+              />
+              <Checkbox
+                onChange={() => toggleMainContentFocus(PublicationMainFocus.TextOnly)}
+                checked={mainContentFocus.includes(PublicationMainFocus.TextOnly)}
+                name="text"
+                label={t`Text`}
+              />
+              <Checkbox
+                onChange={() => toggleMainContentFocus(PublicationMainFocus.Video)}
+                checked={mainContentFocus.includes(PublicationMainFocus.Video)}
+                name="videos"
+                label={t`Videos`}
+              />
+            </div>
+          </div>
+          <div className="divider my-3" />
+          <div className="space-y-2">
+            <span className="font-bold">
               <Trans>Custom filters</Trans>
             </span>
-            <div>
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
               <Checkbox
                 onChange={() => {
                   if (customFilters.includes(CustomFiltersTypes.Gardeners)) {


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75c73f9</samp>

Added media filters to the `Mod` and `Feed` components. This lets the user narrow down the publications they see on the web app by their main focus, such as text, image, video, or audio. Used existing types and fields from `lens` to implement the filter logic.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 75c73f9</samp>

*  Add media type filter to feed query and component props ([link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-5b0f1e4e58cbb931cf2d813a50520a75df01037dc208d5409fc40dd5189fd498L5-R11), [link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-5b0f1e4e58cbb931cf2d813a50520a75df01037dc208d5409fc40dd5189fd498L17-R33), [link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-5b0f1e4e58cbb931cf2d813a50520a75df01037dc208d5409fc40dd5189fd498R42-R44), [link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-5b0f1e4e58cbb931cf2d813a50520a75df01037dc208d5409fc40dd5189fd498L46-R62))
*  Add media type filter state and helper functions to `Mod` component ([link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-166fe517c88169cff038fd5153b474ead4b4a4e1e1c8cc19a787a49fb36882edL6-R6), [link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-166fe517c88169cff038fd5153b474ead4b4a4e1e1c8cc19a787a49fb36882edR22-R30), [link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-166fe517c88169cff038fd5153b474ead4b4a4e1e1c8cc19a787a49fb36882edR41-R56))
*  Pass media type filter state as prop to `Feed` component ([link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-166fe517c88169cff038fd5153b474ead4b4a4e1e1c8cc19a787a49fb36882edR65))
*  Refactor publication type filter logic to use helper functions ([link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-166fe517c88169cff038fd5153b474ead4b4a4e1e1c8cc19a787a49fb36882edL53-R81), [link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-166fe517c88169cff038fd5153b474ead4b4a4e1e1c8cc19a787a49fb36882edL67-R87))
*  Add media type filter UI with checkboxes and translations to `Mod` component ([link](https://github.com/lensterxyz/lenster/pull/2649/files?diff=unified&w=0#diff-166fe517c88169cff038fd5153b474ead4b4a4e1e1c8cc19a787a49fb36882edL83-R149))

## Emoji

<!--
copilot:emoji
-->

🎞️🔍♻️

<!--
1.  🎞️ - This emoji represents the media type filter feature, as it is related to different kinds of media formats and content. It can also convey the idea of exploring and discovering new publications based on their media type.
2.  🔍 - This emoji represents the filtering functionality, as it is a common symbol for searching and filtering data. It can also suggest the user's intention to narrow down their feed and find publications that match their preferences and interests.
3.  ♻️ - This emoji represents the refactoring of the existing code, as it is a symbol of recycling and reusing resources. It can also imply the improvement of the code quality and performance by simplifying the logic and using helper functions.
-->
