### PR TITLE
feat: add poll renderer for lenster poll

### DIFF
--- a/apps/web/src/components/Composer/Actions/PollSettings/PollEditor.tsx
+++ b/apps/web/src/components/Composer/Actions/PollSettings/PollEditor.tsx
@@ -1,10 +1,5 @@
-import {
-  ClockIcon,
-  MenuAlt2Icon,
-  PlusIcon,
-  XIcon
-} from '@heroicons/react/outline';
-import { XCircleIcon } from '@heroicons/react/solid';
+import { ClockIcon, PlusIcon, XIcon } from '@heroicons/react/outline';
+import { MenuAlt2Icon, XCircleIcon } from '@heroicons/react/solid';
 import { t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';

--- a/apps/web/src/components/Composer/Actions/PollSettings/index.tsx
+++ b/apps/web/src/components/Composer/Actions/PollSettings/index.tsx
@@ -1,5 +1,5 @@
 import { useFeature } from '@growthbook/growthbook-react';
-import { MenuAlt2Icon } from '@heroicons/react/outline';
+import { MenuAlt2Icon } from '@heroicons/react/solid';
 import { t } from '@lingui/macro';
 import { FeatureFlag } from 'data';
 import { motion } from 'framer-motion';

--- a/apps/web/src/components/Shared/Snapshot/index.tsx
+++ b/apps/web/src/components/Shared/Snapshot/index.tsx
@@ -1,3 +1,4 @@
+import { LENSTER_POLLS_SPACE } from 'data';
 import { stopEventPropagation } from 'lib/stopEventPropagation';
 import type { FC, ReactNode } from 'react';
 import { useState } from 'react';
@@ -65,6 +66,18 @@ const Snapshot: FC<SnapshotProps> = ({ propsalId }) => {
   }
 
   const { proposal, votes } = data;
+  const isLensterPoll = proposal?.space?.id === LENSTER_POLLS_SPACE;
+
+  if (isLensterPoll) {
+    return (
+      <Choices
+        proposal={proposal as Proposal}
+        votes={votes as Vote[]}
+        isLensterPoll={isLensterPoll}
+        refetch={refetch}
+      />
+    );
+  }
 
   return (
     <Wrapper dataTestId={`snapshot-${proposal.id}`}>

--- a/apps/web/src/components/utils/hooks/useCreatePoll.tsx
+++ b/apps/web/src/components/utils/hooks/useCreatePoll.tsx
@@ -1,5 +1,5 @@
 import { snapshotClient } from '@lib/snapshotClient';
-import { APP_NAME } from 'data';
+import { APP_NAME, LENSTER_POLLS_SPACE } from 'data';
 import { useAppStore } from 'src/store/app';
 import { usePublicationStore } from 'src/store/publication';
 import { useBlockNumber, useSigner } from 'wagmi';
@@ -21,7 +21,7 @@ const useCreatePoll = (): [createPoll: () => Promise<CreatePollResponse>] => {
         signer as any,
         currentProfile?.ownedBy,
         {
-          space: 'polls.lenster.xyz',
+          space: LENSTER_POLLS_SPACE,
           type: 'single-choice',
           title: `Poll by @${currentProfile?.handle}`,
           body: publicationContent,
@@ -36,7 +36,7 @@ const useCreatePoll = (): [createPoll: () => Promise<CreatePollResponse>] => {
         }
       );
 
-      return `${publicationContent}\n\nhttps://snapshot.org/#/polls.lenster.xyz/proposal/${receipt.id}`;
+      return `${publicationContent}\n\nhttps://snapshot.org/#/${LENSTER_POLLS_SPACE}/proposal/${receipt.id}`;
     } catch (error) {
       throw error;
     }

--- a/apps/web/src/lib/formatTime.ts
+++ b/apps/web/src/lib/formatTime.ts
@@ -61,6 +61,16 @@ export const getTimeFromNow = (date: Date) => {
 };
 
 /**
+ * Formats a date as a string representing the elapsed time between the date and the current time.
+ *
+ * @param date The date to format.
+ * @returns A string representing the elapsed time between the date and the current time.
+ */
+export const getTimetoNow = (date: Date) => {
+  return dayjs(date).toNow(true);
+};
+
+/**
  * Formats a date as a string in the format used by Twitter.
  *
  * @param date The date to format.

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -21,6 +21,9 @@ export const IS_MAINNET = API_URL === LensEndpoint.Mainnet;
 export const XMTP_ENV = IS_MAINNET ? 'production' : 'dev';
 export const XMTP_PREFIX = 'lens.dev/dm';
 
+// Snapshot
+export const LENSTER_POLLS_SPACE = 'polls.lenster.xyz';
+
 // Application
 export const APP_NAME = 'Lenster';
 export const DESCRIPTION =

--- a/packages/snapshot/documents/queries/Snapshot.graphql
+++ b/packages/snapshot/documents/queries/Snapshot.graphql
@@ -11,6 +11,7 @@ query Snapshot($id: String, $where: VoteWhere) {
     symbol
     network
     type
+    end
     space {
       id
       name

--- a/packages/snapshot/generated.ts
+++ b/packages/snapshot/generated.ts
@@ -529,6 +529,7 @@ export type SnapshotQuery = {
     symbol: string;
     network: string;
     type?: string | null;
+    end: number;
     space?: { __typename?: 'Space'; id: string; name?: string | null } | null;
     strategies: Array<{
       __typename?: 'Strategy';
@@ -554,6 +555,7 @@ export const SnapshotDocument = gql`
       symbol
       network
       type
+      end
       space {
         id
         name


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a38d442</samp>

This pull request adds support for rendering Lenster polls in the composer and the snapshot components. Lenster polls are a special type of polls that have different UI elements and information. The pull request introduces a new constant, `LENSTER_POLLS_SPACE`, to identify the Lenster polls space, and a new field, `end`, to query the poll end date. It also refactors some components and hooks, and adds a new function, `getTimetoNow`, to format the poll duration.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a38d442</samp>

*  Replaced the outline icon with the solid icon for the poll editor component ([link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-60e3f5b80c2b77b36d4b19d49d0b67eadc64f7c8727c3f1c770435830bc956d0L2-R2))
*  Reordered the icon imports by their variants in `PollEditor.tsx` ([link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-a98bb8d5bdf06f11b9097470283fb87b29fca1487aec39aa8e7ebf9e9f2a99b5L1-R2))
*  Added the `end` field to the `Snapshot` query and the generated types and values in the `snapshot` package ([link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-173ed4866ea93c0a39d5a81dbabe15e7688af5e2b4d4078cccc3677e1e2a1258R14), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-5621065a29dec1dcda1b13a09c157b9f954146ceaee71708bde7c2ae426dfb70R532), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-5621065a29dec1dcda1b13a09c157b9f954146ceaee71708bde7c2ae426dfb70R558))
*  Added the `LENSTER_POLLS_SPACE` constant to the `data` package and used it to set and check the space for the poll creation and rendering ([link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-6ec8aa7fb4c2ed1478249a38aabfb5f5b619d73fbe771513d05679e976037348R24-R26), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-733d08f69afce849b4eaea085b1a2aa7468cb8341666fcea65a73fff55b412e6L24-R24), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-733d08f69afce849b4eaea085b1a2aa7468cb8341666fcea65a73fff55b412e6L39-R39), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-5e2a85bbef6fd078bf1bb439c196013da324ca8be3b2efbbcdf45efd050602f3R1), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-5e2a85bbef6fd078bf1bb439c196013da324ca8be3b2efbbcdf45efd050602f3L68-R81))
*  Added the `isLensterPoll` prop to the `ChoicesProps` interface and the `Choices` component in `PollEditor.tsx` and used it to conditionally render some UI elements ([link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3L25-R33), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3L76-R92), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3L105-R112), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3R131-R149), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-5e2a85bbef6fd078bf1bb439c196013da324ca8be3b2efbbcdf45efd050602f3L68-R81))
*  Added the `getTimetoNow` function to `formatTime.ts` and used it to format the poll duration in the `Choices` component ([link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-c71e5b7b6caba3401666f3701b9e2057a397c41e7845de7ecf3f707a7bbe3009R64-R73), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3L35-R40), [link](https://github.com/lensterxyz/lenster/pull/2762/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3R131-R149))

## Emoji

<!--
copilot:emoji
-->

🎨🕒🚀

<!--
1.  🎨 - This emoji represents the change in the `MenuAlt2Icon` import and the reordering of the import statements, as they are related to improving the appearance and style of the code and the UI.
2.  🕒 - This emoji represents the addition of the `getTimetoNow` function and the `end` field in the `Snapshot` query, as they are related to displaying and formatting time-related data in the UI and the API.
3.  🚀 - This emoji represents the update of the `Choices` component, the conditional rendering logic in the `Snapshot` component, and the refactoring of the `useCreatePoll` hook, as they are related to adding new features and functionality to the poll editor and the composer.
-->
