### PR TITLE
feat: use uploadFileToIPFS instead of uploadToIPFS

### DIFF
--- a/apps/web/src/components/Shared/Audio/CoverImage.tsx
+++ b/apps/web/src/components/Shared/Audio/CoverImage.tsx
@@ -1,5 +1,5 @@
 import { PhotographIcon } from '@heroicons/react/outline';
-import uploadToIPFS from '@lib/uploadToIPFS';
+import { uploadFileToIPFS } from '@lib/uploadToIPFS';
 import clsx from 'clsx';
 import { ATTACHMENT } from 'data/constants';
 import Errors from 'data/errors';
@@ -26,12 +26,12 @@ const CoverImage: FC<CoverImageProps> = ({ isNew = false, cover, setCover, image
     setLoading(false);
   };
 
-  const onChange = async (e: ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files?.length) {
+  const onChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files?.length) {
       try {
         setLoading(true);
-        const attachment = await uploadToIPFS(e.target.files);
-        setCover(attachment[0].original.url, attachment[0].original.mimeType);
+        const attachment = await uploadFileToIPFS(event.target.files[0]);
+        setCover(attachment.original.url, attachment.original.mimeType);
       } catch (error) {
         onError(error);
       }

--- a/apps/web/src/components/Shared/Login/New/index.tsx
+++ b/apps/web/src/components/Shared/Login/New/index.tsx
@@ -1,6 +1,6 @@
 import ChooseFile from '@components/Shared/ChooseFile';
 import { PlusIcon } from '@heroicons/react/outline';
-import uploadToIPFS from '@lib/uploadToIPFS';
+import { uploadFileToIPFS } from '@lib/uploadToIPFS';
 import { t, Trans } from '@lingui/macro';
 import { APP_NAME, HANDLE_REGEX, ZERO_ADDRESS } from 'data/constants';
 import { useCreateProfileMutation } from 'lens';
@@ -36,16 +36,18 @@ const NewProfile: FC<NewProfileProps> = ({ isModal = false }) => {
     schema: newUserSchema
   });
 
-  const handleUpload = async (evt: ChangeEvent<HTMLInputElement>) => {
-    evt.preventDefault();
-    setUploading(true);
-    try {
-      const attachment = await uploadToIPFS(evt.target.files);
-      if (attachment[0]?.original.url) {
-        setAvatar(attachment[0].original.url);
+  const handleUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    event.preventDefault();
+    if (event.target.files?.length) {
+      try {
+        setUploading(true);
+        const attachment = await uploadFileToIPFS(event.target.files[0]);
+        if (attachment.original.url) {
+          setAvatar(attachment.original.url);
+        }
+      } finally {
+        setUploading(false);
       }
-    } finally {
-      setUploading(false);
     }
   };
 

--- a/apps/web/src/components/utils/hooks/useUploadAttachments.tsx
+++ b/apps/web/src/components/utils/hooks/useUploadAttachments.tsx
@@ -28,8 +28,7 @@ const useUploadAttachments = () => {
           previewItem: URL.createObjectURL(file),
           original: {
             url: URL.createObjectURL(file),
-            mimeType: file.type,
-            altTag: ''
+            mimeType: file.type
           }
         };
       });
@@ -72,8 +71,7 @@ const useUploadAttachments = () => {
             ...attachment,
             original: {
               url: attachmentsUploaded[index].original.url,
-              mimeType: attachmentsUploaded[index].original.mimeType,
-              altTag: ''
+              mimeType: attachmentsUploaded[index].original.mimeType
             }
           }));
           updateAttachments(attachmentsIPFS);

