### PR TITLE
feat: add getPoll snapshot endpoint

### DIFF
--- a/packages/workers/snapshot-relay/package.json
+++ b/packages/workers/snapshot-relay/package.json
@@ -16,6 +16,7 @@
     "@tsndr/cloudflare-worker-jwt": "^2.2.1",
     "itty-router": "4.0.0-next.46",
     "lib": "workspace:*",
+    "snapshot": "workspace:*",
     "viem": "^0.3.19"
   },
   "devDependencies": {

--- a/packages/workers/snapshot-relay/src/handlers/getPoll.ts
+++ b/packages/workers/snapshot-relay/src/handlers/getPoll.ts
@@ -1,18 +1,13 @@
 import { SnapshotDocument } from 'snapshot';
 import { webClient } from 'snapshot/apollo';
 
-export default async (id: string) => {
+export default async (id: string, voter: string) => {
   try {
     const { data } = await webClient.query({
       query: SnapshotDocument,
-      variables: {
-        id,
-        where: {
-          voter: '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3',
-          proposal: id
-        }
-      }
+      variables: { id, where: { voter, proposal: id } }
     });
+
     return new Response(JSON.stringify({ success: data }));
   } catch {
     return new Response(

--- a/packages/workers/snapshot-relay/src/handlers/getPoll.ts
+++ b/packages/workers/snapshot-relay/src/handlers/getPoll.ts
@@ -1,0 +1,22 @@
+import { SnapshotDocument } from 'snapshot';
+import { webClient } from 'snapshot/apollo';
+
+export default async (id: string) => {
+  try {
+    const { data } = await webClient.query({
+      query: SnapshotDocument,
+      variables: {
+        id,
+        where: {
+          voter: '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3',
+          proposal: id
+        }
+      }
+    });
+    return new Response(JSON.stringify({ success: data }));
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Something went wrong!' })
+    );
+  }
+};

--- a/packages/workers/snapshot-relay/src/index.ts
+++ b/packages/workers/snapshot-relay/src/index.ts
@@ -7,14 +7,16 @@ import type { Env } from './types';
 
 const { preflight, corsify } = createCors({
   origins: ['*'],
-  methods: ['POST']
+  methods: ['GET', 'POST']
 });
 
 const router = Router();
 
 router.all('*', preflight);
 router.get('/', () => new Response('Snapshot Relay'));
-router.get('/getPoll/:id', ({ params }) => getPoll(params.id));
+router.get('/getPoll/:id/:voter', ({ params }) =>
+  getPoll(params.id, params.voter)
+);
 router.post('/createPoll', createPoll);
 router.post('/votePoll', votePoll);
 

--- a/packages/workers/snapshot-relay/src/index.ts
+++ b/packages/workers/snapshot-relay/src/index.ts
@@ -1,6 +1,7 @@
 import { createCors, error, Router } from 'itty-router';
 
 import createPoll from './handlers/createPoll';
+import getPoll from './handlers/getPoll';
 import votePoll from './handlers/votePoll';
 import type { Env } from './types';
 
@@ -13,6 +14,7 @@ const router = Router();
 
 router.all('*', preflight);
 router.get('/', () => new Response('Snapshot Relay'));
+router.get('/getPoll/:id', ({ params }) => getPoll(params.id));
 router.post('/createPoll', createPoll);
 router.post('/votePoll', votePoll);
 

--- a/packages/workers/snapshot-relay/wrangler.toml
+++ b/packages/workers/snapshot-relay/wrangler.toml
@@ -2,6 +2,7 @@ name = "snapshot-relay"
 main = "src/index.ts"
 compatibility_date = "2023-01-25"
 keep_vars = true
+node_compat = true
 
 routes = [
 	{ pattern = "snapshot-relay.lenster.xyz", custom_domain = true }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,6 +730,9 @@ importers:
       lib:
         specifier: workspace:*
         version: link:../../lib
+      snapshot:
+        specifier: workspace:*
+        version: link:../../snapshot
       viem:
         specifier: ^0.3.19
         version: 0.3.19(typescript@5.0.4)(zod@3.21.4)


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63e5df2</samp>

The `snapshot-relay` package adds a new feature to fetch poll data by proposal id using the `snapshot` package. It also updates its configuration and dependencies to support TypeScript and Node.js compatibility for Cloudflare Workers.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63e5df2</samp>

*  Add `snapshot` dependency and `node_compat` option to `snapshot-relay` package ([link](https://github.com/lensterxyz/lenster/pull/2839/files?diff=unified&w=0#diff-190bb47eeddf0230d5d8ffdab97e4336f1b2e254b608c0818fa4478c44686a74R19), [link](https://github.com/lensterxyz/lenster/pull/2839/files?diff=unified&w=0#diff-b50cd529b47afe32c9c1db44aede01783ac2a2a6acb77aebc96f98f631cd0f7cR5), [link](https://github.com/lensterxyz/lenster/pull/2839/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR733-R735))
*  Implement and expose `getPoll` function to query snapshot data by proposal id ([link](https://github.com/lensterxyz/lenster/pull/2839/files?diff=unified&w=0#diff-234f1143593e6ec28f570936cfc96eb13e288a53b5fe69ad658f6d26fc2d19beR1-R22), [link](https://github.com/lensterxyz/lenster/pull/2839/files?diff=unified&w=0#diff-e278e7e11456e7751419373e1fc2f577f55d1c52cc8ae2519891f6363cff058dR4), [link](https://github.com/lensterxyz/lenster/pull/2839/files?diff=unified&w=0#diff-e278e7e11456e7751419373e1fc2f577f55d1c52cc8ae2519891f6363cff058dR17))

## Emoji

<!--
copilot:emoji
-->

:sparkles::wrench::link:

<!--
1.  :sparkles: This emoji represents the addition of a new feature or functionality, such as the new GET route for `/getPoll/:id`.
2.  :wrench: This emoji represents the improvement or adjustment of a tool or configuration, such as the `node_compat` field in the `wrangler.toml` file.
3.  :link: This emoji represents the connection or dependency between packages or components, such as the `snapshot` field in the `package.json` and `pnpm-lock.yaml` files.
-->
