### PR TITLE
feat: dexie powered message db (#2711)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,8 @@
     "data": "workspace:*",
     "dayjs": "^1.11.5",
     "dayjs-twitter": "^0.5.0",
+    "dexie": "^3.2.3",
+    "dexie-react-hooks": "^1.1.3",
     "dotenv": "^16.0.3",
     "ethers": "5.6.0",
     "framer-motion": "^10.12.4",

--- a/apps/web/src/components/Messages/Message.tsx
+++ b/apps/web/src/components/Messages/Message.tsx
@@ -3,6 +3,7 @@ import MessageHeader from '@components/Messages/MessageHeader';
 import Loader from '@components/Shared/Loader';
 import useGetConversation from '@components/utils/hooks/useGetConversation';
 import useGetMessages from '@components/utils/hooks/useGetMessages';
+import { useGetProfile } from '@components/utils/hooks/useMessageDb';
 import useSendMessage from '@components/utils/hooks/useSendMessage';
 import useStreamMessages from '@components/utils/hooks/useStreamMessages';
 import { parseConversationKey } from '@lib/conversationKey';
@@ -16,7 +17,6 @@ import type { FC } from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import Custom404 from 'src/pages/404';
 import { useAppStore } from 'src/store/app';
-import { useMessageStore } from 'src/store/message';
 import { PAGEVIEW } from 'src/tracking';
 import { Card, GridItemEight, GridLayout } from 'ui';
 
@@ -30,9 +30,7 @@ interface MessageProps {
 
 const Message: FC<MessageProps> = ({ conversationKey }) => {
   const currentProfile = useAppStore((state) => state.currentProfile);
-  const profile = useMessageStore((state) =>
-    state.messageProfiles.get(conversationKey)
-  );
+  const { profile } = useGetProfile(currentProfile?.id, conversationKey);
   const { selectedConversation, missingXmtpAuth } = useGetConversation(
     conversationKey,
     profile

--- a/apps/web/src/components/Messages/MessageHeader.tsx
+++ b/apps/web/src/components/Messages/MessageHeader.tsx
@@ -4,7 +4,8 @@ import { ChevronLeftIcon } from '@heroicons/react/outline';
 import type { Profile } from 'lens';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useMessageStore } from 'src/store/message';
 import { FollowSource } from 'src/tracking';
 
 import Follow from '../Shared/Follow';
@@ -16,6 +17,15 @@ interface MessageHeaderProps {
 const MessageHeader: FC<MessageHeaderProps> = ({ profile }) => {
   const router = useRouter();
   const [following, setFollowing] = useState(true);
+  const unsyncProfile = useMessageStore((state) => state.unsyncProfile);
+
+  const setFollowingWrapped = useCallback(
+    (following: boolean) => {
+      setFollowing(following);
+      unsyncProfile(profile?.id ?? '');
+    },
+    [setFollowing, unsyncProfile, profile?.id]
+  );
 
   const onBackClick = () => {
     router.push('/messages');
@@ -23,7 +33,7 @@ const MessageHeader: FC<MessageHeaderProps> = ({ profile }) => {
 
   useEffect(() => {
     setFollowing(profile?.isFollowedByMe ?? false);
-  }, [profile?.isFollowedByMe, profile]);
+  }, [profile?.isFollowedByMe]);
 
   if (!profile) {
     return null;
@@ -42,11 +52,11 @@ const MessageHeader: FC<MessageHeaderProps> = ({ profile }) => {
         <Follow
           showText
           profile={profile}
-          setFollowing={setFollowing}
+          setFollowing={setFollowingWrapped}
           followSource={FollowSource.DIRECT_MESSAGE_HEADER}
         />
       ) : (
-        <Unfollow showText profile={profile} setFollowing={setFollowing} />
+        <Unfollow showText profile={profile} setFollowing={setFollowingWrapped} />
       )}
     </div>
   );

--- a/apps/web/src/components/Messages/MessageHeader.tsx
+++ b/apps/web/src/components/Messages/MessageHeader.tsx
@@ -56,7 +56,11 @@ const MessageHeader: FC<MessageHeaderProps> = ({ profile }) => {
           followSource={FollowSource.DIRECT_MESSAGE_HEADER}
         />
       ) : (
-        <Unfollow showText profile={profile} setFollowing={setFollowingWrapped} />
+        <Unfollow
+          showText
+          profile={profile}
+          setFollowing={setFollowingWrapped}
+        />
       )}
     </div>
   );

--- a/apps/web/src/components/Profile/Details.tsx
+++ b/apps/web/src/components/Profile/Details.tsx
@@ -5,6 +5,7 @@ import Slug from '@components/Shared/Slug';
 import SuperFollow from '@components/Shared/SuperFollow';
 import Unfollow from '@components/Shared/Unfollow';
 import ProfileStaffTool from '@components/StaffTools/Panels/Profile';
+import { useMessageDb } from '@components/utils/hooks/useMessageDb';
 import useStaffMode from '@components/utils/hooks/useStaffMode';
 import {
   CogIcon,
@@ -31,6 +32,7 @@ import { useTheme } from 'next-themes';
 import type { Dispatch, FC, ReactNode } from 'react';
 import { useState } from 'react';
 import { useAppStore } from 'src/store/app';
+import type { TabValues } from 'src/store/message';
 import { useMessageStore } from 'src/store/message';
 import { FollowSource } from 'src/tracking';
 import { Button, Image, Modal, Tooltip } from 'ui';
@@ -53,9 +55,9 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
   const { allowed: staffMode } = useStaffMode();
   const { resolvedTheme } = useTheme();
   const router = useRouter();
-  const addProfileAndSelectTab = useMessageStore(
-    (state) => state.addProfileAndSelectTab
-  );
+
+  const { persistProfile } = useMessageDb();
+  const setSelectedTab = useMessageStore((state) => state.setSelectedTab);
 
   const onMessageClick = () => {
     if (!currentProfile) {
@@ -66,7 +68,11 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
       profile.ownedBy,
       conversationId
     );
-    addProfileAndSelectTab(conversationKey, profile);
+    persistProfile(conversationKey, profile);
+    const selectedTab: TabValues = profile.isFollowedByMe
+      ? 'Following'
+      : 'Requested';
+    setSelectedTab(selectedTab);
     router.push(`/messages/${conversationKey}`);
   };
 

--- a/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
+++ b/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
@@ -7,6 +7,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useMessageStore } from 'src/store/message';
 
 import { useMessageDb } from './useMessageDb';
+import { useAppStore } from 'src/store/app';
 
 const fetchMostRecentMessage = async (
   convo: Conversation,
@@ -28,6 +29,7 @@ const useGetMessagePreviews = () => {
   const conversations = useMessageStore((state) => state.conversations);
   const previewMessages = useMessageStore((state) => state.previewMessages);
   const client = useMessageStore((state) => state.client);
+  const currentProfile = useAppStore((state) => state.currentProfile);
   const { batchPersistPreviewMessages } = useMessageDb();
   const hasSyncedMessages = useMessageStore((state) => state.hasSyncedMessages);
   const setHasSyncedMessages = useMessageStore(
@@ -82,7 +84,6 @@ const useGetMessagePreviews = () => {
         ).filter((m) => !!m) as [string, DecodedMessage][];
         await batchPersistPreviewMessages(new Map(batch));
       }
-
       setLoading(false);
       setHasSyncedMessages(true);
       loadingRef.current = false;
@@ -90,7 +91,11 @@ const useGetMessagePreviews = () => {
 
     getMessagePreviews();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, conversations]);
+  }, [client, conversations, currentProfile?.id]);
+
+  useEffect(() => {
+    setHasSyncedMessages(false);
+  }, currentProfile?.id);
 
   return {
     loading,

--- a/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
+++ b/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
@@ -6,81 +6,91 @@ import type { DecodedMessage } from '@xmtp/xmtp-js/dist/types/src/Message';
 import { useEffect, useRef, useState } from 'react';
 import { useMessageStore } from 'src/store/message';
 
+import { useMessageDb } from './useMessageDb';
+
 const fetchMostRecentMessage = async (
-  convo: Conversation
-): Promise<{ key: string; message?: DecodedMessage }> => {
-  const key = buildConversationKey(
-    convo.peerAddress,
-    convo.context?.conversationId as string
-  );
+  convo: Conversation,
+  checkAfter?: Date
+): Promise<DecodedMessage | null> => {
   const latestMessageQuery = await convo.messages({
     limit: 1,
-    direction: SortDirection.SORT_DIRECTION_DESCENDING
+    direction: SortDirection.SORT_DIRECTION_DESCENDING,
+    // Add 1ms to the start time to avoid getting the same message back
+    startTime: checkAfter ? new Date(checkAfter.getTime() + 1) : undefined
   });
   if (latestMessageQuery.length <= 0) {
-    return { key };
+    return null;
   }
-  return { key, message: latestMessageQuery[0] };
+  return latestMessageQuery[0];
 };
 
 const useGetMessagePreviews = () => {
   const conversations = useMessageStore((state) => state.conversations);
   const previewMessages = useMessageStore((state) => state.previewMessages);
-  const setPreviewMessage = useMessageStore((state) => state.setPreviewMessage);
   const client = useMessageStore((state) => state.client);
+  const { batchPersistPreviewMessages } = useMessageDb();
+  const hasSyncedMessages = useMessageStore((state) => state.hasSyncedMessages);
+  const setHasSyncedMessages = useMessageStore(
+    (state) => state.setHasSyncedMessages
+  );
   const [loading, setLoading] = useState<boolean>(false);
   const loadingRef = useRef<boolean>(false);
   const countRef = useRef<number>(0);
   const [progress, setProgress] = useState<number>(0);
 
   useEffect(() => {
-    if (!client || loadingRef.current) {
+    if (!client || loadingRef.current || hasSyncedMessages) {
       return;
     }
 
     const getMessagePreviews = async () => {
+      const needsSync = [...conversations.values()];
+      if (!needsSync.length) {
+        return;
+      }
       loadingRef.current = true;
       setLoading(true);
-
-      // Diff the conversations and preview messages to see which ones are missing
-      const needsSync = Array.from(conversations.values()).filter(
-        (convo) =>
-          previewMessages.get(
-            buildConversationKey(
-              convo.peerAddress,
-              convo.context?.conversationId as string
-            )
-          ) === undefined
-      );
 
       for (const chunk of chunkArray(needsSync, 50)) {
         // Yield to the UI between pages of conversations, since this all happens in the background
         await new Promise((resolve) => requestAnimationFrame(resolve));
-        await Promise.all(
-          chunk.map(async (convo) => {
-            const latestMessage = await fetchMostRecentMessage(convo);
-            const existingValue = previewMessages.get(latestMessage.key)?.sent;
-            if (
-              latestMessage.message &&
-              (!existingValue || latestMessage?.message.sent > existingValue)
-            ) {
-              setPreviewMessage(latestMessage.key, latestMessage.message);
-            }
-            countRef.current = countRef.current + 1;
-            setProgress(
-              Math.round((countRef.current / needsSync.length) * 100)
-            );
-          })
-        );
+        const batch = (
+          await Promise.all(
+            chunk.map(async (convo) => {
+              const key = buildConversationKey(
+                convo.peerAddress,
+                convo.context?.conversationId as string
+              );
+              const existingValue = previewMessages.get(key)?.sent;
+              const latestMessage = await fetchMostRecentMessage(
+                convo,
+                existingValue
+              );
+              countRef.current = countRef.current + 1;
+              setProgress(
+                Math.round((countRef.current / needsSync.length) * 100)
+              );
+
+              if (
+                latestMessage &&
+                (!existingValue || latestMessage.sent > existingValue)
+              ) {
+                return [key, latestMessage];
+              }
+            })
+          )
+        ).filter((m) => !!m) as [string, DecodedMessage][];
+        await batchPersistPreviewMessages(new Map(batch));
       }
 
       setLoading(false);
+      setHasSyncedMessages(true);
       loadingRef.current = false;
     };
 
     getMessagePreviews();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, conversations, previewMessages]);
+  }, [client, conversations]);
 
   return {
     loading,

--- a/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
+++ b/apps/web/src/components/utils/hooks/useGetMessagePreviews.tsx
@@ -4,10 +4,10 @@ import type { Conversation } from '@xmtp/xmtp-js';
 import { SortDirection } from '@xmtp/xmtp-js';
 import type { DecodedMessage } from '@xmtp/xmtp-js/dist/types/src/Message';
 import { useEffect, useRef, useState } from 'react';
+import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 
 import { useMessageDb } from './useMessageDb';
-import { useAppStore } from 'src/store/app';
 
 const fetchMostRecentMessage = async (
   convo: Conversation,

--- a/apps/web/src/components/utils/hooks/useMessageDb.tsx
+++ b/apps/web/src/components/utils/hooks/useMessageDb.tsx
@@ -1,0 +1,115 @@
+import type { DecodedMessage } from '@xmtp/xmtp-js';
+import { useLiveQuery } from 'dexie-react-hooks';
+import type { Profile } from 'lens';
+import { useCallback } from 'react';
+import { useAppStore } from 'src/store/app';
+import type { LensProfile, PreviewMessage } from 'src/store/message-db';
+import { db } from 'src/store/message-db';
+
+const decodedMessageToPreview = (
+  conversationKey: string,
+  myProfileId: string,
+  decoded: DecodedMessage
+): PreviewMessage => ({
+  conversationKey,
+  myProfileId,
+  sent: decoded.sent,
+  messageBytes: decoded.toBytes()
+});
+
+const assertProfileId = (profileId: string | undefined) => {
+  if (!profileId) {
+    throw new Error('No profile id');
+  }
+};
+
+export const useMessageDb = () => {
+  const currentProfile = useAppStore((state) => state.currentProfile);
+
+  const batchPersistPreviewMessages = useCallback(
+    async (previewMap: Map<string, DecodedMessage>) => {
+      const myProfileId = currentProfile?.id;
+      assertProfileId(myProfileId);
+      await db.transaction('rw', db.previewMessages, async () => {
+        for (const [conversationKey, message] of previewMap.entries()) {
+          const record = decodedMessageToPreview(conversationKey, currentProfile?.id, message);
+          await db.persistPreviewMessage(record);
+        }
+      });
+    },
+    [currentProfile]
+  );
+
+  const persistPreviewMessage = useCallback(
+    async (conversationKey: string, message: DecodedMessage) => {
+      const myProfileId = currentProfile?.id;
+      assertProfileId(myProfileId);
+      const record = decodedMessageToPreview(conversationKey, myProfileId, message);
+      await db.persistPreviewMessage(record);
+    },
+    [currentProfile]
+  );
+
+  const batchPersistProfiles = useCallback(
+    async (profiles: Map<string, Partial<Profile>>) => {
+      const myProfileId = currentProfile?.id;
+      assertProfileId(myProfileId);
+      await db.transaction('rw', db.lensProfiles, async () => {
+        for (const [conversationKey, profile] of profiles.entries()) {
+          const record = { ...profile, myProfileId, conversationKey };
+          await db.persistProfile(record as LensProfile);
+        }
+      });
+    },
+    [currentProfile]
+  );
+
+  const persistProfile = useCallback(
+    async (conversationKey: string, profile: Profile) => {
+      const myProfileId = currentProfile?.id;
+      assertProfileId(myProfileId);
+      const record = { ...profile, myProfileId, conversationKey };
+      await db.persistProfile(record as LensProfile);
+    },
+    [currentProfile]
+  );
+
+  const previewMessages = useLiveQuery(async () => {
+    if (!currentProfile) {
+      return;
+    }
+    return db.previewMessages.where('myProfileId').equals(currentProfile.id).sortBy('sent');
+  }, [currentProfile]);
+
+  const messageProfiles = useLiveQuery(async () => {
+    if (!currentProfile) {
+      return;
+    }
+
+    const profiles = await db.lensProfiles.where('myProfileId').equals(currentProfile.id).sortBy('name');
+
+    return new Map(profiles.map((p) => [p.conversationKey, p]));
+  }, [currentProfile]);
+
+  return {
+    persistPreviewMessage,
+    batchPersistPreviewMessages,
+    batchPersistProfiles,
+    persistProfile,
+    previewMessages,
+    messageProfiles
+  };
+};
+
+export const useGetProfile = (myProfileId: string | undefined, conversationKey: string) => {
+  const profile = useLiveQuery(() => {
+    if (!myProfileId) {
+      return;
+    }
+    return db.lensProfiles.get([myProfileId, conversationKey]);
+  }, [myProfileId, conversationKey]);
+
+  return {
+    profile
+  };
+};

--- a/apps/web/src/components/utils/hooks/useMessageDb.tsx
+++ b/apps/web/src/components/utils/hooks/useMessageDb.tsx
@@ -32,7 +32,11 @@ export const useMessageDb = () => {
       assertProfileId(myProfileId);
       await db.transaction('rw', db.previewMessages, async () => {
         for (const [conversationKey, message] of previewMap.entries()) {
-          const record = decodedMessageToPreview(conversationKey, currentProfile?.id, message);
+          const record = decodedMessageToPreview(
+            conversationKey,
+            currentProfile?.id,
+            message
+          );
           await db.persistPreviewMessage(record);
         }
       });
@@ -44,7 +48,11 @@ export const useMessageDb = () => {
     async (conversationKey: string, message: DecodedMessage) => {
       const myProfileId = currentProfile?.id;
       assertProfileId(myProfileId);
-      const record = decodedMessageToPreview(conversationKey, myProfileId, message);
+      const record = decodedMessageToPreview(
+        conversationKey,
+        myProfileId,
+        message
+      );
       await db.persistPreviewMessage(record);
     },
     [currentProfile]
@@ -78,7 +86,10 @@ export const useMessageDb = () => {
     if (!currentProfile) {
       return;
     }
-    return db.previewMessages.where('myProfileId').equals(currentProfile.id).sortBy('sent');
+    return db.previewMessages
+      .where('myProfileId')
+      .equals(currentProfile.id)
+      .sortBy('sent');
   }, [currentProfile]);
 
   const messageProfiles = useLiveQuery(async () => {
@@ -86,7 +97,10 @@ export const useMessageDb = () => {
       return;
     }
 
-    const profiles = await db.lensProfiles.where('myProfileId').equals(currentProfile.id).sortBy('name');
+    const profiles = await db.lensProfiles
+      .where('myProfileId')
+      .equals(currentProfile.id)
+      .sortBy('name');
 
     return new Map(profiles.map((p) => [p.conversationKey, p]));
   }, [currentProfile]);
@@ -101,7 +115,10 @@ export const useMessageDb = () => {
   };
 };
 
-export const useGetProfile = (myProfileId: string | undefined, conversationKey: string) => {
+export const useGetProfile = (
+  myProfileId: string | undefined,
+  conversationKey: string
+) => {
   const profile = useLiveQuery(() => {
     if (!myProfileId) {
       return;

--- a/apps/web/src/store/message-db.ts
+++ b/apps/web/src/store/message-db.ts
@@ -30,7 +30,11 @@ export class MessageDB extends Dexie {
 
   async persistPreviewMessage(message: PreviewMessage) {
     const { conversationKey, myProfileId, sent } = message;
-    await this.previewMessages.put(message, [conversationKey, myProfileId, sent]);
+    await this.previewMessages.put(message, [
+      conversationKey,
+      myProfileId,
+      sent
+    ]);
   }
 
   async persistProfile(profile: LensProfile) {

--- a/apps/web/src/store/message-db.ts
+++ b/apps/web/src/store/message-db.ts
@@ -1,0 +1,42 @@
+import type { Table } from 'dexie';
+import Dexie from 'dexie';
+import type { Profile } from 'lens';
+
+export interface PreviewMessage {
+  conversationKey: string;
+  myProfileId: string;
+  sent: Date;
+  messageBytes: Uint8Array;
+}
+
+export type LensProfile = Profile & {
+  myProfileId: string;
+  conversationKey: string;
+};
+
+export class MessageDB extends Dexie {
+  // 'friends' is added by dexie when declaring the stores()
+  // We just tell the typing system this is the case
+  previewMessages!: Table<PreviewMessage>;
+  lensProfiles!: Table<LensProfile>;
+
+  constructor() {
+    super('messageDb');
+    this.version(1).stores({
+      previewMessages: 'conversationKey, myProfileId, sent', // Primary key and indexed props
+      lensProfiles: '[myProfileId+conversationKey], myProfileId'
+    });
+  }
+
+  async persistPreviewMessage(message: PreviewMessage) {
+    const { conversationKey, myProfileId, sent } = message;
+    await this.previewMessages.put(message, [conversationKey, myProfileId, sent]);
+  }
+
+  async persistProfile(profile: LensProfile) {
+    const { myProfileId, conversationKey } = profile;
+    await this.lensProfiles.put(profile, [myProfileId, conversationKey]);
+  }
+}
+
+export const db = new MessageDB();

--- a/apps/web/src/store/message.ts
+++ b/apps/web/src/store/message.ts
@@ -61,7 +61,6 @@ export const useMessageStore = create<MessageState>((set) => ({
     });
     return numAdded;
   },
-
   hasSyncedMessages: false,
   setHasSyncedMessages: (hasSyncedMessages) =>
     set(() => ({ hasSyncedMessages })),
@@ -73,11 +72,6 @@ export const useMessageStore = create<MessageState>((set) => ({
       return { previewMessages: newPreviewMessages };
     }),
   setPreviewMessages: (previewMessages) => set(() => ({ previewMessages })),
-  selectedProfileId: '',
-  setSelectedProfileId: (selectedProfileId) =>
-    set(() => ({ selectedProfileId })),
-  selectedTab: 'Following',
-  setSelectedTab: (selectedTab) => set(() => ({ selectedTab })),
   reset: () =>
     set((state) => {
       return {
@@ -89,6 +83,11 @@ export const useMessageStore = create<MessageState>((set) => ({
         selectedTab: 'Following'
       };
     }),
+  selectedProfileId: '',
+  setSelectedProfileId: (selectedProfileId) =>
+    set(() => ({ selectedProfileId })),
+  selectedTab: 'Following',
+  setSelectedTab: (selectedTab) => set(() => ({ selectedTab })),
   syncedProfiles: new Set(),
   addSyncedProfiles: (profileIds) =>
     set(({ syncedProfiles }) => ({

--- a/apps/web/src/store/message.ts
+++ b/apps/web/src/store/message.ts
@@ -21,7 +21,6 @@ interface MessageState {
   previewMessages: Map<string, DecodedMessage>;
   setPreviewMessage: (key: string, message: DecodedMessage) => void;
   setPreviewMessages: (previewMessages: Map<string, DecodedMessage>) => void;
-  reset: () => void;
   selectedProfileId: string;
   setSelectedProfileId: (selectedProfileId: string) => void;
   selectedTab: TabValues;
@@ -29,6 +28,7 @@ interface MessageState {
   syncedProfiles: Set<string>;
   addSyncedProfiles: (profileIds: string[]) => void;
   unsyncProfile: (profileId: string) => void;
+  reset: () => void;
 }
 
 export const useMessageStore = create<MessageState>((set) => ({
@@ -72,17 +72,6 @@ export const useMessageStore = create<MessageState>((set) => ({
       return { previewMessages: newPreviewMessages };
     }),
   setPreviewMessages: (previewMessages) => set(() => ({ previewMessages })),
-  reset: () =>
-    set((state) => {
-      return {
-        ...state,
-        conversations: new Map(),
-        messages: new Map(),
-        messageProfiles: new Map(),
-        previewMessages: new Map(),
-        selectedTab: 'Following'
-      };
-    }),
   selectedProfileId: '',
   setSelectedProfileId: (selectedProfileId) =>
     set(() => ({ selectedProfileId })),
@@ -98,7 +87,18 @@ export const useMessageStore = create<MessageState>((set) => ({
       syncedProfiles: new Set(
         [...syncedProfiles].filter((id) => id !== profileId)
       )
-    }))
+    })),
+  reset: () =>
+    set((state) => {
+      return {
+        ...state,
+        conversations: new Map(),
+        messages: new Map(),
+        messageProfiles: new Map(),
+        previewMessages: new Map(),
+        selectedTab: 'Following'
+      };
+    })
 }));
 
 // Each Map is storing a profileId as the key.

--- a/apps/web/src/store/message.ts
+++ b/apps/web/src/store/message.ts
@@ -2,11 +2,10 @@ import getUniqueMessages from '@lib/getUniqueMessages';
 import type { Client, Conversation, DecodedMessage } from '@xmtp/xmtp-js';
 import { toNanoString } from '@xmtp/xmtp-js';
 import { Localstorage } from 'data/storage';
-import type { Profile } from 'lens';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-type TabValues = 'Following' | 'Requested';
+export type TabValues = 'Following' | 'Requested';
 
 interface MessageState {
   client: Client | undefined;
@@ -17,9 +16,8 @@ interface MessageState {
   messages: Map<string, DecodedMessage[]>;
   setMessages: (messages: Map<string, DecodedMessage[]>) => void;
   addMessages: (key: string, newMessages: DecodedMessage[]) => number;
-  messageProfiles: Map<string, Profile>;
-  setMessageProfiles: (messageProfiles: Map<string, Profile>) => void;
-  addProfileAndSelectTab: (key: string, profile: Profile) => void;
+  hasSyncedMessages: boolean;
+  setHasSyncedMessages: (hasSyncedMessages: boolean) => void;
   previewMessages: Map<string, DecodedMessage>;
   setPreviewMessage: (key: string, message: DecodedMessage) => void;
   setPreviewMessages: (previewMessages: Map<string, DecodedMessage>) => void;
@@ -28,6 +26,9 @@ interface MessageState {
   setSelectedProfileId: (selectedProfileId: string) => void;
   selectedTab: TabValues;
   setSelectedTab: (selectedTab: TabValues) => void;
+  syncedProfiles: Set<string>;
+  addSyncedProfiles: (profileIds: string[]) => void;
+  unsyncProfile: (profileId: string) => void;
 }
 
 export const useMessageStore = create<MessageState>((set) => ({
@@ -60,22 +61,10 @@ export const useMessageStore = create<MessageState>((set) => ({
     });
     return numAdded;
   },
-  messageProfiles: new Map(),
-  setMessageProfiles: (messageProfiles) => set(() => ({ messageProfiles })),
-  addProfileAndSelectTab: (key, profile) =>
-    set((state) => {
-      let profiles: Map<string, Profile>;
-      if (!state.messageProfiles.get(key)) {
-        profiles = new Map(state.messageProfiles);
-        profiles.set(key, profile);
-      } else {
-        profiles = state.messageProfiles;
-      }
-      const selectedTab: TabValues = profile.isFollowedByMe
-        ? 'Following'
-        : 'Requested';
-      return { messageProfiles: profiles, selectedTab: selectedTab };
-    }),
+
+  hasSyncedMessages: false,
+  setHasSyncedMessages: (hasSyncedMessages) =>
+    set(() => ({ hasSyncedMessages })),
   previewMessages: new Map(),
   setPreviewMessage: (key: string, message: DecodedMessage) =>
     set((state) => {
@@ -99,7 +88,18 @@ export const useMessageStore = create<MessageState>((set) => ({
         previewMessages: new Map(),
         selectedTab: 'Following'
       };
-    })
+    }),
+  syncedProfiles: new Set(),
+  addSyncedProfiles: (profileIds) =>
+    set(({ syncedProfiles }) => ({
+      syncedProfiles: new Set([...syncedProfiles, ...profileIds])
+    })),
+  unsyncProfile: (profileId: string) =>
+    set(({ syncedProfiles }) => ({
+      syncedProfiles: new Set(
+        [...syncedProfiles].filter((id) => id !== profileId)
+      )
+    }))
 }));
 
 // Each Map is storing a profileId as the key.

--- a/apps/web/src/store/message.ts
+++ b/apps/web/src/store/message.ts
@@ -14,12 +14,10 @@ interface MessageState {
   setConversations: (conversations: Map<string, Conversation>) => void;
   addConversation: (key: string, newConversation: Conversation) => void;
   messages: Map<string, DecodedMessage[]>;
-  setMessages: (messages: Map<string, DecodedMessage[]>) => void;
   addMessages: (key: string, newMessages: DecodedMessage[]) => number;
   hasSyncedMessages: boolean;
   setHasSyncedMessages: (hasSyncedMessages: boolean) => void;
   previewMessages: Map<string, DecodedMessage>;
-  setPreviewMessage: (key: string, message: DecodedMessage) => void;
   setPreviewMessages: (previewMessages: Map<string, DecodedMessage>) => void;
   selectedProfileId: string;
   setSelectedProfileId: (selectedProfileId: string) => void;
@@ -44,7 +42,6 @@ export const useMessageStore = create<MessageState>((set) => ({
     });
   },
   messages: new Map(),
-  setMessages: (messages) => set(() => ({ messages })),
   addMessages: (key: string, newMessages: DecodedMessage[]) => {
     let numAdded = 0;
     set((state) => {
@@ -65,12 +62,6 @@ export const useMessageStore = create<MessageState>((set) => ({
   setHasSyncedMessages: (hasSyncedMessages) =>
     set(() => ({ hasSyncedMessages })),
   previewMessages: new Map(),
-  setPreviewMessage: (key: string, message: DecodedMessage) =>
-    set((state) => {
-      const newPreviewMessages = new Map(state.previewMessages);
-      newPreviewMessages.set(key, message);
-      return { previewMessages: newPreviewMessages };
-    }),
   setPreviewMessages: (previewMessages) => set(() => ({ previewMessages })),
   selectedProfileId: '',
   setSelectedProfileId: (selectedProfileId) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,12 @@ importers:
       dayjs-twitter:
         specifier: ^0.5.0
         version: 0.5.0
+      dexie:
+        specifier: ^3.2.3
+        version: 3.2.3
+      dexie-react-hooks:
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react@18.2.0)(dexie@3.2.3)(react@18.2.0)
       dotenv:
         specifier: ^16.0.3
         version: 16.0.3
@@ -12314,6 +12320,23 @@ packages:
       debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /dexie-react-hooks@1.1.3(@types/react@18.2.0)(dexie@3.2.3)(react@18.2.0):
+    resolution: {integrity: sha512-bXXE1gfYtfuVYTNiOlyam+YVaO8KaqacgRuxFuP37YtpS6o/jxT6KOl5h+hhqY36s0UavlHWbL+HWJFMcQumIg==}
+    peerDependencies:
+      '@types/react': '>=16'
+      dexie: '>=3.1.0-alpha.1 <5.0.0'
+      react: '>=16'
+    dependencies:
+      '@types/react': 18.2.0
+      dexie: 3.2.3
+      react: 18.2.0
+    dev: false
+
+  /dexie@3.2.3:
+    resolution: {integrity: sha512-iHayBd4UYryDCVUNa3PMsJMEnd8yjyh5p7a+RFeC8i8n476BC9wMhVvqiImq5zJZJf5Tuer+s4SSj+AA3x+ZbQ==}
+    engines: {node: '>=6.0'}
     dev: false
 
   /didyoumean@1.2.2:


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b81dbc</samp>

This pull request refactors the web app to use a local database for profile and preview message data, instead of the store. It uses the `dexie` and `dexie-react-hooks` libraries to create and access the database, and custom hooks to provide data to the components. It also simplifies the store logic and improves the performance and usability of the app. It affects the following files: `Message.tsx`, `MessageHeader.tsx`, `PreviewList.tsx`, `Details.tsx`, `useGetMessagePreviews.tsx`, `useMessagePreviews.tsx`, `message.ts`, `pnpm-lock.yaml`, `useMessageDb.tsx`, and `message-db.ts`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b81dbc</samp>

*  Create and use custom hooks to access the local database for profile and preview message data, and provide functions to persist the data in the database ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-5648372a44a6312ee755a3755b67eae25eda61d21826c43f088f8594b26db0d7R1-R132),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-c555a2deee77a53c6da774d69866edba991f7fbf97d2d8d4cff9bc1203146cc7R1-R46))
*  Import the `useMessageDb` and `useGetProfile` hooks from `@components/utils/hooks/useMessageDb` in the components that need them ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-2ce189b37041c30ccd1e2909ceecbb30ea9b59738f19f0311bf70e40993bca6bR6),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-0b872fbacf4157f72d0c9b94ce54ae519739cf13975d047070f197a3b3fdccbbL7-R8),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778R6),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04R8),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b971652b1e5c5c7d512e6c7091d49059c858f7e50f84d8364cd66384c14bda4aL29-R35),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3R18-R19))
*  Remove the unused state and actions for profile and preview message data from the `useMessageStore` hook and the `MessageState` interface in `message.ts` ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-bf53ea74161761cc199afb3af1d4962130ed9eb89d191b26bd5fb551e83d534dL20-R20),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-bf53ea74161761cc199afb3af1d4962130ed9eb89d191b26bd5fb551e83d534dL63-R66))
*  Add the new state and actions for tracking and updating the profile ids that have been synced with the local database to the `useMessageStore` hook and the `MessageState` interface in `message.ts` ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-bf53ea74161761cc199afb3af1d4962130ed9eb89d191b26bd5fb551e83d534dR29-R31),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-bf53ea74161761cc199afb3af1d4962130ed9eb89d191b26bd5fb551e83d534dL102-R101))
*  Replace the store functions for profile and preview message data with the local database functions in the components and hooks that use them ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-2ce189b37041c30ccd1e2909ceecbb30ea9b59738f19f0311bf70e40993bca6bL19),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-2ce189b37041c30ccd1e2909ceecbb30ea9b59738f19f0311bf70e40993bca6bL33-R33),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-0b872fbacf4157f72d0c9b94ce54ae519739cf13975d047070f197a3b3fdccbbL19-R29),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-0b872fbacf4157f72d0c9b94ce54ae519739cf13975d047070f197a3b3fdccbbL26-R36),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-0b872fbacf4157f72d0c9b94ce54ae519739cf13975d047070f197a3b3fdccbbL45-R63),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778L47-R49),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778L92-R92),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778L98-R102),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04L56-R61),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04L69-R75),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b971652b1e5c5c7d512e6c7091d49059c858f7e50f84d8364cd66384c14bda4aL37-R87),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b971652b1e5c5c7d512e6c7091d49059c858f7e50f84d8364cd66384c14bda4aL83-R93),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L25-R37),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3R49-R54),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L59-R97),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L74-R110),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3R127-R128),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L99-R138),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L124-R158),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L225-R259),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L247-R281))
*  Export the `TabValues` type from `message.ts` and import it in the components that need it ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-bf53ea74161761cc199afb3af1d4962130ed9eb89d191b26bd5fb551e83d534dL5-R8),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778R26),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04R35))
*  Use the shorter and more direct import path for the `DecodedMessage` type from `@xmtp/xmtp-js` ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b971652b1e5c5c7d512e6c7091d49059c858f7e50f84d8364cd66384c14bda4aL9-R24),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L10-R10))
*  Add the optional chaining operator to the `messageProfiles` variable in `useMessagePreviews.tsx` to handle the case when it is undefined ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L225-R259))
*  Add the `messageProfiles?.size` condition to the `loading` return value in `useMessagePreviews.tsx` to avoid showing the loading state when the profiles are already loaded from the local database ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b4f3b185340d536623bfcecce43624e3f8d2155a371a469dacb7aaf372397bf3L247-R281))
*  Remove the `previewMessages` dependency from the `useEffect` hook in `useGetMessagePreviews.tsx` to avoid triggering the effect when the preview messages change in the store ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-b971652b1e5c5c7d512e6c7091d49059c858f7e50f84d8364cd66384c14bda4aL83-R93))
*  Remove the `selectedProfileId`, `setSelectedProfileId`, `selectedTab`, and `setSelectedTab` state and actions from the `persist` middleware in the `useMessageStore` hook in `message.ts` to avoid persisting them in the local storage ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-bf53ea74161761cc199afb3af1d4962130ed9eb89d191b26bd5fb551e83d534dL87-L91))
*  Add the `dexie` and `dexie-react-hooks` dependencies and sub-dependencies to the `pnpm-lock.yaml` file to install the packages for the local database ([link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR231-R236),[link](https://github.com/lensterxyz/lenster/pull/2775/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR12325-R12341))

## Emoji

<!--
copilot:emoji
-->

🗄️🔄📑

<!--
1.  🗄️ - This emoji represents the local database feature and the use of the `dexie` and `dexie-react-hooks` packages.
2.  🔄 - This emoji represents the syncing and unsyncing of the profile data and the refactoring of the hooks and components to use the local database instead of the store.
3.  📑 - This emoji represents the tab switching and selection feature and the use of the `TabValues` type and the `selectedTab` state.
-->
