### PR TITLE
feat: add iframely proxy worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ yarn-error.log*
 *.tsbuildinfo
 
 # cloudflare workers
+.wrangler
 .dev.vars
 
 # playwright

--- a/apps/web/src/components/Shared/IFramely/index.tsx
+++ b/apps/web/src/components/Shared/IFramely/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
-import { IFRAMELY_URL } from 'data/constants';
+import { IFRAMELY_WORKER_URL } from 'data/constants';
 import type { FC } from 'react';
 import { useEffect } from 'react';
 
@@ -24,9 +24,9 @@ const IFramely: FC<IFramelyProps> = ({ url }) => {
     [url],
     () =>
       axios({
-        url: IFRAMELY_URL,
+        url: IFRAMELY_WORKER_URL,
         params: { url }
-      }).then((res) => res.data),
+      }).then((res) => res.data.iframely),
     { enabled: Boolean(url) }
   );
 

--- a/packages/data/constants.ts
+++ b/packages/data/constants.ts
@@ -64,7 +64,6 @@ export const IPFS_GATEWAY = 'https://gateway.ipfscdn.io/ipfs/';
 export const ARWEAVE_GATEWAY = 'https://arweave.net/';
 export const EVER_API = 'https://endpoint.4everland.co';
 export const DEFAULT_OG = `${STATIC_IMAGES_URL}/og/logo.jpeg`;
-export const IFRAMELY_URL = 'https://iframely.lenster.xyz/iframely';
 
 // Workers
 export const USER_CONTENT_URL = 'https://user-content.lenster.xyz';
@@ -80,7 +79,12 @@ export const FRESHDESK_WORKER_URL = IS_PRODUCTION
 export const SNAPSHOR_RELAY_WORKER_URL = IS_PRODUCTION
   ? 'https://snapshot-relay.lenster.xyz'
   : 'http://localhost:8085';
-export const ENS_RESOLVER_WORKER_URL = 'https://ens-resolver.lenster.xyz';
+export const ENS_RESOLVER_WORKER_URL = IS_PRODUCTION
+  ? 'https://ens-resolver.lenster.xyz'
+  : 'http://localhost:8086';
+export const IFRAMELY_WORKER_URL = IS_PRODUCTION
+  ? 'https://iframely.lenster.xyz'
+  : 'http://localhost:8087';
 
 // Tokens / Keys
 export const ALCHEMY_KEY = '7jxlM7yIx-aJXDivcEZxsLFFRKQS6-ue';

--- a/packages/workers/iframely/.dev.vars.example
+++ b/packages/workers/iframely/.dev.vars.example
@@ -1,0 +1,1 @@
+IFRAMELY_API_KEY=""

--- a/packages/workers/iframely/.eslintrc.js
+++ b/packages/workers/iframely/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['weblint'],
+  rules: {
+    'import/no-anonymous-default-export': 'off'
+  },
+  ignorePatterns: ['generated.ts']
+};

--- a/packages/workers/iframely/README.md
+++ b/packages/workers/iframely/README.md
@@ -1,0 +1,1 @@
+# IFramely worker

--- a/packages/workers/iframely/package.json
+++ b/packages/workers/iframely/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@workers/iframely",
+  "version": "0.0.0",
+  "private": true,
+  "license": "GPL-3.0",
+  "scripts": {
+    "dev": "wrangler dev --port 8086 --local",
+    "start": "pnpm dev",
+    "worker:deploy": "wrangler publish",
+    "typecheck": "tsc --pretty",
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --fix --ext .ts",
+    "prettier": "prettier --check \"**/*.{js,ts,tsx,md}\"  --cache",
+    "prettier:fix": "prettier --write \"**/*.{js,ts,tsx,md}\"  --cache"
+  },
+  "dependencies": {
+    "itty-router": "4.0.0-next.46",
+    "lib": "workspace:*"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20230518.0",
+    "eslint-config-weblint": "workspace:*",
+    "tsconfig": "workspace:*",
+    "typescript": "^5.0.4",
+    "wrangler": "^3.0.1"
+  }
+}

--- a/packages/workers/iframely/package.json
+++ b/packages/workers/iframely/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "wrangler dev --port 8086 --local",
+    "dev": "wrangler dev --port 8086",
     "start": "pnpm dev",
     "worker:deploy": "wrangler publish",
     "typecheck": "tsc --pretty",

--- a/packages/workers/iframely/package.json
+++ b/packages/workers/iframely/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "wrangler dev --port 8086",
+    "dev": "wrangler dev --port 8087 --local",
     "start": "pnpm dev",
     "worker:deploy": "wrangler publish",
     "typecheck": "tsc --pretty",

