### PR TITLE
fix: json rpc errors because of nonce out of sync

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -75,6 +75,7 @@
     "react-virtuoso": "^4.3.5",
     "remark-breaks": "^3.0.2",
     "remark-linkify-regex": "^1.2.1",
+    "shared-zustand": "^2.0.0",
     "snapshot": "workspace:*",
     "strip-markdown": "^5.0.0",
     "tlds": "^1.238.0",

--- a/apps/web/src/components/Common/Layout.tsx
+++ b/apps/web/src/components/Common/Layout.tsx
@@ -27,7 +27,6 @@ interface LayoutProps {
 const Layout: FC<LayoutProps> = ({ children }) => {
   const { resolvedTheme } = useTheme();
   const setProfiles = useAppStore((state) => state.setProfiles);
-  const setUserSigNonce = useAppStore((state) => state.setUserSigNonce);
   const currentProfile = useAppStore((state) => state.currentProfile);
   const setCurrentProfile = useAppStore((state) => state.setCurrentProfile);
   const profileId = useAppPersistStore((state) => state.profileId);
@@ -64,7 +63,6 @@ const Layout: FC<LayoutProps> = ({ children }) => {
       setProfiles(profiles as Profile[]);
       setCurrentProfile(selectedUser as Profile);
       setProfileId(selectedUser?.id);
-      setUserSigNonce(data?.userSigNonces?.lensHubOnChainSigNonce);
     },
     onError: () => {
       setProfileId(null);

--- a/apps/web/src/components/Common/Providers/UserSigNoncesProvider.tsx
+++ b/apps/web/src/components/Common/Providers/UserSigNoncesProvider.tsx
@@ -1,0 +1,27 @@
+import { useUserSigNoncesQuery } from 'lens';
+import type { FC } from 'react';
+import { isSupported, share } from 'shared-zustand';
+import { useAppPersistStore } from 'src/store/app';
+import { useNonceStore } from 'src/store/nonce';
+
+const UserSigNoncesProvider: FC = () => {
+  const profileId = useAppPersistStore((state) => state.profileId);
+  const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
+
+  if (isSupported()) {
+    share('userSigNonce', useNonceStore);
+  }
+
+  // Sync nonce every 10 seconds
+  useUserSigNoncesQuery({
+    skip: !profileId,
+    onCompleted: ({ userSigNonces }) => {
+      setUserSigNonce(userSigNonces.lensHubOnChainSigNonce);
+    },
+    pollInterval: 10000
+  });
+
+  return null;
+};
+
+export default UserSigNoncesProvider;

--- a/apps/web/src/components/Common/Providers/index.tsx
+++ b/apps/web/src/components/Common/Providers/index.tsx
@@ -25,6 +25,7 @@ import Layout from '../Layout';
 import FeatureFlagsProvider from './FeatureFlagsProvider';
 import LanguageProvider from './LanguageProvider';
 import TelemetryProvider from './TelemetryProvider';
+import UserSigNoncesProvider from './UserSigNoncesProvider';
 
 const { chains, provider } = configureChains(
   [IS_MAINNET ? polygon : polygonMumbai, mainnet],
@@ -61,6 +62,7 @@ const Providers = ({ children }: { children: ReactNode }) => {
         <TelemetryProvider />
         <WagmiConfig client={wagmiClient}>
           <ApolloProvider client={apolloClient}>
+            <UserSigNoncesProvider />
             <QueryClientProvider client={queryClient}>
               <LivepeerConfig client={livepeerClient} theme={getLivepeerTheme}>
                 <ThemeProvider defaultTheme="light" attribute="class">

--- a/apps/web/src/components/Settings/Account/SetProfile.tsx
+++ b/apps/web/src/components/Settings/Account/SetProfile.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import Custom404 from 'src/pages/404';
 import { useAppStore } from 'src/store/app';
+import { useNonceStore } from 'src/store/nonce';
 import { SETTINGS } from 'src/tracking';
 import { Button, Card, ErrorMessage, Spinner } from 'ui';
 import { useAccount, useContractWrite, useSignTypedData } from 'wagmi';
@@ -25,8 +26,8 @@ import { useAccount, useContractWrite, useSignTypedData } from 'wagmi';
 const SetProfile: FC = () => {
   const profiles = useAppStore((state) => state.profiles);
   const currentProfile = useAppStore((state) => state.currentProfile);
-  const userSigNonce = useAppStore((state) => state.userSigNonce);
-  const setUserSigNonce = useAppStore((state) => state.setUserSigNonce);
+  const userSigNonce = useNonceStore((state) => state.userSigNonce);
+  const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
   const [selectedUser, setSelectedUser] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { address } = useAccount();

--- a/apps/web/src/components/Settings/Delete/index.tsx
+++ b/apps/web/src/components/Settings/Delete/index.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
 import Custom404 from 'src/pages/404';
 import { useAppPersistStore, useAppStore } from 'src/store/app';
+import { useNonceStore } from 'src/store/nonce';
 import { PAGEVIEW } from 'src/tracking';
 import {
   Button,
@@ -33,8 +34,8 @@ import SettingsSidebar from '../Sidebar';
 
 const DeleteSettings: FC = () => {
   const [showWarningModal, setShowWarningModal] = useState(false);
-  const userSigNonce = useAppStore((state) => state.userSigNonce);
-  const setUserSigNonce = useAppStore((state) => state.setUserSigNonce);
+  const userSigNonce = useNonceStore((state) => state.userSigNonce);
+  const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
   const currentProfile = useAppStore((state) => state.currentProfile);
   const setCurrentProfile = useAppStore((state) => state.setCurrentProfile);
   const setProfileId = useAppPersistStore((state) => state.setProfileId);

--- a/apps/web/src/components/Settings/Profile/NftPicture.tsx
+++ b/apps/web/src/components/Settings/Profile/NftPicture.tsx
@@ -17,6 +17,7 @@ import type { FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useAppStore } from 'src/store/app';
+import { useNonceStore } from 'src/store/nonce';
 import { SETTINGS } from 'src/tracking';
 import { Button, ErrorMessage, Form, Input, Spinner, useZodForm } from 'ui';
 import { useContractWrite, useSignMessage, useSignTypedData } from 'wagmi';
@@ -35,8 +36,8 @@ interface NftPictureProps {
 }
 
 const NftPicture: FC<NftPictureProps> = ({ profile }) => {
-  const userSigNonce = useAppStore((state) => state.userSigNonce);
-  const setUserSigNonce = useAppStore((state) => state.setUserSigNonce);
+  const userSigNonce = useNonceStore((state) => state.userSigNonce);
+  const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [isLoading, setIsLoading] = useState(false);
   const [chainId, setChainId] = useState<number>(

--- a/apps/web/src/components/Shared/Follow.tsx
+++ b/apps/web/src/components/Shared/Follow.tsx
@@ -19,6 +19,7 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { useAppStore } from 'src/store/app';
 import { useAuthStore } from 'src/store/auth';
+import { useNonceStore } from 'src/store/nonce';
 import { PROFILE } from 'src/tracking';
 import { Button, Spinner } from 'ui';
 import { useAccount, useContractWrite, useSignTypedData } from 'wagmi';
@@ -43,8 +44,8 @@ const Follow: FC<FollowProps> = ({
   followPosition
 }) => {
   const { pathname } = useRouter();
-  const userSigNonce = useAppStore((state) => state.userSigNonce);
-  const setUserSigNonce = useAppStore((state) => state.setUserSigNonce);
+  const userSigNonce = useNonceStore((state) => state.userSigNonce);
+  const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
   const currentProfile = useAppStore((state) => state.currentProfile);
   const setShowAuthModal = useAuthStore((state) => state.setShowAuthModal);
   const [isLoading, setIsLoading] = useState(false);

--- a/apps/web/src/store/app.ts
+++ b/apps/web/src/store/app.ts
@@ -8,17 +8,13 @@ interface AppState {
   setProfiles: (profiles: Profile[]) => void;
   currentProfile: Profile | null;
   setCurrentProfile: (currentProfile: Profile | null) => void;
-  userSigNonce: number;
-  setUserSigNonce: (userSigNonce: number) => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
   profiles: [],
   setProfiles: (profiles) => set(() => ({ profiles })),
   currentProfile: null,
-  setCurrentProfile: (currentProfile) => set(() => ({ currentProfile })),
-  userSigNonce: 0,
-  setUserSigNonce: (userSigNonce) => set(() => ({ userSigNonce }))
+  setCurrentProfile: (currentProfile) => set(() => ({ currentProfile }))
 }));
 
 interface AppPersistState {

--- a/apps/web/src/store/nonce.ts
+++ b/apps/web/src/store/nonce.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+
+interface NonceState {
+  userSigNonce: number;
+  setUserSigNonce: (userSigNonce: number) => void;
+}
+
+export const useNonceStore = create(
+  subscribeWithSelector<NonceState>((set) => ({
+    userSigNonce: 0,
+    setUserSigNonce: (userSigNonce) => set(() => ({ userSigNonce }))
+  }))
+);

--- a/packages/data/storage.ts
+++ b/packages/data/storage.ts
@@ -2,6 +2,7 @@
 export const Localstorage = {
   LensterStore: 'lenster.store',
   NotificationStore: 'notification.store',
+  NonceStore: 'nonce.store',
   PreferencesStore: 'preferences.store',
   TransactionStore: 'transaction.store',
   TimelineStore: 'timeline.store',

--- a/packages/lens/documents/queries/UserProfiles.graphql
+++ b/packages/lens/documents/queries/UserProfiles.graphql
@@ -11,7 +11,4 @@ query UserProfiles($ownedBy: [EthereumAddress!]) {
       }
     }
   }
-  userSigNonces {
-    lensHubOnChainSigNonce
-  }
 }

--- a/packages/lens/documents/queries/UserSigNonces.graphql
+++ b/packages/lens/documents/queries/UserSigNonces.graphql
@@ -1,0 +1,5 @@
+query UserSigNonces {
+  userSigNonces {
+    lensHubOnChainSigNonce
+  }
+}

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -36382,6 +36382,12 @@ export type UserProfilesQuery = {
         | null;
     }>;
   };
+};
+
+export type UserSigNoncesQueryVariables = Exact<{ [key: string]: never }>;
+
+export type UserSigNoncesQuery = {
+  __typename?: 'Query';
   userSigNonces: { __typename?: 'UserSigNonces'; lensHubOnChainSigNonce: any };
 };
 
@@ -42162,9 +42168,6 @@ export const UserProfilesDocument = gql`
         }
       }
     }
-    userSigNonces {
-      lensHubOnChainSigNonce
-    }
   }
   ${ProfileFieldsFragmentDoc}
 `;
@@ -42218,6 +42221,63 @@ export type UserProfilesLazyQueryHookResult = ReturnType<
 export type UserProfilesQueryResult = Apollo.QueryResult<
   UserProfilesQuery,
   UserProfilesQueryVariables
+>;
+export const UserSigNoncesDocument = gql`
+  query UserSigNonces {
+    userSigNonces {
+      lensHubOnChainSigNonce
+    }
+  }
+`;
+
+/**
+ * __useUserSigNoncesQuery__
+ *
+ * To run a query within a React component, call `useUserSigNoncesQuery` and pass it any options that fit your needs.
+ * When your component renders, `useUserSigNoncesQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useUserSigNoncesQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useUserSigNoncesQuery(
+  baseOptions?: Apollo.QueryHookOptions<
+    UserSigNoncesQuery,
+    UserSigNoncesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<UserSigNoncesQuery, UserSigNoncesQueryVariables>(
+    UserSigNoncesDocument,
+    options
+  );
+}
+export function useUserSigNoncesLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    UserSigNoncesQuery,
+    UserSigNoncesQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<UserSigNoncesQuery, UserSigNoncesQueryVariables>(
+    UserSigNoncesDocument,
+    options
+  );
+}
+export type UserSigNoncesQueryHookResult = ReturnType<
+  typeof useUserSigNoncesQuery
+>;
+export type UserSigNoncesLazyQueryHookResult = ReturnType<
+  typeof useUserSigNoncesLazyQuery
+>;
+export type UserSigNoncesQueryResult = Apollo.QueryResult<
+  UserSigNoncesQuery,
+  UserSigNoncesQueryVariables
 >;
 export const VerifyDocument = gql`
   query Verify($request: VerifyRequest!) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,6 +312,9 @@ importers:
       remark-linkify-regex:
         specifier: ^1.2.1
         version: 1.2.1
+      shared-zustand:
+        specifier: ^2.0.0
+        version: 2.0.0
       snapshot:
         specifier: workspace:*
         version: link:../../packages/snapshot
@@ -17366,6 +17369,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       kind-of: 6.0.3
+    dev: false
+
+  /shared-zustand@2.0.0:
+    resolution: {integrity: sha512-DKBWe2w62wZif79XcUXStBBQ47T4y3XEApueseZ1O3wEsMbamDK01ac0zQNVj4MOH9Z5jesM2oLuug/79LPM1A==}
     dev: false
 
   /shebang-command@2.0.0:


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2409232</samp>

This pull request refactors the user signature nonce management in the web app. It introduces a new zustand store, a new query, and a new provider component to handle the user signature nonce state. It updates various components and mutations to use the new store and query. It also adds a dependency on `shared-zustand` to enable syncing the user signature nonce across different tabs or windows. It removes the user signature nonce logic from the app store and the `UserProfiles` query.

## Related issues

Fixes #2804

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2409232</samp>

*  Add `shared-zustand` dependency to enable sharing zustand stores across React contexts or iframes ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8R78))
*  Create a new zustand store called `useNonceStore` to manage the user signature nonce state and persist it in local storage ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-9d48bf4f6d1d659295575d1539dfc64ad7a008b75dee96f498d3a38b558baccbR1-R14), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-711bcbb5c6e354cff3bc54fe8552c04f0a0245182c2afb5a7d6f8b74e7ae122cR5))
*  Create a new query called `UserSigNonces` to fetch the user signature nonce for the current user from the Lens API ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-88e2c40e9931ff03c4851b154f1765914092e4742edf40869552c7583f1e1a84R1-R5))
*  Create a new component called `UserSigNoncesProvider` that uses the `UserSigNonces` query and the `useNonceStore` hook to sync the user signature nonce across different tabs or windows ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-3de31fe2a7d40b06fadedd6eb12fde678d512af6fa81dce4b9d64c97cd2c2841R1-R27))
*  Render the `UserSigNoncesProvider` component inside the `Providers` component to ensure that the user signature nonce is fetched and updated for every page ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-f7e122c26f9b485a5a519e88e671db9096185dd146ff170dcd0a37c71f57b573R28), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-f7e122c26f9b485a5a519e88e671db9096185dd146ff170dcd0a37c71f57b573R65))
*  Remove the `userSigNonce` and `setUserSigNonce` properties and selectors from the `AppState` interface and the `useAppStore` hook as they are no longer needed ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-9390cfccb3090a6b6b18dfaea3caaee07c9b76c4778a9ab1ac08ee61b8ca0c70L11-L12), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-9390cfccb3090a6b6b18dfaea3caaee07c9b76c4778a9ab1ac08ee61b8ca0c70L19-R17))
*  Remove the `userSigNonces` field from the `UserProfiles` query as it is no longer needed ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-b667eb2237b7b27bf7f9edce3ff3c94c109ea3affb5445373303b6f473527be8L14-L16))
*  Import the `useNonceStore` hook and replace the `useAppStore` hook for the `userSigNonce` and `setUserSigNonce` selectors in various components that require signing transactions with the user signature nonce ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637L30), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637L67), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517R75), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L135-R137), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebR49), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL74-R76), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fR30), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fL41-R43), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-4140e9fa5dba053d642a89f16e93d79a9b944b23e11e6f1746e3411ad9b0542aR21), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-4140e9fa5dba053d642a89f16e93d79a9b944b23e11e6f1746e3411ad9b0542aL28-R30), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249R24), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L37-R39), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-24350b827973549fb283ddcf1c5a7ee4401f88d7a72d2205a78a1a0350c80cd6R19), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-24350b827973549fb283ddcf1c5a7ee4401f88d7a72d2205a78a1a0350c80cd6L36-R38), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-1fa1065ebf72ab9da791b7a0cdc742f6baffa25342dfeb1f99dfefd1c9350fdfR20), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-1fa1065ebf72ab9da791b7a0cdc742f6baffa25342dfeb1f99dfefd1c9350fdfL29-R31), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-cf0a97986c4205646f837237d73d253f968c2212d1745a1bf33b795784a7db1cR20), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-cf0a97986c4205646f837237d73d253f968c2212d1745a1bf33b795784a7db1cL38-R40), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526R30), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L41-R43), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-13d4bceb37aa9a8fbfb289da32670451dffff4b1aa212cc07a4559e5bef0c3f2R22), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-13d4bceb37aa9a8fbfb289da32670451dffff4b1aa212cc07a4559e5bef0c3f2L46-R48), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-c9dc50d00ae6e20957ce95b12e76c80b0548fc9743ca5969a597c8e7a9ec9ea6R26), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-c9dc50d00ae6e20957ce95b12e76c80b0548fc9743ca5969a597c8e7a9ec9ea6L59-R61))
*  Increment the user signature nonce by one after calling the mutations that require a user signature and decrement it by one in case of an error in various components that require signing transactions with the user signature nonce ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517R315), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L319-R324), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL147-R155), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fL105-R113), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L78-R86), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-1fa1065ebf72ab9da791b7a0cdc742f6baffa25342dfeb1f99dfefd1c9350fdfL65-R73), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L77-R85), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-c9dc50d00ae6e20957ce95b12e76c80b0548fc9743ca5969a597c8e7a9ec9ea6L96-R104))
*  Remove the lines that increment the user signature nonce by one after calling the mutations that do not require a user signature in various components that require signing transactions with the user signature nonce ([link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L407), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL235), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-fe787eba695bfa1650d36a6b877e352afd47e34adc6a7625f92afe5c8677094fL137), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L107), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-1fa1065ebf72ab9da791b7a0cdc742f6baffa25342dfeb1f99dfefd1c9350fdfL85), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L97), [link](https://github.com/lensterxyz/lenster/pull/2833/files?diff=unified&w=0#diff-c9dc50d00ae6e20957ce95b12e76c80b0548fc9743ca5969a597c8e7a9ec9ea6L156))

## Emoji

<!--
copilot:emoji
-->

🔒🚀🧹

<!--
1.  🔒 - This emoji represents the security aspect of the changes, as they aim to prevent replay attacks and ensure that the user signature nonce is always up to date and synced across different tabs or windows.
2.  🚀 - This emoji represents the performance aspect of the changes, as they reduce the number of unnecessary queries and mutations and improve the state management and reactivity of the user signature nonce.
3.  🧹 - This emoji represents the refactoring aspect of the changes, as they clean up the codebase and introduce a dedicated zustand store and provider component for the user signature nonce.
-->
