### PR TITLE
feat: add dismiss recommended profile

### DIFF
--- a/apps/web/src/components/Home/RecommendedProfiles.tsx
+++ b/apps/web/src/components/Home/RecommendedProfiles.tsx
@@ -1,3 +1,4 @@
+import DismissRecommendedProfile from '@components/Shared/DismissRecommendedProfile';
 import UserProfileShimmer from '@components/Shared/Shimmer/UserProfileShimmer';
 import UserProfile from '@components/Shared/UserProfile';
 import { DotsCircleHorizontalIcon, UsersIcon } from '@heroicons/react/outline';
@@ -67,13 +68,23 @@ const RecommendedProfiles: FC = () => {
             error={error}
           />
           {data?.recommendedProfiles?.slice(0, 5)?.map((profile, index) => (
-            <div key={profile?.id} className="truncate">
-              <UserProfile
+            <div
+              key={profile?.id}
+              className="flex items-center space-x-3 truncate"
+            >
+              <div className="w-full">
+                <UserProfile
+                  profile={profile as Profile}
+                  isFollowing={profile.isFollowedByMe}
+                  followPosition={index + 1}
+                  followSource={FollowSource.WHO_TO_FOLLOW}
+                  showFollow
+                />
+              </div>
+              <DismissRecommendedProfile
                 profile={profile as Profile}
-                isFollowing={profile.isFollowedByMe}
-                followPosition={index + 1}
-                followSource={FollowSource.WHO_TO_FOLLOW}
-                showFollow
+                dismissPosition={index + 1}
+                dismissSource={FollowSource.WHO_TO_FOLLOW}
               />
             </div>
           ))}

--- a/apps/web/src/components/Home/Suggested.tsx
+++ b/apps/web/src/components/Home/Suggested.tsx
@@ -1,3 +1,4 @@
+import DismissRecommendedProfile from '@components/Shared/DismissRecommendedProfile';
 import Loader from '@components/Shared/Loader';
 import UserProfile from '@components/Shared/UserProfile';
 import { UsersIcon } from '@heroicons/react/outline';
@@ -34,15 +35,22 @@ const Suggested: FC = () => {
         data={data?.recommendedProfiles}
         itemContent={(index, profile) => {
           return (
-            <div className="p-5">
-              <UserProfile
+            <div className="flex items-center space-x-3 p-5">
+              <div className="w-full">
+                <UserProfile
+                  profile={profile as Profile}
+                  isFollowing={profile?.isFollowedByMe}
+                  followPosition={index + 1}
+                  followSource={FollowSource.WHO_TO_FOLLOW_MODAL}
+                  showBio
+                  showFollow
+                  showUserPreview={false}
+                />
+              </div>
+              <DismissRecommendedProfile
                 profile={profile as Profile}
-                isFollowing={profile?.isFollowedByMe}
-                followPosition={index + 1}
-                followSource={FollowSource.WHO_TO_FOLLOW_MODAL}
-                showBio
-                showFollow
-                showUserPreview={false}
+                dismissPosition={index + 1}
+                dismissSource={FollowSource.WHO_TO_FOLLOW_MODAL}
               />
             </div>
           );

--- a/apps/web/src/components/Shared/DismissRecommendedProfile.tsx
+++ b/apps/web/src/components/Shared/DismissRecommendedProfile.tsx
@@ -34,7 +34,7 @@ const DismissRecommendedProfile: FC<DismissRecommendedProfileProps> = ({
 
   return (
     <button onClick={handleDismiss}>
-      <XIcon className="h-4 w-4 text-gray-400" />
+      <XIcon className="h-4 w-4 text-gray-500" />
     </button>
   );
 };

--- a/apps/web/src/components/Shared/DismissRecommendedProfile.tsx
+++ b/apps/web/src/components/Shared/DismissRecommendedProfile.tsx
@@ -1,0 +1,42 @@
+import { XIcon } from '@heroicons/react/outline';
+import { Mixpanel } from '@lib/mixpanel';
+import type { Profile } from 'lens';
+import { useDismissRecommendedProfilesMutation } from 'lens';
+import type { FC } from 'react';
+import { PROFILE } from 'src/tracking';
+
+interface DismissRecommendedProfileProps {
+  profile: Profile;
+  dismissSource?: string;
+  dismissPosition?: number;
+}
+
+const DismissRecommendedProfile: FC<DismissRecommendedProfileProps> = ({
+  profile,
+  dismissSource,
+  dismissPosition
+}) => {
+  const [dismissRecommendedProfile] = useDismissRecommendedProfilesMutation({
+    variables: { request: { profileIds: [profile.id] } },
+    update: (cache) => {
+      cache.evict({ id: cache.identify(profile) });
+    }
+  });
+
+  const handleDismiss = async () => {
+    await dismissRecommendedProfile();
+    Mixpanel.track(PROFILE.DISMISS_RECOMMENDED_PROFILE, {
+      ...(dismissSource && { dismiss_source: dismissSource }),
+      ...(dismissPosition && { dismiss_position: dismissPosition }),
+      dismiss_target: profile.id
+    });
+  };
+
+  return (
+    <button onClick={handleDismiss}>
+      <XIcon className="h-4 w-4 text-gray-400" />
+    </button>
+  );
+};
+
+export default DismissRecommendedProfile;

--- a/apps/web/src/tracking.ts
+++ b/apps/web/src/tracking.ts
@@ -13,6 +13,7 @@ export const PROFILE = {
   FOLLOW: 'Follow profile',
   SUPER_FOLLOW: 'Super follow profile',
   UNFOLLOW: 'Unfollow profile',
+  DISMISS_RECOMMENDED_PROFILE: 'Dismiss recommended profile',
   OPEN_SUPER_FOLLOW: 'Open super follow modal',
   SWITCH_PROFILE_FEED_TAB: 'Switch profile feed tab',
   SWITCH_PROFILE: 'Switch profile',

--- a/packages/lens/documents/mutations/DismissRecommendedProfiles.graphql
+++ b/packages/lens/documents/mutations/DismissRecommendedProfiles.graphql
@@ -1,0 +1,5 @@
+mutation DismissRecommendedProfiles(
+  $request: DismissRecommendedProfilesRequest!
+) {
+  dismissRecommendedProfiles(request: $request)
+}

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -8923,6 +8923,15 @@ export type DeleteNftGalleryMutation = {
   deleteNftGallery?: any | null;
 };
 
+export type DismissRecommendedProfilesMutationVariables = Exact<{
+  request: DismissRecommendedProfilesRequest;
+}>;
+
+export type DismissRecommendedProfilesMutation = {
+  __typename?: 'Mutation';
+  dismissRecommendedProfiles?: any | null;
+};
+
 export type HidePublicationMutationVariables = Exact<{
   request: HidePublicationRequest;
 }>;
@@ -38723,6 +38732,57 @@ export type DeleteNftGalleryMutationOptions = Apollo.BaseMutationOptions<
   DeleteNftGalleryMutation,
   DeleteNftGalleryMutationVariables
 >;
+export const DismissRecommendedProfilesDocument = gql`
+  mutation DismissRecommendedProfiles(
+    $request: DismissRecommendedProfilesRequest!
+  ) {
+    dismissRecommendedProfiles(request: $request)
+  }
+`;
+export type DismissRecommendedProfilesMutationFn = Apollo.MutationFunction<
+  DismissRecommendedProfilesMutation,
+  DismissRecommendedProfilesMutationVariables
+>;
+
+/**
+ * __useDismissRecommendedProfilesMutation__
+ *
+ * To run a mutation, you first call `useDismissRecommendedProfilesMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDismissRecommendedProfilesMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [dismissRecommendedProfilesMutation, { data, loading, error }] = useDismissRecommendedProfilesMutation({
+ *   variables: {
+ *      request: // value for 'request'
+ *   },
+ * });
+ */
+export function useDismissRecommendedProfilesMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    DismissRecommendedProfilesMutation,
+    DismissRecommendedProfilesMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    DismissRecommendedProfilesMutation,
+    DismissRecommendedProfilesMutationVariables
+  >(DismissRecommendedProfilesDocument, options);
+}
+export type DismissRecommendedProfilesMutationHookResult = ReturnType<
+  typeof useDismissRecommendedProfilesMutation
+>;
+export type DismissRecommendedProfilesMutationResult =
+  Apollo.MutationResult<DismissRecommendedProfilesMutation>;
+export type DismissRecommendedProfilesMutationOptions =
+  Apollo.BaseMutationOptions<
+    DismissRecommendedProfilesMutation,
+    DismissRecommendedProfilesMutationVariables
+  >;
 export const HidePublicationDocument = gql`
   mutation HidePublication($request: HidePublicationRequest!) {
     hidePublication(request: $request)


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0784596</samp>

This pull request adds a feature to dismiss recommended profiles from the home page or the modal. It creates a shared `DismissRecommendedProfile` component that calls the `dismissRecommendedProfiles` mutation and updates the cache and tracking. It modifies the `RecommendedProfiles` and `Suggested` components to use the shared component.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0784596</samp>

*  Add `DismissRecommendedProfile` component to allow users to dismiss recommended profiles from home page or modal ([link](https://github.com/lensterxyz/lenster/pull/2856/files?diff=unified&w=0#diff-a47aa11fb9015a9b1be1d9c1518cf186f5830826d6871b379374a6efe522c7a3R1-R42))
* Import and display `DismissRecommendedProfile` component next to `UserProfile` component in `RecommendedProfiles` and `Suggested` components ([link](https://github.com/lensterxyz/lenster/pull/2856/files?diff=unified&w=0#diff-7e6283b745927732caef5c4e351b3b1391e995ba32e5631869eb3f9666e6b7edR1), [link](https://github.com/lensterxyz/lenster/pull/2856/files?diff=unified&w=0#diff-7e6283b745927732caef5c4e351b3b1391e995ba32e5631869eb3f9666e6b7edL70-R87), [link](https://github.com/lensterxyz/lenster/pull/2856/files?diff=unified&w=0#diff-195d287c965b91ad0d3ddab93aa2df42fe53e19ce4876338cc33648b4fda8461R1), [link](https://github.com/lensterxyz/lenster/pull/2856/files?diff=unified&w=0#diff-195d287c965b91ad0d3ddab93aa2df42fe53e19ce4876338cc33648b4fda8461L37-R53))
* Add `DismissRecommendedProfiles` mutation to mark profiles as dismissed by current user and update cache ([link](https://github.com/lensterxyz/lenster/pull/2856/files?diff=unified&w=0#diff-e2ff0c643793de3a8ca41ccf95b570569856fa86eace9e98e9fd21b83e875816R1-R5))
* Add `DISMISS_RECOMMENDED_PROFILE` event name to track user action with Mixpanel ([link](https://github.com/lensterxyz/lenster/pull/2856/files?diff=unified&w=0#diff-0de632705ed1f05ebcd4fe3b52d970b5c5cbabcddb8c1b9eabd948887cd6eab3R16))

## Emoji

<!--
copilot:emoji
-->

🚫🏠🎁

<!--
1.  🚫 - This emoji conveys the idea of dismissing or rejecting something, which is the main action of the feature.
2.  🏠 - This emoji represents the home page, which is one of the places where the feature is available.
3.  🎁 - This emoji suggests the concept of a recommendation or a suggestion, which is the source of the profiles that can be dismissed.
-->
