### PR TITLE
fix: oembed test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prettier:fix": "turbo run prettier:fix --parallel",
     "prepare": "husky install",
     "test:dev": "turbo run test:dev",
-    "test:e2e": "start-server-and-test start '4783|4784|8083|8085' test:dev",
+    "test:e2e": "start-server-and-test start '4783|4784|8083|8085|8087' test:dev",
     "test:nightly": "turbo run test:nightly"
   },
   "devDependencies": {

--- a/tests/apps/web/publication/attachment.spec.ts
+++ b/tests/apps/web/publication/attachment.spec.ts
@@ -52,7 +52,7 @@ test.describe('Publication attachments', () => {
     // );
   });
 
-  test.describe.skip('Publication oembed', () => {
+  test.describe('Publication oembed', () => {
     test('should have normal oembed', async ({ page }) => {
       const publicationId = '0x0d-0x0375';
       await page.goto(`${WEB_BASE_URL}/posts/${publicationId}`);
@@ -62,7 +62,9 @@ test.describe('Publication attachments', () => {
         .getByTestId(
           'normal-oembed-https://testflight.apple.com/join/U9YkOlOy'
         );
-      await expect(publicationOembed).toBeVisible();
+      await expect(publicationOembed).toContainText(
+        'Join the Uniswap Wallet beta'
+      );
     });
 
     test('should have rich oembed', async ({ page }) => {


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2eb9d1f</samp>

Improved and enabled oembed testing for publications. Added a check for `oembed.content` in `attachment.spec.ts`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2eb9d1f</samp>

* Enable and verify oembed feature for publications
  - Remove `test.describe.skip` to run test suite for publication oembed ([link](https://github.com/lensterxyz/lenster/pull/2959/files?diff=unified&w=0#diff-a7c7d17bd29a8e89030c9826dfea4fa65908df8b31f7d316cca0daa61f626e7aL55-R55))
  - Add assertion to check oembed element text for a specific publication ([link](https://github.com/lensterxyz/lenster/pull/2959/files?diff=unified&w=0#diff-a7c7d17bd29a8e89030c9826dfea4fa65908df8b31f7d316cca0daa61f626e7aL65-R67))

## Emoji

<!--
copilot:emoji
-->

🧪✅📰

<!--
1.  🧪 - This emoji represents testing or experimentation, and can be used to indicate that the test suite was enabled and improved for publication oembed.
2.  ✅ - This emoji represents success or completion, and can be used to indicate that an assertion was added to check the oembed content for a publication.
3.  📰 - This emoji represents news or media, and can be used to indicate that the changes relate to publication oembed, which is a way of embedding media content from a publication.
-->