--- a/packages/workers/iframely/src/handlers/getIframely.ts
+++ b/packages/workers/iframely/src/handlers/getIframely.ts
@@ -1,7 +1,18 @@
+import type { IRequest } from 'itty-router';
+
 import type { Env } from '../types';
 
-export default async (url: string, env: Env) => {
+export default async (request: IRequest, env: Env) => {
+  console.log(request.query);
   try {
+    const url = request.query.url as string;
+
+    if (!url) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Missing URL' })
+      );
+    }
+
     const decodedUrl = decodeURIComponent(url);
 
     const response = await fetch(
@@ -29,7 +40,8 @@ export default async (url: string, env: Env) => {
           success: true,
           cached: true,
           key,
-          data: await responseBody.json()
+          decodedUrl,
+          iframely: await responseBody.json()
         })
       );
     }
@@ -37,7 +49,7 @@ export default async (url: string, env: Env) => {
     await env.LENSTER_IFRAMELY.put(key, JSON.stringify(data));
 
     return new Response(
-      JSON.stringify({ success: true, cached: false, key, data })
+      JSON.stringify({ success: true, cached: false, key, iframely: data })
     );
   } catch (error) {
     console.error('Failed to get iframely data', error);

--- a/packages/workers/iframely/src/handlers/getIframely.ts
+++ b/packages/workers/iframely/src/handlers/getIframely.ts
@@ -1,0 +1,17 @@
+export default async (url: string) => {
+  try {
+    const response = new Response(
+      JSON.stringify({ success: true, poll: 'gm' })
+    );
+
+    // Disable caching because the poll data is dynamic and changes frequently because of live polling.
+    response.headers.set('Cache-Control', 'no-store');
+
+    return response;
+  } catch (error) {
+    console.error('Failed to get proposal', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Something went wrong!' })
+    );
+  }
+};

--- a/packages/workers/iframely/src/handlers/getIframely.ts
+++ b/packages/workers/iframely/src/handlers/getIframely.ts
@@ -22,7 +22,6 @@ export default async (url: string, env: Env) => {
       const headers = new Headers();
       object.writeHttpMetadata(headers);
       headers.set('etag', object.httpEtag);
-
       const responseBody = new Response(object.body, { headers });
 
       return new Response(

--- a/packages/workers/iframely/src/handlers/getIframely.ts
+++ b/packages/workers/iframely/src/handlers/getIframely.ts
@@ -19,13 +19,27 @@ export default async (url: string, env: Env) => {
     const object = await env.LENSTER_IFRAMELY.get(key);
 
     if (object) {
+      const headers = new Headers();
+      object.writeHttpMetadata(headers);
+      headers.set('etag', object.httpEtag);
+
+      const responseBody = new Response(object.body, { headers });
+
       return new Response(
-        JSON.stringify({ success: true, fromR2: true, data: object.body })
+        JSON.stringify({
+          success: true,
+          cached: true,
+          key,
+          data: await responseBody.json()
+        })
       );
     }
+
     await env.LENSTER_IFRAMELY.put(key, JSON.stringify(data));
 
-    return new Response(JSON.stringify({ success: true, data }));
+    return new Response(
+      JSON.stringify({ success: true, cached: false, key, data })
+    );
   } catch (error) {
     console.error('Failed to get iframely data', error);
     return new Response(

--- a/packages/workers/iframely/src/handlers/getIframely.ts
+++ b/packages/workers/iframely/src/handlers/getIframely.ts
@@ -14,7 +14,6 @@ export default async (request: IRequest, env: Env) => {
     }
 
     const decodedUrl = decodeURIComponent(url);
-
     const response = await fetch(
       `https://iframely.lenster.xyz/iframely?url=${decodedUrl}`
     );
@@ -24,9 +23,7 @@ export default async (request: IRequest, env: Env) => {
     const key = [...new Uint8Array(digest)]
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');
-
     const data = await response.json();
-
     const object = await env.LENSTER_IFRAMELY.get(key);
 
     if (object) {
@@ -40,7 +37,6 @@ export default async (request: IRequest, env: Env) => {
           success: true,
           cached: true,
           key,
-          decodedUrl,
           iframely: await responseBody.json()
         })
       );

--- a/packages/workers/iframely/src/index.ts
+++ b/packages/workers/iframely/src/index.ts
@@ -11,8 +11,7 @@ const { preflight, corsify } = createCors({
 const router = Router();
 
 router.all('*', preflight);
-router.get('/', () => new Response('IFramely Proxy'));
-router.get('/:url', ({ params }, env) => getIframely(params.url, env));
+router.get('/', getIframely);
 
 const routerHandleStack = (request: Request, env: Env, ctx: ExecutionContext) =>
   router.handle(request, env, ctx).then(json);

--- a/packages/workers/iframely/src/index.ts
+++ b/packages/workers/iframely/src/index.ts
@@ -12,7 +12,7 @@ const router = Router();
 
 router.all('*', preflight);
 router.get('/', () => new Response('IFramely Proxy'));
-router.get('/:url', ({ params }) => getIframely(params.url));
+router.get('/:url', ({ params }, env) => getIframely(params.url, env));
 
 const routerHandleStack = (request: Request, env: Env, ctx: ExecutionContext) =>
   router.handle(request, env, ctx).then(json);

--- a/packages/workers/iframely/src/index.ts
+++ b/packages/workers/iframely/src/index.ts
@@ -1,0 +1,36 @@
+import { createCors, error, json, Router } from 'itty-router';
+
+import getIframely from './handlers/getIframely';
+import type { Env } from './types';
+
+const { preflight, corsify } = createCors({
+  origins: ['*'],
+  methods: ['HEAD', 'GET']
+});
+
+const router = Router();
+
+router.all('*', preflight);
+router.get('/', () => new Response('IFramely Proxy'));
+router.get('/:url', ({ params }) => getIframely(params.url));
+
+const routerHandleStack = (request: Request, env: Env, ctx: ExecutionContext) =>
+  router.handle(request, env, ctx).then(json);
+
+const handleFetch = async (
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext
+) => {
+  try {
+    return await routerHandleStack(request, env, ctx);
+  } catch (error_) {
+    console.error('Failed to handle request', error_);
+    return error(500);
+  }
+};
+
+export default {
+  fetch: (request: Request, env: Env, context: ExecutionContext) =>
+    handleFetch(request, env, context).then(corsify)
+};

--- a/packages/workers/iframely/src/types.ts
+++ b/packages/workers/iframely/src/types.ts
@@ -1,0 +1,3 @@
+export interface Env {
+  IFRAMELY_API_KEY: string;
+}

--- a/packages/workers/iframely/src/types.ts
+++ b/packages/workers/iframely/src/types.ts
@@ -1,3 +1,4 @@
 export interface Env {
   IFRAMELY_API_KEY: string;
+  LENSTER_IFRAMELY: R2Bucket;
 }

--- a/packages/workers/iframely/tsconfig.json
+++ b/packages/workers/iframely/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "tsconfig/base.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types"]
+  }
+}

--- a/packages/workers/iframely/wrangler.toml
+++ b/packages/workers/iframely/wrangler.toml
@@ -1,0 +1,11 @@
+name = "iframely"
+main = "src/index.ts"
+compatibility_date = "2023-01-25"
+keep_vars = true
+
+routes = [
+	{ pattern = "iframely.lenster.xyz", custom_domain = true }
+]
+
+[env.production.vars]
+IFRAMELY_API_KEY = ""

--- a/packages/workers/iframely/wrangler.toml
+++ b/packages/workers/iframely/wrangler.toml
@@ -7,5 +7,10 @@ routes = [
 	{ pattern = "iframely.lenster.xyz", custom_domain = true }
 ]
 
+[[r2_buckets]]
+binding = 'LENSTER_IFRAMELY'
+bucket_name = 'lenster-iframely'
+preview_bucket_name = 'lenster-iframely'
+
 [env.production.vars]
 IFRAMELY_API_KEY = ""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -609,6 +609,31 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
 
+  packages/workers/iframely:
+    dependencies:
+      itty-router:
+        specifier: 4.0.0-next.46
+        version: 4.0.0-next.46
+      lib:
+        specifier: workspace:*
+        version: link:../../lib
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20230518.0
+        version: 4.20230518.0
+      eslint-config-weblint:
+        specifier: workspace:*
+        version: link:../../eslint-config-weblint
+      tsconfig:
+        specifier: workspace:*
+        version: link:../../tsconfig
+      typescript:
+        specifier: ^5.0.4
+        version: 5.0.4
+      wrangler:
+        specifier: ^3.0.1
+        version: 3.0.1
+
   packages/workers/metadata:
     dependencies:
       bundlr:


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ceb987d</samp>

This pull request adds a new IFramely worker package to the monorepo, which provides a Cloudflare Worker that fetches rich media embeds for URLs using the IFramely API. The package includes the source code, configuration files, documentation, and dependencies for the worker. The package also requires an environment variable `IFRAMELY_API_KEY` to be set with a valid API key.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ceb987d</samp>

*  Add a new IFramely worker package to fetch rich media embeds for URLs using the IFramely API (F1-F8)

## Emoji

<!--
copilot:emoji
-->

📄🚀🛠️

<!--
1.  📄 for adding new files, such as the example, README, handler, main, types, and config files.
2.  🚀 for adding a new feature, such as the IFramely API integration and the Cloudflare Workers deployment.
3.  🛠️ for adding configuration and tooling, such as the ESLint, TypeScript, and wrangler settings.
-->
