### PR TITLE
chore: remove bonsai ff 🌳

### DIFF
--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -2,7 +2,6 @@ import Attachments from '@components/Shared/Attachments';
 import { AudioPublicationSchema } from '@components/Shared/Audio';
 import withLexicalContext from '@components/Shared/Lexical/withLexicalContext';
 import type { IGif } from '@giphy/js-types';
-import { useFeature } from '@growthbook/growthbook-react';
 import { ChatAlt2Icon, PencilAltIcon } from '@heroicons/react/outline';
 import type {
   CollectCondition,
@@ -26,7 +25,6 @@ import uploadToArweave from '@lib/uploadToArweave';
 import { t } from '@lingui/macro';
 import { LensHub } from 'abis';
 import clsx from 'clsx';
-import { FeatureFlag } from 'data';
 import {
   ALLOWED_AUDIO_TYPES,
   ALLOWED_IMAGE_TYPES,
@@ -153,8 +151,6 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
   const [editor] = useLexicalComposerContext();
   const provider = useProvider();
   const { data: signer } = useSigner();
-
-  const { on: isBonsaiEnabled } = useFeature(FeatureFlag.Bonsai as string);
 
   const isComment = Boolean(publication);
   const hasAudio = ALLOWED_AUDIO_TYPES.includes(attachments[0]?.original.mimeType);
@@ -658,7 +654,7 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
       };
 
       if (currentProfile?.dispatcher?.canUseRelay) {
-        if (isBonsaiEnabled && useDataAvailability) {
+        if (useDataAvailability) {
           return await createViaDataAvailablityDispatcher(dataAvailablityRequest);
         } else {
           return await createViaDispatcher(request);

--- a/apps/web/src/components/Publication/Actions/Mirror.tsx
+++ b/apps/web/src/components/Publication/Actions/Mirror.tsx
@@ -1,4 +1,3 @@
-import { useFeature } from '@growthbook/growthbook-react';
 import { SwitchHorizontalIcon } from '@heroicons/react/outline';
 import { Mixpanel } from '@lib/mixpanel';
 import onError from '@lib/onError';
@@ -6,7 +5,6 @@ import splitSignature from '@lib/splitSignature';
 import { t } from '@lingui/macro';
 import { LensHub } from 'abis';
 import clsx from 'clsx';
-import { FeatureFlag } from 'data';
 import { LENSHUB_PROXY } from 'data/constants';
 import Errors from 'data/errors';
 import { motion } from 'framer-motion';
@@ -47,7 +45,6 @@ const Mirror: FC<MirrorProps> = ({ publication, showCount }) => {
     // @ts-ignore
     isMirror ? publication?.mirrorOf?.mirrors?.length > 0 : publication?.mirrors?.length > 0
   );
-  const { on: isBonsaiEnabled } = useFeature(FeatureFlag.Bonsai as string);
 
   const { isLoading: signLoading, signTypedDataAsync } = useSignTypedData({ onError });
 
@@ -178,7 +175,7 @@ const Mirror: FC<MirrorProps> = ({ publication, showCount }) => {
       };
 
       if (currentProfile?.dispatcher?.canUseRelay) {
-        if (isBonsaiEnabled && publication.isDataAvailability) {
+        if (publication.isDataAvailability) {
           await createViaDataAvailablityDispatcher(dataAvailablityRequest);
         } else {
           await createViaDispatcher(request);

--- a/packages/data/feature-flags.ts
+++ b/packages/data/feature-flags.ts
@@ -3,6 +3,5 @@ export enum FeatureFlag {
   NftGallery = 'nft-gallery',
   NftDetail = 'nft-detail',
   GatedLocales = 'gated-locales',
-  ExportData = 'export-data',
-  Bonsai = 'bonsai'
+  ExportData = 'export-data'
 }


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6dafcbb</samp>

Removed Bonsai integration feature flag and related logic from the web app. Simplified the code for creating and mirroring publications using data availability.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6dafcbb</samp>

*  Remove `Bonsai` feature flag and related logic from `NewPublication` and `Mirror` components
  - Delete import of `useFeature` hook from `@growthbook/growthbook-react` library ([link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L5), [link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fL1))
  - Delete import of `FeatureFlag` enum from `data` module ([link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L29), [link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fL9))
  - Delete call to `useFeature` hook with `FeatureFlag.Bonsai` argument and `isBonsaiEnabled` variable ([link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L157-L158), [link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fL50))
  - Delete condition `isBonsaiEnabled` from `if` statements and always call `createViaDataAvailablityDispatcher` function when data availability is true ([link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L661-R657), [link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fL181-R178))
* Remove `Bonsai` value from `FeatureFlag` enum in `feature-flags.ts` file ([link](https://github.com/lensterxyz/lenster/pull/2708/files?diff=unified&w=0#diff-e06e181e3ef331e886fe8bfb4b664826e1a3ae2d1f22097dd7273c0e917c566eL6-R6))

## Emoji

<!--
copilot:emoji
-->

🗑️🧹🚀

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, which is what happened to the `Bonsai` value and the unused feature flag and hook in the `NewPublication` component.
2.  🧹 - This emoji represents the cleaning or simplifying of something, which is what happened to the logic for creating a publication or a mirror publication via data availability.
3.  🚀 - This emoji represents the improvement or enhancement of something, which is what happened to the user experience and performance of the publication and mirror creation features.
-->
