### PR TITLE
feat: migrate from ethers to viem in bundlr package

### DIFF
--- a/packages/bundlr/index.ts
+++ b/packages/bundlr/index.ts
@@ -1,7 +1,9 @@
 import type { DataItemCreateOptions } from 'arbundles';
 import base64url from 'base64url';
-import { Wallet } from 'ethers';
 import { publicKeyCreate } from 'secp256k1';
+import { createWalletClient, http, toHex } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { polygon } from 'viem/chains';
 
 import {
   byteArrayToLong,
@@ -45,10 +47,16 @@ export class EthereumSigner extends Secp256k1 {
   }
 
   sign(message: Uint8Array): Uint8Array {
-    const wallet = new Wallet(this._key);
-    return wallet
-      .signMessage(message)
-      .then((r) => Buffer.from(r.slice(2), 'hex')) as any;
+    const account = privateKeyToAccount(`0x${this._key}`);
+    const wallet = createWalletClient({
+      account,
+      chain: polygon,
+      transport: http()
+    });
+
+    return wallet.signMessage({ message: toHex(message) }).then((r) => {
+      return Buffer.from(r.slice(2), 'hex');
+    }) as any;
   }
 }
 

--- a/packages/bundlr/package.json
+++ b/packages/bundlr/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "arbundles": "^0.9.5",
     "base64url": "^3.0.1",
-    "ethers": "5.7.2",
-    "secp256k1": "^5.0.0"
+    "secp256k1": "^5.0.0",
+    "viem": "^0.3.17"
   },
   "devDependencies": {
     "@types/secp256k1": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,12 +406,12 @@ importers:
       base64url:
         specifier: ^3.0.1
         version: 3.0.1
-      ethers:
-        specifier: 5.7.2
-        version: 5.7.2
       secp256k1:
         specifier: ^5.0.0
         version: 5.0.0
+      viem:
+        specifier: ^0.3.17
+        version: 0.3.17(typescript@5.0.4)
     devDependencies:
       '@types/secp256k1':
         specifier: ^4.0.3


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae86a7e</samp>

The code migrates from `ethers` to `viem` for Ethereum functionality in the `bundlr` package. This change simplifies the code and enables cross-chain compatibility.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae86a7e</samp>

*  Replace `ethers` with `viem` for signing messages on Ethereum-compatible chains ([link](https://github.com/lensterxyz/lenster/pull/2801/files?diff=unified&w=0#diff-9623927fc6e67b086266b612c042dd04910fea1a5949f8ccfb270af9a3217d79L3-R6),[link](https://github.com/lensterxyz/lenster/pull/2801/files?diff=unified&w=0#diff-9623927fc6e67b086266b612c042dd04910fea1a5949f8ccfb270af9a3217d79L48-R59),[link](https://github.com/lensterxyz/lenster/pull/2801/files?diff=unified&w=0#diff-e0bf3fc5872f59c831dacd7b82a39063628888671005bd41dc595e376dda9b41L16-R17),[link](https://github.com/lensterxyz/lenster/pull/2801/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL409-R414))

## Emoji

<!--
copilot:emoji
-->

:package::lock::globe_with_meridians:

<!--
1.  :package: This emoji represents adding or updating a dependency in the `package.json` file.
2.  :lock: This emoji represents updating the lockfile in the `pnpm-lock.yaml` file.
3.  :globe_with_meridians: This emoji represents changing the network or protocol layer of the code.
-->
