### PR TITLE
Update Requests styling

### DIFF
--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -150,14 +150,17 @@ const PreviewList: FC<PreviewListProps> = ({
               showOnSm
             />
           </div>
-          {requestedCount > 0 && (
-            <div
-              onClick={() => setSelectedTab(MessageTabs.Requests)}
-              className="cursor-pointer py-2 text-xs font-bold text-gray-500 dark:bg-gray-700 dark:text-gray-400"
-            >
-              {requestedCount > 99 ? '99+' : requestedCount.toString()} Requests
-            </div>
-          )}
+          <TabButton
+            className="p-2 px-4"
+            name={
+              requestedCount > 99
+                ? '99+'
+                : `${requestedCount.toString()} Requests`
+            }
+            active={selectedTab === MessageTabs.Requests}
+            onClick={() => setSelectedTab(MessageTabs.Requests)}
+            showOnSm
+          />
         </div>
         {selectedTab === MessageTabs.Requests ? (
           <div className="bg-yellow-100 p-2 px-5 text-sm text-yellow-800">


### PR DESCRIPTION
## What does this PR do?

Updates the styling of the "Requests" tab to align with the styling of the other tabs. Also shows this tab in cases of 0 requests. 

## Related issues

Relates to the universal inbox changes from https://github.com/lensterxyz/lenster/pull/2866

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

Before (Requests is selected here, it just doesn't visually indicate that)
<img width="384" alt="Screenshot 2023-05-23 at 4 46 00 PM" src="https://github.com/lensterxyz/lenster/assets/35409260/99670391-e423-4ca4-9558-2d530d852bd3">

After 
<img width="406" alt="Screenshot 2023-05-23 at 4 46 20 PM" src="https://github.com/lensterxyz/lenster/assets/35409260/f020dbb3-e7ac-451b-b044-9d2db2075afd">

## Emoji

<!--
copilot:emoji
-->

🎨♻️🚚

<!--
1.  🎨 - This emoji is often used for code improvements that involve styling, formatting, or design. In this case, the TabButton component abstracts the common styles and layout of the tab buttons, such as the font size, color, border, and padding.
2.  ♻️ - This emoji is often used for code refactors that involve reorganizing, simplifying, or optimizing the code. In this case, the TabButton component extracts the common logic of the tab buttons, such as the click handler, the active state, and the request count.
3.  🚚 - This emoji is often used for code changes that involve moving or renaming files or components. In this case, the TabButton component is moved to a separate file and imported by the PreviewList component.
-->
