### PR TITLE
feat: add sponsor check

### DIFF
--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -653,7 +653,7 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
         contentURI: `ar://${arweaveId}`
       };
 
-      if (currentProfile?.dispatcher?.canUseRelay) {
+      if (currentProfile?.dispatcher?.canUseRelay && currentProfile.dispatcher.sponsor) {
         if (useDataAvailability) {
           return await createViaDataAvailablityDispatcher(dataAvailablityRequest);
         } else {

--- a/apps/web/src/components/Publication/Actions/Mirror.tsx
+++ b/apps/web/src/components/Publication/Actions/Mirror.tsx
@@ -174,20 +174,20 @@ const Mirror: FC<MirrorProps> = ({ publication, showCount }) => {
         mirror: publication?.id
       };
 
-      if (currentProfile?.dispatcher?.canUseRelay) {
+      if (currentProfile?.dispatcher?.canUseRelay && currentProfile.dispatcher.sponsor) {
         if (publication.isDataAvailability) {
-          await createViaDataAvailablityDispatcher(dataAvailablityRequest);
+          return await createViaDataAvailablityDispatcher(dataAvailablityRequest);
         } else {
-          await createViaDispatcher(request);
+          return await createViaDispatcher(request);
         }
-      } else {
-        await createMirrorTypedData({
-          variables: {
-            options: { overrideSigNonce: userSigNonce },
-            request
-          }
-        });
       }
+
+      return await createMirrorTypedData({
+        variables: {
+          options: { overrideSigNonce: userSigNonce },
+          request
+        }
+      });
     } catch {}
   };
 

--- a/apps/web/src/components/Settings/Profile/NftPicture.tsx
+++ b/apps/web/src/components/Settings/Profile/NftPicture.tsx
@@ -153,7 +153,7 @@ const NftPicture: FC<NftPictureProps> = ({ profile }) => {
         }
       };
 
-      if (currentProfile?.dispatcher?.canUseRelay) {
+      if (currentProfile?.dispatcher?.canUseRelay && currentProfile.dispatcher.sponsor) {
         return await createViaDispatcher(request);
       }
 

--- a/apps/web/src/components/Settings/Profile/Picture.tsx
+++ b/apps/web/src/components/Settings/Profile/Picture.tsx
@@ -131,7 +131,7 @@ const Picture: FC<PictureProps> = ({ profile }) => {
         url: ipfsUrl
       };
 
-      if (currentProfile?.dispatcher?.canUseRelay) {
+      if (currentProfile?.dispatcher?.canUseRelay && currentProfile.dispatcher.sponsor) {
         await createViaDispatcher(request);
       } else {
         await createSetProfileImageURITypedData({

--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -203,7 +203,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
         metadata: `https://arweave.net/${id}`
       };
 
-      if (currentProfile?.dispatcher?.canUseRelay) {
+      if (currentProfile?.dispatcher?.canUseRelay && currentProfile.dispatcher.sponsor) {
         return await createViaDispatcher(request);
       }
 

--- a/apps/web/src/components/Shared/Status.tsx
+++ b/apps/web/src/components/Shared/Status.tsx
@@ -167,7 +167,7 @@ const Status: FC = () => {
         metadata: `ar://${id}`
       };
 
-      if (currentProfile?.dispatcher?.canUseRelay) {
+      if (currentProfile?.dispatcher?.canUseRelay && currentProfile.dispatcher.sponsor) {
         return await createViaDispatcher(request);
       }
 

--- a/apps/web/src/components/StaffTools/Panels/Profile.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Profile.tsx
@@ -72,6 +72,13 @@ const ProfileStaffTool: FC<ProfileStaffToolProps> = ({ profile }) => {
         >
           {profile?.dispatcher?.canUseRelay ? 'Yes' : 'No'}
         </MetaDetails>
+        <MetaDetails
+          icon={<HandIcon className="lt-text-gray-500 h-4 w-4" />}
+          value={profile?.dispatcher?.sponsor ? 'Yes' : 'No'}
+          title={t`Gas sponsored`}
+        >
+          {profile?.dispatcher?.sponsor ? 'Yes' : 'No'}
+        </MetaDetails>
         {profile?.followNftAddress ? (
           <MetaDetails
             icon={<PhotographIcon className="lt-text-gray-500 h-4 w-4" />}


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 689b628</samp>

This pull request adds a condition to check for gas sponsorship before performing various actions that require data availability dispatcher. This is to avoid creating publications or updating profile data without paying gas fees. It also adds a new meta detail to the profile staff tool panel to show the sponsorship status. The affected files are `NewPublication.tsx`, `Mirror.tsx`, `NftPicture.tsx`, `Picture.tsx`, `Profile.tsx`, `Status.tsx`, and `Profile.tsx`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 689b628</samp>

*  Add a condition to check for gas sponsor before creating or updating publications, pictures, profile settings, and status ([link](https://github.com/lensterxyz/lenster/pull/2721/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L656-R656), [link](https://github.com/lensterxyz/lenster/pull/2721/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fL177-R190), [link](https://github.com/lensterxyz/lenster/pull/2721/files?diff=unified&w=0#diff-cf0a97986c4205646f837237d73d253f968c2212d1745a1bf33b795784a7db1cL156-R156), [link](https://github.com/lensterxyz/lenster/pull/2721/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L134-R134), [link](https://github.com/lensterxyz/lenster/pull/2721/files?diff=unified&w=0#diff-cc605dc6510d575486ca4cc4d51a003ca10dfeb338fced8f413d3c60d1543c90L206-R206), [link](https://github.com/lensterxyz/lenster/pull/2721/files?diff=unified&w=0#diff-ea16fcefe5daf9bfbf6d18ab7dde87b5140ecfeb5999e72401c4c411322a4fb0L170-R170))
* Add a meta detail to show the gas sponsor status of a profile in the staff tool panel ([link](https://github.com/lensterxyz/lenster/pull/2721/files?diff=unified&w=0#diff-b2948fe8062e3a622bd5d197fb8cb0a7cc683193abb1b417d2db82ee470e0871R75-R81))

## Emoji

<!--
copilot:emoji
-->

🚫🛠️ℹ️

<!--
1.  🚫 - This emoji represents the condition that prevents users from creating or updating their profile data without a sponsor. It conveys the idea of blocking or denying an action that is not allowed.
2.  🛠️ - This emoji represents the changes that make the mirror action consistent and handle the result in the caller function. It conveys the idea of fixing or improving something that was not working as expected.
3.  ℹ️ - This emoji represents the new meta detail that shows the sponsor status of the profile. It conveys the idea of providing more information or insight about something.
-->
