### PR TITLE
feat: add lens open graph standards

### DIFF
--- a/apps/prerender/src/components/Shared/Tags.tsx
+++ b/apps/prerender/src/components/Shared/Tags.tsx
@@ -45,12 +45,12 @@ const Tags: FC<TagsProps> = ({
       <meta property="twitter:image:width" content="400" />
       <meta property="twitter:image:height" content="400" />
       <meta property="twitter:creator" content="lensterxyz" />
-      {/* Lenster OG */}
-      <meta property="lenster:card" content={cardType} />
-      <meta property="lenster:site" content="Lenster" />
-      <meta property="lenster:title" content={title} />
-      <meta property="lenster:description" content={description} />
-      <meta property="lenster:image" content={image} />
+      {/* Lens OG */}
+      <meta property="lens:card" content={cardType} />
+      <meta property="lens:site" content="Lenster" />
+      <meta property="lens:title" content={title} />
+      <meta property="lens:description" content={description} />
+      <meta property="lens:image" content={image} />
       {publishedTime ? (
         <meta property="article:published_time" content={publishedTime} />
       ) : null}

--- a/packages/workers/oembed/src/helper/meta/getDescription.ts
+++ b/packages/workers/oembed/src/helper/meta/getDescription.ts
@@ -5,11 +5,14 @@ const getDescription = (document: Document): string | null => {
   const twitter =
     document.querySelector('meta[name="twitter:description"]') ||
     document.querySelector('meta[property="twitter:description"]');
+  const lenster = document.querySelector('meta[name="lenster:description"]');
 
   if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
+  } else if (lenster) {
+    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getDescription.ts
+++ b/packages/workers/oembed/src/helper/meta/getDescription.ts
@@ -1,18 +1,22 @@
 import type { Document } from 'linkedom';
 
 const getDescription = (document: Document): string | null => {
-  const og = document.querySelector('meta[property="og:description"]');
+  const lens =
+    document.querySelector('meta[name="lens:description"]') ||
+    document.querySelector('meta[property="lens:description"]');
+  const og =
+    document.querySelector('meta[name="og:description"]') ||
+    document.querySelector('meta[property="og:description"]');
   const twitter =
     document.querySelector('meta[name="twitter:description"]') ||
     document.querySelector('meta[property="twitter:description"]');
-  const lenster = document.querySelector('meta[name="lenster:description"]');
 
-  if (og) {
+  if (lens) {
+    return lens.getAttribute('content');
+  } else if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
-  } else if (lenster) {
-    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getEmbedUrl.ts
+++ b/packages/workers/oembed/src/helper/meta/getEmbedUrl.ts
@@ -1,20 +1,24 @@
 import type { Document } from 'linkedom';
 
 const getEmbedUrl = (document: Document): string | null => {
+  const lens =
+    document.querySelector('meta[name="lens:player"]') ||
+    document.querySelector('meta[property="lens:player"]');
   const og =
+    document.querySelector('meta[name="og:video:url"]') ||
+    document.querySelector('meta[name="og:video:secure_url"]') ||
     document.querySelector('meta[property="og:video:url"]') ||
     document.querySelector('meta[property="og:video:secure_url"]');
   const twitter =
     document.querySelector('meta[name="twitter:player"]') ||
     document.querySelector('meta[property="twitter:player"]');
-  const lenster = document.querySelector('meta[name="lenster:player"]');
 
-  if (og) {
+  if (lens) {
+    return lens.getAttribute('content');
+  } else if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
-  } else if (lenster) {
-    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getEmbedUrl.ts
+++ b/packages/workers/oembed/src/helper/meta/getEmbedUrl.ts
@@ -7,11 +7,14 @@ const getEmbedUrl = (document: Document): string | null => {
   const twitter =
     document.querySelector('meta[name="twitter:player"]') ||
     document.querySelector('meta[property="twitter:player"]');
+  const lenster = document.querySelector('meta[name="lenster:player"]');
 
   if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
+  } else if (lenster) {
+    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getImage.ts
+++ b/packages/workers/oembed/src/helper/meta/getImage.ts
@@ -7,11 +7,14 @@ const getImage = (document: Document): string | null => {
     document.querySelector('meta[name="twitter:image:src"]') ||
     document.querySelector('meta[property="twitter:image"]') ||
     document.querySelector('meta[property="twitter:image:src"]');
+  const lenster = document.querySelector('meta[name="lenster:image"]');
 
   if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
+  } else if (lenster) {
+    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getImage.ts
+++ b/packages/workers/oembed/src/helper/meta/getImage.ts
@@ -1,20 +1,24 @@
 import type { Document } from 'linkedom';
 
 const getImage = (document: Document): string | null => {
-  const og = document.querySelector('meta[property="og:image"]');
+  const lens =
+    document.querySelector('meta[name="lens:image"]') ||
+    document.querySelector('meta[property="lens:image"]');
+  const og =
+    document.querySelector('meta[name="og:image"]') ||
+    document.querySelector('meta[property="og:image"]');
   const twitter =
     document.querySelector('meta[name="twitter:image"]') ||
     document.querySelector('meta[name="twitter:image:src"]') ||
     document.querySelector('meta[property="twitter:image"]') ||
     document.querySelector('meta[property="twitter:image:src"]');
-  const lenster = document.querySelector('meta[name="lenster:image"]');
 
-  if (og) {
+  if (lens) {
+    return lens.getAttribute('content');
+  } else if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
-  } else if (lenster) {
-    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getIsLarge.ts
+++ b/packages/workers/oembed/src/helper/meta/getIsLarge.ts
@@ -1,18 +1,20 @@
 import type { Document } from 'linkedom';
 
 const getIsLarge = (document: Document): boolean | null => {
+  const lens =
+    document.querySelector('meta[name="lens:card"]') ||
+    document.querySelector('meta[property="lens:card"]');
   const twitter =
     document.querySelector('meta[name="twitter:card"]') ||
     document.querySelector('meta[property="twitter:card"]');
-  const lenster = document.querySelector('meta[name="lenster:card"]');
 
   const largeTypes = ['summary_large_image', 'player'];
 
-  if (twitter) {
-    const card = twitter.getAttribute('content') || '';
+  if (lens) {
+    const card = lens.getAttribute('content') || '';
     return largeTypes.includes(card);
-  } else if (lenster) {
-    const card = lenster.getAttribute('content') || '';
+  } else if (twitter) {
+    const card = twitter.getAttribute('content') || '';
     return largeTypes.includes(card);
   }
 

--- a/packages/workers/oembed/src/helper/meta/getIsLarge.ts
+++ b/packages/workers/oembed/src/helper/meta/getIsLarge.ts
@@ -4,11 +4,15 @@ const getIsLarge = (document: Document): boolean | null => {
   const twitter =
     document.querySelector('meta[name="twitter:card"]') ||
     document.querySelector('meta[property="twitter:card"]');
+  const lenster = document.querySelector('meta[name="lenster:card"]');
 
   const largeTypes = ['summary_large_image', 'player'];
 
   if (twitter) {
     const card = twitter.getAttribute('content') || '';
+    return largeTypes.includes(card);
+  } else if (lenster) {
+    const card = lenster.getAttribute('content') || '';
     return largeTypes.includes(card);
   }
 

--- a/packages/workers/oembed/src/helper/meta/getSite.ts
+++ b/packages/workers/oembed/src/helper/meta/getSite.ts
@@ -1,18 +1,22 @@
 import type { Document } from 'linkedom';
 
 const getSite = (document: Document): string | null => {
-  const og = document.querySelector('meta[property="og:site_name"]');
+  const lens =
+    document.querySelector('meta[name="lens:site"]') ||
+    document.querySelector('meta[property="lens:site"]');
+  const og =
+    document.querySelector('meta[name="og:site_name"]') ||
+    document.querySelector('meta[property="og:site_name"]');
   const twitter =
     document.querySelector('meta[name="twitter:site"]') ||
     document.querySelector('meta[property="twitter:site"]');
-  const lenster = document.querySelector('meta[name="lenster:site"]');
 
-  if (og) {
+  if (lens) {
+    return lens.getAttribute('content');
+  } else if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
-  } else if (lenster) {
-    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getSite.ts
+++ b/packages/workers/oembed/src/helper/meta/getSite.ts
@@ -5,11 +5,14 @@ const getSite = (document: Document): string | null => {
   const twitter =
     document.querySelector('meta[name="twitter:site"]') ||
     document.querySelector('meta[property="twitter:site"]');
+  const lenster = document.querySelector('meta[name="lenster:site"]');
 
   if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
+  } else if (lenster) {
+    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getTitle.ts
+++ b/packages/workers/oembed/src/helper/meta/getTitle.ts
@@ -1,18 +1,22 @@
 import type { Document } from 'linkedom';
 
 const getTitle = (document: Document): string | null => {
-  const og = document.querySelector('meta[property="og:title"]');
+  const lens =
+    document.querySelector('meta[name="lens:title"]') ||
+    document.querySelector('meta[property="lens:title"]');
+  const og =
+    document.querySelector('meta[name="og:title"]') ||
+    document.querySelector('meta[property="og:title"]');
   const twitter =
     document.querySelector('meta[name="twitter:title"]') ||
     document.querySelector('meta[property="twitter:title"]');
-  const lenster = document.querySelector('meta[name="lenster:title"]');
 
-  if (og) {
+  if (lens) {
+    return lens.getAttribute('content');
+  } else if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
-  } else if (lenster) {
-    return lenster.getAttribute('content');
   }
 
   return null;

--- a/packages/workers/oembed/src/helper/meta/getTitle.ts
+++ b/packages/workers/oembed/src/helper/meta/getTitle.ts
@@ -5,11 +5,14 @@ const getTitle = (document: Document): string | null => {
   const twitter =
     document.querySelector('meta[name="twitter:title"]') ||
     document.querySelector('meta[property="twitter:title"]');
+  const lenster = document.querySelector('meta[name="lenster:title"]');
 
   if (og) {
     return og.getAttribute('content');
   } else if (twitter) {
     return twitter.getAttribute('content');
+  } else if (lenster) {
+    return lenster.getAttribute('content');
   }
 
   return null;


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0168748</samp>

This pull request adds support for custom `lenster` meta tags in the oEmbed worker. These meta tags allow lenster pages to customize the oEmbed response with their own title, description, image, embed URL, site name, and card type. The pull request modifies the `get*` functions in the `packages/workers/oembed/src/helper/meta` folder to query and use these meta tags.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0168748</samp>

*  Add support for custom meta tags for lenster pages in the oEmbed response ([link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-d8aff685e6b66f92958a631cfd1566f77d8dca04f85662a87f1b3b2222189731R8),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-d8aff685e6b66f92958a631cfd1566f77d8dca04f85662a87f1b3b2222189731R14-R15),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-4fb7a1823838d5a42ff11365217a68a63b909079274fb92b62a1d86b1a69b2a0R10),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-4fb7a1823838d5a42ff11365217a68a63b909079274fb92b62a1d86b1a69b2a0R16-R17),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-d11abf162ae1410093efe80e0656c5a900e75ae8eafb9ac70ac40fd83d532eceR10),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-d11abf162ae1410093efe80e0656c5a900e75ae8eafb9ac70ac40fd83d532eceR16-R17),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-e71e319f64216ed439162bdf2ecd3f829d125fc0f2be6785504f88cf951ba126R7),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-e71e319f64216ed439162bdf2ecd3f829d125fc0f2be6785504f88cf951ba126R14-R16),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-c9b81692de4adb0a910beff895c8bbb665b17b6879b54f9c27ce20ded72b9be2R8),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-c9b81692de4adb0a910beff895c8bbb665b17b6879b54f9c27ce20ded72b9be2R14-R15),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-cb235d15eac50305e8e843894e5800876581822c3b3efc98e9facca480062662R8),[link](https://github.com/lensterxyz/lenster/pull/2948/files?diff=unified&w=0#diff-cb235d15eac50305e8e843894e5800876581822c3b3efc98e9facca480062662R14-R15))

## Emoji

<!--
copilot:emoji
-->

🏷️🎞️🖼️

<!--
1.  🏷️ - This emoji represents the addition of custom meta tags for lenster pages, which can be seen as labels or tags for the oEmbed response.
2. 🎞️ - This emoji represents the addition of custom embed URLs for lenster pages, which can be seen as film strips or videos for the oEmbed response.
3. 🖼️ - This emoji represents the addition of custom image URLs for lenster pages, which can be seen as pictures or frames for the oEmbed response.
-->
