### PR TITLE
chore: remove deprecated --local command in wrangler cli

### DIFF
--- a/packages/workers/ens-resolver/package.json
+++ b/packages/workers/ens-resolver/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "wrangler dev --port 8086 --local",
+    "dev": "wrangler dev --port 8086",
     "worker:deploy": "wrangler deploy",
     "typecheck": "tsc --pretty",
     "lint": "eslint . --ext .ts",

--- a/packages/workers/freshdesk/package.json
+++ b/packages/workers/freshdesk/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "wrangler dev --port 8084 --local",
+    "dev": "wrangler dev --port 8084",
     "worker:deploy": "wrangler deploy",
     "typecheck": "tsc --pretty",
     "lint": "eslint . --ext .ts",

--- a/packages/workers/metadata/package.json
+++ b/packages/workers/metadata/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "wrangler dev --port 8083 --local",
+    "dev": "wrangler dev --port 8083",
     "start": "pnpm dev",
     "worker:deploy": "wrangler deploy",
     "typecheck": "tsc --pretty",

--- a/packages/workers/oembed/package.json
+++ b/packages/workers/oembed/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "wrangler dev --port 8087 --local",
+    "dev": "wrangler dev --port 8087",
     "start": "pnpm dev",
     "worker:deploy": "wrangler deploy",
     "typecheck": "tsc --pretty",

--- a/packages/workers/snapshot-relay/package.json
+++ b/packages/workers/snapshot-relay/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "wrangler dev --port 8085 --local",
+    "dev": "wrangler dev --port 8085",
     "start": "pnpm dev",
     "worker:deploy": "wrangler deploy",
     "codegen": "graphql-codegen",

--- a/packages/workers/sts-generator/package.json
+++ b/packages/workers/sts-generator/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "GPL-3.0",
   "scripts": {
-    "dev": "wrangler dev --port 8082 --local",
+    "dev": "wrangler dev --port 8082",
     "worker:deploy": "wrangler deploy",
     "typecheck": "tsc --pretty",
     "lint": "eslint . --ext .ts",


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7781133</samp>

Removed the `--local` flag from the `dev` scripts in all the worker packages. This flag is unnecessary and may cause problems with the Cloudflare Workers environment variables.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7781133</samp>

* Remove the `--local` flag from the `dev` script in six worker packages to avoid errors with Cloudflare Workers environment variables and align with the other packages ([link](https://github.com/lensterxyz/lenster/pull/2949/files?diff=unified&w=0#diff-81b512c61d0f2313dfb42f88dfb5a205ef0f583a353fe3b1153e29caca87a24dL7-R7), [link](https://github.com/lensterxyz/lenster/pull/2949/files?diff=unified&w=0#diff-8c982851af5fabc8ad3cfe13d06f41067e5dcd0fc15efc16632512636ac55737L7-R7), [link](https://github.com/lensterxyz/lenster/pull/2949/files?diff=unified&w=0#diff-fe9f7f73c59cba6fc4d588090077cd14ed6b853300be17ed13a1d045beafbc9cL7-R7), [link](https://github.com/lensterxyz/lenster/pull/2949/files?diff=unified&w=0#diff-07adc5b8ee6d78359ba934d4ab323b7382e1f42091079350b365f99d2964774aL7-R7), [link](https://github.com/lensterxyz/lenster/pull/2949/files?diff=unified&w=0#diff-190bb47eeddf0230d5d8ffdab97e4336f1b2e254b608c0818fa4478c44686a74L8-R8), [link](https://github.com/lensterxyz/lenster/pull/2949/files?diff=unified&w=0#diff-ac247611b89638693301f44640877cb2abb599a619665a9bd84591deb9ae5520L7-R7))

## Emoji

<!--
copilot:emoji
-->

🚫🛠️🌐

<!--
1.  🚫 - This emoji can be used to indicate that something was removed or disabled, such as the `--local` flag.
2.  🛠️ - This emoji can be used to indicate that something was fixed or improved, such as the alignment of the worker packages and the avoidance of potential errors.
3.  🌐 - This emoji can be used to indicate that something was related to the web or the Cloudflare Workers environment, such as the `wrangler dev` command.
-->
