### PR TITLE
feat: async batch message previews

### DIFF
--- a/apps/web/src/components/Messages/Preview.tsx
+++ b/apps/web/src/components/Messages/Preview.tsx
@@ -13,7 +13,7 @@ import { Image } from 'ui';
 
 interface PreviewProps {
   profile: Profile;
-  message: DecodedMessage;
+  message?: DecodedMessage;
   conversationKey: string;
   isSelected: boolean;
 }
@@ -54,14 +54,14 @@ const Preview: FC<PreviewProps> = ({ profile, message, conversationKey, isSelect
               <div className="text-md truncate">{profile?.name ?? formatHandle(profile.handle)}</div>
               {isVerified(profile?.id) && <BadgeCheckIcon className="text-brand h-4 w-4 min-w-fit" />}
             </div>
-            {message.sent && (
-              <span className="lt-text-gray-500 shrink-0 pt-0.5 text-xs" title={formatTime(message.sent)}>
+            {message?.sent && (
+              <span className="lt-text-gray-500 min-w-fit pt-0.5 text-xs" title={formatTime(message.sent)}>
                 {getTimeFromNow(message.sent)}
               </span>
             )}
           </div>
           <span className="lt-text-gray-500 line-clamp-1 break-all text-sm">
-            {address === message.senderAddress && 'You: '} {message.content}
+            {address === message?.senderAddress && 'You: '} {message?.content}
           </span>
         </div>
       </div>

--- a/apps/web/src/components/Messages/Preview.tsx
+++ b/apps/web/src/components/Messages/Preview.tsx
@@ -55,7 +55,7 @@ const Preview: FC<PreviewProps> = ({ profile, message, conversationKey, isSelect
               {isVerified(profile?.id) && <BadgeCheckIcon className="text-brand h-4 w-4 min-w-fit" />}
             </div>
             {message?.sent && (
-              <span className="lt-text-gray-500 min-w-fit pt-0.5 text-xs" title={formatTime(message.sent)}>
+              <span className="lt-text-gray-500 shrink-0 pt-0.5 text-xs" title={formatTime(message.sent)}>
                 {getTimeFromNow(message.sent)}
               </span>
             )}

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -2,6 +2,7 @@ import Preview from '@components/Messages/Preview';
 import Following from '@components/Profile/Following';
 import Loader from '@components/Shared/Loader';
 import Search from '@components/Shared/Navbar/Search';
+import useGetMessagePreviews from '@components/utils/hooks/useGetMessagePreviews';
 import useMessagePreviews from '@components/utils/hooks/useMessagePreviews';
 import { MailIcon, PlusCircleIcon, UsersIcon } from '@heroicons/react/outline';
 import buildConversationId from '@lib/buildConversationId';
@@ -34,6 +35,7 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
   const [showSearchModal, setShowSearchModal] = useState(false);
   const { authenticating, loading, messages, profilesToShow, requestedCount, profilesError } =
     useMessagePreviews();
+  const { loading: previewsLoading, progress: previewsProgress } = useGetMessagePreviews();
   const clearMessagesBadge = useMessagePersistStore((state) => state.clearMessagesBadge);
 
   const sortedProfiles = Array.from(profilesToShow).sort(([keyA], [keyB]) => {
@@ -86,19 +88,28 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
           <div
             onClick={() => setSelectedTab('Following')}
             className={clsx(
-              'text-brand tab-bg m-2 ml-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
-              selectedTab === 'Following' ? 'bg-brand-100' : ''
+              'text-brand tab-bg relative m-2 ml-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
+              selectedTab === 'Following' ? 'bg-brand-100' : '',
+              selectedTab === 'Following' && previewsLoading ? 'shimmer-brand' : ''
             )}
             aria-hidden="true"
           >
             <UsersIcon className="mr-2 h-4 w-4" />
             <Trans>Following</Trans>
+            {selectedTab === 'Following' && previewsLoading && (
+              <progress
+                className="absolute bottom-0 h-1 w-full appearance-none border-none bg-transparent"
+                value={previewsProgress}
+                max={100}
+              />
+            )}
           </div>
           <div
             onClick={() => setSelectedTab('Requested')}
             className={clsx(
-              'text-brand tab-bg m-2 mr-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
-              selectedTab === 'Requested' ? 'bg-brand-100' : ''
+              'text-brand tab-bg relative m-2 mr-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
+              selectedTab === 'Requested' ? 'bg-brand-100' : '',
+              selectedTab === 'Requested' && previewsLoading ? 'shimmer-brand' : ''
             )}
             aria-hidden="true"
           >
@@ -107,6 +118,13 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
               <span className="bg-brand-200 ml-2 rounded-2xl px-3 py-0.5 text-sm font-bold">
                 {requestedCount > 99 ? '99+' : requestedCount}
               </span>
+            )}
+            {selectedTab === 'Requested' && previewsLoading && (
+              <progress
+                className="absolute bottom-0 h-1 w-full appearance-none border-none bg-transparent"
+                value={previewsProgress}
+                max={100}
+              />
             )}
           </div>
         </div>
@@ -147,10 +165,6 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
               data={sortedProfiles}
               itemContent={(_, [key, profile]) => {
                 const message = messages.get(key);
-                if (!message) {
-                  return null;
-                }
-
                 return (
                   <Preview
                     isSelected={key === selectedConversationKey}

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -76,40 +76,38 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
       )}
     >
       <Card className="flex h-full flex-col justify-between">
-        <div className="divider flex items-center justify-between p-5">
+        <div className="divider relative flex items-center justify-between p-5">
           <div className="font-bold">Messages</div>
           {currentProfile && !showAuthenticating && !showLoading && (
             <button onClick={newMessageClick} type="button">
               <PlusCircleIcon className="h-6 w-6" />
             </button>
           )}
+          {previewsLoading && (
+            <progress
+              className="absolute -bottom-1 left-0 h-1 w-full appearance-none border-none bg-transparent"
+              value={previewsProgress}
+              max={100}
+            />
+          )}
         </div>
         <div className="flex">
           <div
             onClick={() => setSelectedTab('Following')}
             className={clsx(
-              'text-brand tab-bg relative m-2 ml-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
-              selectedTab === 'Following' ? 'bg-brand-100' : '',
-              selectedTab === 'Following' && previewsLoading ? 'shimmer-brand' : ''
+              'text-brand tab-bg m-2 ml-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
+              selectedTab === 'Following' ? 'bg-brand-100' : ''
             )}
             aria-hidden="true"
           >
             <UsersIcon className="mr-2 h-4 w-4" />
             <Trans>Following</Trans>
-            {selectedTab === 'Following' && previewsLoading && (
-              <progress
-                className="absolute bottom-0 h-1 w-full appearance-none border-none bg-transparent"
-                value={previewsProgress}
-                max={100}
-              />
-            )}
           </div>
           <div
             onClick={() => setSelectedTab('Requested')}
             className={clsx(
-              'text-brand tab-bg relative m-2 mr-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
-              selectedTab === 'Requested' ? 'bg-brand-100' : '',
-              selectedTab === 'Requested' && previewsLoading ? 'shimmer-brand' : ''
+              'text-brand tab-bg m-2 mr-4 flex flex-1 cursor-pointer items-center justify-center rounded p-2 font-bold',
+              selectedTab === 'Requested' ? 'bg-brand-100' : ''
             )}
             aria-hidden="true"
           >
@@ -118,13 +116,6 @@ const PreviewList: FC<PreviewListProps> = ({ className, selectedConversationKey 
               <span className="bg-brand-200 ml-2 rounded-2xl px-3 py-0.5 text-sm font-bold">
                 {requestedCount > 99 ? '99+' : requestedCount}
               </span>
-            )}
-            {selectedTab === 'Requested' && previewsLoading && (
-              <progress
-                className="absolute bottom-0 h-1 w-full appearance-none border-none bg-transparent"
-                value={previewsProgress}
-                max={100}
-              />
             )}
           </div>
         </div>

--- a/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
+++ b/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
@@ -1,0 +1,81 @@
+import useXmtpClient from '@components/utils/hooks/useXmtpClient';
+import chunkArray from '@lib/chunkArray';
+import { buildConversationKey } from '@lib/conversationKey';
+import type { Conversation } from '@xmtp/xmtp-js';
+import { SortDirection } from '@xmtp/xmtp-js';
+import type { DecodedMessage } from '@xmtp/xmtp-js/dist/types/src/Message';
+import { useEffect, useRef, useState } from 'react';
+import { useMessageStore } from 'src/store/message';
+
+const fetchMostRecentMessage = async (
+  convo: Conversation
+): Promise<{ key: string; message?: DecodedMessage }> => {
+  const key = buildConversationKey(convo.peerAddress, convo.context?.conversationId as string);
+  const latestMessageQuery = await convo.messages({
+    limit: 1,
+    direction: SortDirection.SORT_DIRECTION_DESCENDING
+  });
+  if (latestMessageQuery.length <= 0) {
+    return { key };
+  }
+  return { key, message: latestMessageQuery[0] };
+};
+
+const useGetMessagePreviews = () => {
+  const conversations = useMessageStore((state) => state.conversations);
+  const previewMessages = useMessageStore((state) => state.previewMessages);
+  const setPreviewMessage = useMessageStore((state) => state.setPreviewMessage);
+  const { client } = useXmtpClient();
+  const [loading, setLoading] = useState<boolean>(false);
+  const loadingRef = useRef<boolean>(false);
+  const countRef = useRef<number>(0);
+  const [progress, setProgress] = useState<number>(0);
+
+  useEffect(() => {
+    if (!client || loadingRef.current) {
+      return;
+    }
+
+    const getMessagePreviews = async () => {
+      loadingRef.current = true;
+      setLoading(true);
+
+      // Diff the conversations and preview messages to see which ones are missing
+      const needsSync = Array.from(conversations.values()).filter(
+        (convo) =>
+          previewMessages.get(
+            buildConversationKey(convo.peerAddress, convo.context?.conversationId as string)
+          ) === undefined
+      );
+
+      for (const chunk of chunkArray(needsSync, 50)) {
+        // Yield to the UI between pages of conversations, since this all happens in the background
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+        await Promise.all(
+          chunk.map(async (convo) => {
+            const latestMessage = await fetchMostRecentMessage(convo);
+            const existingValue = previewMessages.get(latestMessage.key)?.sent;
+            if (latestMessage.message && (!existingValue || latestMessage?.message.sent > existingValue)) {
+              setPreviewMessage(latestMessage.key, latestMessage.message);
+            }
+            countRef.current = countRef.current + 1;
+            setProgress(Math.round((countRef.current / needsSync.length) * 100));
+          })
+        );
+      }
+
+      setLoading(false);
+      loadingRef.current = false;
+    };
+
+    getMessagePreviews();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, conversations, previewMessages]);
+
+  return {
+    loading,
+    progress
+  };
+};
+
+export default useGetMessagePreviews;

--- a/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
+++ b/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
@@ -1,4 +1,3 @@
-import useXmtpClient from '@components/utils/hooks/useXmtpClient';
 import chunkArray from '@lib/chunkArray';
 import { buildConversationKey } from '@lib/conversationKey';
 import type { Conversation } from '@xmtp/xmtp-js';
@@ -25,7 +24,7 @@ const useGetMessagePreviews = () => {
   const conversations = useMessageStore((state) => state.conversations);
   const previewMessages = useMessageStore((state) => state.previewMessages);
   const setPreviewMessage = useMessageStore((state) => state.setPreviewMessage);
-  const { client } = useXmtpClient();
+  const client = useMessageStore((state) => state.client);
   const [loading, setLoading] = useState<boolean>(false);
   const loadingRef = useRef<boolean>(false);
   const countRef = useRef<number>(0);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -19,6 +19,28 @@ body {
   @apply dark:bg-gray-600;
 }
 
+.shimmer-brand {
+  @apply bg-brand-100;
+  @apply animate-pulse;
+}
+
+progress::-webkit-progress-bar {
+  @apply rounded-bl;
+  background-color: transparent;
+}
+
+progress::-webkit-progress-value {
+  @apply rounded-bl;
+  @apply bg-brand-500;
+  transition: width 0.5s ease;
+}
+
+progress::-moz-progress-bar {
+  @apply rounded-bl;
+  @apply bg-brand-500;
+  transition: width 0.5s ease;
+}
+
 .menu-item {
   @apply m-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200;
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -19,18 +19,11 @@ body {
   @apply dark:bg-gray-600;
 }
 
-.shimmer-brand {
-  @apply bg-brand-100;
-  @apply animate-pulse;
-}
-
 progress::-webkit-progress-bar {
-  @apply rounded-bl;
   background-color: transparent;
 }
 
 progress::-webkit-progress-value {
-  @apply rounded-bl;
   @apply bg-brand-500;
   transition: width 0.5s ease;
 }


### PR DESCRIPTION
## What does this PR do?

These changes make the fetching of the latest conversation messages an async background task that fetches messages in batches of 50.

This will allow the conversations list to render immediately after profiles are fetched. During the batched requests, a loading indicator is displayed in the selected tab.

Until we implement message preview caching, the user experience during the loading of message previews will degrade as the previews stream in. This will likely cause some conversations to jump around from sorting or disappear completely because the conversation has no messages. See preview video below to see how this will work.

Even with proper caching, the initial loading of conversations and their preview messages will take time; however, this should only occur when initially signing into an account on a new browser/device.

In the future, we can mitigate this initial degraded user experience by exporting and then importing conversation and message data.

**Loading experience preview**

https://user-images.githubusercontent.com/2925672/234598854-7df78c4c-dc4d-420e-bd89-2a9ab0557715.mp4

@bigint I just took a guess about the design of the loading indicator. I didn't want it to be intrusive, but definitely wanted to show users that there's still something happening in the background.

Another thing that I was considering with this change is some sort of loading state inside of the `Preview` component to indicate that the latest message hasn't been fetched yet. Not sure if it's necessary, but I'll let you play around with this and determine the best way forward.

## Related issues

Fixes #2302 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3fd10c2</samp>

*  Make `message` prop optional in `Preview` component and use optional chaining to access it ([link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-86a42fd57d0cd5557caf0ba432c3f36f048b7f3098460771c3f65de779dd14a4L16-R16), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-86a42fd57d0cd5557caf0ba432c3f36f048b7f3098460771c3f65de779dd14a4L57-R58), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-86a42fd57d0cd5557caf0ba432c3f36f048b7f3098460771c3f65de779dd14a4L64-R64))
* Add `useGetMessagePreviews` hook to fetch the most recent message for each conversation in the background ([link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-b971652b1e5c5c7d512e6c7091d49059c858f7e50f84d8364cd66384c14bda4aR1-R81))
* Use `loading` and `progress` states from `useGetMessagePreviews` hook to show progress bars and shimmer animations in `PreviewList` component ([link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778R5), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778R38), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778L89-R93), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778L96-R112), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778R122-R128))
* Remove unused code and dependencies from `useMessagePreviews` hook ([link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L7), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L26), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L117-R116), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L144-R139), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L226-R205), [link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L241-R214))
* Add `shimmer-brand` class and `progress` element styles to `styles.css` ([link](https://github.com/lensterxyz/lenster/pull/2706/files?diff=unified&w=0#diff-8695905e235830a8430629a67e7b6b265305775a6ed81fe2116cdec08d29af15R22-R43))

## Emoji

<!--
copilot:emoji
-->

📥🌟♻️

<!--
1.  📥 This emoji represents the fetching of message previews in the background, which is a key feature of the pull request.
2.  🌟 This emoji represents the shimmer effects and the progress bar, which enhance the user experience and provide feedback on the loading status.
3.  ♻️ This emoji represents the refactoring and simplification of the code, which improves the readability and maintainability of the hook.
-->
