### PR TITLE
Change Wallet Connect to WalletConnect

### DIFF
--- a/packages/lib/getWalletDetails.ts
+++ b/packages/lib/getWalletDetails.ts
@@ -14,7 +14,7 @@ interface WalletDetails {
 const getWalletDetails = (name: string): WalletDetails => {
   const walletDetails: Record<string, WalletDetails> = {
     WalletConnect: {
-      name: 'Wallet Connect',
+      name: 'WalletConnect',
       logo: `${STATIC_IMAGES_URL}/wallets/walletconnect.svg`
     }
   };

--- a/tests/packages/lib/getWalletDetails.spec.ts
+++ b/tests/packages/lib/getWalletDetails.spec.ts
@@ -5,7 +5,7 @@ import getWalletDetails from 'lib/getWalletDetails';
 test.describe('getWalletDetails', () => {
   test('should return correct details for WalletConnect', () => {
     const walletDetails = getWalletDetails('WalletConnect');
-    expect(walletDetails.name).toBe('Wallet Connect');
+    expect(walletDetails.name).toBe('WalletConnect');
     expect(walletDetails.logo).toBe(
       `${STATIC_IMAGES_URL}/wallets/walletconnect.svg`
     );


### PR DESCRIPTION

## What does this PR do?

Updates name from `Wallet Connect` to `WalletConnect`

## Related issues

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

Changed title for WalletConnect modal. Changed name in test file too.

## Emoji

✌🏽
