### PR TITLE
fix: show message content for non-attachments

### DIFF
--- a/apps/web/src/components/Messages/Preview.tsx
+++ b/apps/web/src/components/Messages/Preview.tsx
@@ -28,7 +28,7 @@ interface MessagePreviewProps {
 
 const MessagePreview: FC<MessagePreviewProps> = ({ message }) => {
   if (message.contentType.sameAs(ContentTypeText)) {
-    return <span>message.content</span>;
+    return <span>{message.content}</span>;
   } else if (message.contentType.sameAs(ContentTypeRemoteAttachment)) {
     const remoteAttachment: RemoteAttachment = message.content;
     return <span>{remoteAttachment.filename}</span>;


### PR DESCRIPTION
## What does this PR do?

Fixes a regression in message preview text where we were showing `message.content` instead of the message content.

## Related issues

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

- Send a message that doesn't include an attachment
- Notice the message preview shows the content of that message

## Emoji

🩹 
