### PR TITLE
feat: add lighbox for avatar

### DIFF
--- a/apps/web/src/components/Profile/Details.tsx
+++ b/apps/web/src/components/Profile/Details.tsx
@@ -35,7 +35,7 @@ import { useAppStore } from 'src/store/app';
 import type { TabValues } from 'src/store/message';
 import { useMessageStore } from 'src/store/message';
 import { FollowSource } from 'src/tracking';
-import { Button, Image, Modal, Tooltip } from 'ui';
+import { Button, Image, LightBox, Modal, Tooltip } from 'ui';
 
 import Badges from './Badges';
 import Followerings from './Followerings';
@@ -52,6 +52,7 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [showMutualFollowersModal, setShowMutualFollowersModal] =
     useState(false);
+  const [expandedImage, setExpandedImage] = useState<string | null>(null);
   const { allowed: staffMode } = useStaffMode();
   const { resolvedTheme } = useTheme();
   const router = useRouter();
@@ -100,12 +101,18 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
           onError={({ currentTarget }) => {
             currentTarget.src = getAvatar(profile, false);
           }}
+          onClick={() => setExpandedImage(getAvatar(profile, false))}
           src={getAvatar(profile)}
-          className="h-32 w-32 rounded-xl bg-gray-200 ring-8 ring-gray-50 dark:bg-gray-700 dark:ring-black sm:h-52 sm:w-52"
+          className="h-32 w-32 cursor-pointer rounded-xl bg-gray-200 ring-8 ring-gray-50 dark:bg-gray-700 dark:ring-black sm:h-52 sm:w-52"
           height={128}
           width={128}
           alt={formatHandle(profile?.handle)}
           data-testid="profile-avatar"
+        />
+        <LightBox
+          show={Boolean(expandedImage)}
+          url={expandedImage}
+          onClose={() => setExpandedImage(null)}
         />
       </div>
       <div className="space-y-1 py-2">


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8836e53</samp>

Added a full-screen avatar feature to the web app's profile page. Used the `LightBox` component and updated the `Details` component in `apps/web/src/components/Profile/Details.tsx`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8836e53</samp>

*  Import and render `LightBox` component to display profile avatar in full-screen mode ([link](https://github.com/lensterxyz/lenster/pull/2783/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04L38-R38), [link](https://github.com/lensterxyz/lenster/pull/2783/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04R112-R116))
*  Add `expandedImage` state variable to store the URL of the image to show in `LightBox` ([link](https://github.com/lensterxyz/lenster/pull/2783/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04R55))
*  Add `onClick` handler and `cursor-pointer` class to `Image` component to make avatar clickable and set `expandedImage` ([link](https://github.com/lensterxyz/lenster/pull/2783/files?diff=unified&w=0#diff-051c5aa8ed716f2a43344cf26ef7f981c4ad1884f3cf442ae394da8e5527aa04L103-R106))

## Emoji

<!--
copilot:emoji
-->

:sparkles::lipstick::hammer:

<!--
1.  :sparkles: - This emoji is often used to indicate a new feature or enhancement, and it could be used to highlight the addition of the full-screen avatar feature.
2.  :lipstick: - This emoji is typically used to denote improvements to the user interface or appearance, and it could be used to emphasize the visual impact of the lightbox component.
3.  :hammer: - This emoji is commonly used to signify work in progress or refactoring, and it could be used to indicate the modification of the existing `Details` component to handle the new logic.
-->
