### PR TITLE
feat: add poll length settings modal

### DIFF
--- a/apps/web/src/components/Composer/Actions/PollSettings/PollEditor.tsx
+++ b/apps/web/src/components/Composer/Actions/PollSettings/PollEditor.tsx
@@ -1,12 +1,17 @@
-import { MenuAlt2Icon } from '@heroicons/react/outline';
+import { ClockIcon, MenuAlt2Icon } from '@heroicons/react/outline';
 import { XCircleIcon } from '@heroicons/react/solid';
-import { t } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
+import { useState } from 'react';
 import { usePublicationStore } from 'src/store/publication';
-import { Card, Tooltip } from 'ui';
+import { Button, Card, Input, Modal, Tooltip } from 'ui';
 
 const PollEditor: FC = () => {
   const setShowPollEditor = usePublicationStore((state) => state.setShowPollEditor);
+  const pollConfig = usePublicationStore((state) => state.pollConfig);
+  const setPollConfig = usePublicationStore((state) => state.setPollConfig);
+
+  const [showPollLengthModal, setShowPollLengthModal] = useState(false);
 
   return (
     <Card className="m-5 px-5 py-3">
@@ -15,7 +20,57 @@ const PollEditor: FC = () => {
           <MenuAlt2Icon className="text-brand h-4 w-4" />
           <b>Poll</b>
         </div>
-        <div>
+        <div className="flex items-center space-x-3">
+          <Button
+            variant="primary"
+            size="sm"
+            icon={<ClockIcon className="h-4 w-4" />}
+            onClick={() => setShowPollLengthModal(true)}
+            outline
+          >
+            {pollConfig.pollLength} days
+          </Button>
+          <Modal
+            title={t`Poll length`}
+            icon={<ClockIcon className="text-brand h-5 w-5" />}
+            show={showPollLengthModal}
+            onClose={() => setShowPollLengthModal(false)}
+          >
+            <div className="p-5">
+              <Input
+                label={t`Poll length (days)`}
+                type="number"
+                value={pollConfig.pollLength}
+                min={1}
+                max={30}
+                onChange={(e) =>
+                  setPollConfig({
+                    ...pollConfig,
+                    pollLength: Number(e.target.value)
+                  })
+                }
+              />
+              <div className="flex space-x-2 pt-5">
+                <Button
+                  className="ml-auto"
+                  variant="danger"
+                  onClick={() => {
+                    setPollConfig({
+                      ...pollConfig,
+                      pollLength: 7
+                    });
+                    setShowPollLengthModal(false);
+                  }}
+                  outline
+                >
+                  <Trans>Cancel</Trans>
+                </Button>
+                <Button className="ml-auto" variant="primary" onClick={() => setShowPollLengthModal(false)}>
+                  <Trans>Save</Trans>
+                </Button>
+              </div>
+            </div>
+          </Modal>
           <Tooltip placement="top" content={t`Delete`}>
             <button className="flex" onClick={() => setShowPollEditor(false)}>
               <XCircleIcon className="h-5 w-5 text-red-400" />

--- a/apps/web/src/store/publication.ts
+++ b/apps/web/src/store/publication.ts
@@ -30,6 +30,11 @@ interface PublicationState {
   setIsUploading: (isUploading: boolean) => void;
   showPollEditor: boolean;
   setShowPollEditor: (showPollEditor: boolean) => void;
+  pollConfig: {
+    pollLength: number;
+    pollOptions: string[];
+  };
+  setPollConfig: (pollConfig: { pollLength: number; pollOptions: string[] }) => void;
 }
 
 export const usePublicationStore = create<PublicationState>((set) => ({
@@ -74,5 +79,7 @@ export const usePublicationStore = create<PublicationState>((set) => ({
   isUploading: false,
   setIsUploading: (isUploading) => set(() => ({ isUploading })),
   showPollEditor: false,
-  setShowPollEditor: (showPollEditor) => set(() => ({ showPollEditor }))
+  setShowPollEditor: (showPollEditor) => set(() => ({ showPollEditor })),
+  pollConfig: { pollLength: 0, pollOptions: [] },
+  setPollConfig: (pollConfig) => set(() => ({ pollConfig }))
 }));


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 88d1453</samp>

Added a feature to let users set the poll length for their publications. Modified the `PollEditor` component and the `publication` store to handle the poll configuration. Updated the `PollEditor.tsx` and `publication.ts` files.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 88d1453</samp>

*  Add a button and a modal for setting the poll length in days in the PollEditor component ([link](https://github.com/lensterxyz/lenster/pull/2747/files?diff=unified&w=0#diff-a98bb8d5bdf06f11b9097470283fb87b29fca1487aec39aa8e7ebf9e9f2a99b5L1-R15), [link](https://github.com/lensterxyz/lenster/pull/2747/files?diff=unified&w=0#diff-a98bb8d5bdf06f11b9097470283fb87b29fca1487aec39aa8e7ebf9e9f2a99b5L18-R73))
* Extend the PublicationState interface and the usePublicationStore hook to include the pollConfig and setPollConfig properties ([link](https://github.com/lensterxyz/lenster/pull/2747/files?diff=unified&w=0#diff-2228f51b676a318c177b066c630f682bc919f57f199e86f9ccbdcd31c561c680R33-R37), [link](https://github.com/lensterxyz/lenster/pull/2747/files?diff=unified&w=0#diff-2228f51b676a318c177b066c630f682bc919f57f199e86f9ccbdcd31c561c680L77-R84))

## Emoji

<!--
copilot:emoji
-->

🗳️🕒🌐

<!--
1.  🗳️ - This emoji represents polls or voting, and can be used to indicate the main feature of allowing users to set the poll length in days.
2.  🕒 - This emoji represents time or clocks, and can be used to indicate the secondary feature of using a modal with an input and an icon to let users choose the poll duration.
3.  🌐 - This emoji represents the globe or internationalization, and can be used to indicate the tertiary feature of using translation components to support multiple languages for the poll feature.
-->