--- a/apps/web/src/lib/profilePictureUtils.ts
+++ b/apps/web/src/lib/profilePictureUtils.ts
@@ -1,4 +1,4 @@
-import uploadToIPFS from './uploadToIPFS';
+import { uploadFileToIPFS } from './uploadToIPFS';
 
 export function readFile(file: Blob): Promise<string> {
   return new Promise((resolve) => {
@@ -11,11 +11,12 @@ export function readFile(file: Blob): Promise<string> {
 const uploadCroppedImage = async (image: HTMLCanvasElement): Promise<string> => {
   const blob = await new Promise((resolve) => image.toBlob(resolve));
   const file = new File([blob as Blob], 'cropped_image.png', { type: (blob as Blob).type });
-  const attachment = await uploadToIPFS([file]);
-  const ipfsUrl = attachment[0]?.original.url;
+  const attachment = await uploadFileToIPFS(file);
+  const ipfsUrl = attachment.original.url;
   if (!ipfsUrl) {
     throw new Error('uploadToIPFS failed');
   }
+
   return ipfsUrl;
 };
 

--- a/apps/web/src/lib/uploadToIPFS.ts
+++ b/apps/web/src/lib/uploadToIPFS.ts
@@ -4,6 +4,8 @@ import { EVER_API, S3_BUCKET, STS_TOKEN_URL } from 'data/constants';
 import type { MediaSet } from 'lens';
 import { v4 as uuid } from 'uuid';
 
+const FALLBACK_TYPE = 'image/jpeg';
+
 /**
  * Returns an S3 client with temporary credentials obtained from the STS service.
  *
@@ -47,11 +49,7 @@ const uploadToIPFS = async (data: any): Promise<MediaSet[]> => {
         const metadata = result.Metadata;
 
         return {
-          original: {
-            url: `ipfs://${metadata?.['ipfs-hash']}`,
-            mimeType: file.type || 'image/jpeg',
-            altTag: ''
-          }
+          original: { url: `ipfs://${metadata?.['ipfs-hash']}`, mimeType: file.type || FALLBACK_TYPE }
         };
       })
     );
@@ -80,19 +78,11 @@ export const uploadFileToIPFS = async (file: File): Promise<MediaSet> => {
     const metadata = result.Metadata;
 
     return {
-      original: {
-        url: `ipfs://${metadata?.['ipfs-hash']}`,
-        mimeType: file.type || 'image/jpeg',
-        altTag: ''
-      }
+      original: { url: `ipfs://${metadata?.['ipfs-hash']}`, mimeType: file.type || FALLBACK_TYPE }
     };
   } catch {
     return {
-      original: {
-        url: '',
-        mimeType: file.type,
-        altTag: ''
-      }
+      original: { url: '', mimeType: file.type || FALLBACK_TYPE }
     };
   }
 };


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8c5fd5</samp>

Refactored and simplified the code for uploading files to IPFS in various components and modules. Used more consistent and descriptive function names and data structures. Removed unused and unnecessary properties from the attachment objects.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8c5fd5</samp>

*  Rename `uploadToIPFS` to `uploadFileToIPFS` and update its usage in `CoverImage.tsx`, `New/index.tsx`, and `profilePictureUtils.ts` ([link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-e4960701bac4eaac4421909729d3fa13cba5b96b84839a99889a9290fdc57abeL2-R2), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-03620ba1622da3c91f0bab45f87bbcd8328153294b7af06e0292b1e57049e0c6L3-R3), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-ece2beae4fe47b832ac0f0c9e1420606662de015d91e767bbee477cf00db511aL1-R1), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-e4960701bac4eaac4421909729d3fa13cba5b96b84839a99889a9290fdc57abeL29-R34), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-03620ba1622da3c91f0bab45f87bbcd8328153294b7af06e0292b1e57049e0c6L39-R50), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-ece2beae4fe47b832ac0f0c9e1420606662de015d91e767bbee477cf00db511aL14-R19))
* Simplify attachment object to access original property directly instead of using array index in `CoverImage.tsx`, `New/index.tsx`, and `profilePictureUtils.ts` ([link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-e4960701bac4eaac4421909729d3fa13cba5b96b84839a99889a9290fdc57abeL29-R34), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-03620ba1622da3c91f0bab45f87bbcd8328153294b7af06e0292b1e57049e0c6L39-R50), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-ece2beae4fe47b832ac0f0c9e1420606662de015d91e767bbee477cf00db511aL14-R19))
* Remove unused `altTag` property from attachment object in `useUploadAttachments.tsx` and `uploadToIPFS.ts` ([link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-2b10663530d5e1d24985131acf7ffe974de2ef545982c50c4294e37b4c33859eL31-R31), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-2b10663530d5e1d24985131acf7ffe974de2ef545982c50c4294e37b4c33859eL75-R74), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-b1aedb60c7ba1c942c488f48e7912312cc0684d40b2bf3886c08ac583424fd91L50-R52), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-b1aedb60c7ba1c942c488f48e7912312cc0684d40b2bf3886c08ac583424fd91L83-R85))
* Add `FALLBACK_TYPE` constant for default mime type and use it in `uploadToIPFS.ts` ([link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-b1aedb60c7ba1c942c488f48e7912312cc0684d40b2bf3886c08ac583424fd91R7-R8), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-b1aedb60c7ba1c942c488f48e7912312cc0684d40b2bf3886c08ac583424fd91L50-R52), [link](https://github.com/lensterxyz/lenster/pull/2673/files?diff=unified&w=0#diff-b1aedb60c7ba1c942c488f48e7912312cc0684d40b2bf3886c08ac583424fd91L83-R85))

## Emoji

<!--
copilot:emoji
-->

📁🧹🔧

<!--
1.  📁 - This emoji represents the file uploading functionality and the refactoring of the code for uploading cover images and profile pictures to IPFS.
2.  🧹 - This emoji represents the simplification and cleanup of the data structure for the attachment object and the removal of unused properties and logic.
3.  🔧 - This emoji represents the renaming and usage of a utility function and a constant for the default mime type, which improves code readability and maintainability.
-->
