### PR TITLE
feat: add oembed worker test cases

### DIFF
--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -8,3 +8,6 @@ export const PRERENDER_BASE_URL = isNightly
 export const METADATA_BASE_URL = isNightly
   ? 'https://metadata.lenster.xyz'
   : 'http://localhost:8083';
+export const OEMBED_BASE_URL = isNightly
+  ? 'https://oembed.lenster.xyz'
+  : 'http://localhost:8087';

--- a/tests/packages/workers/oembed/image.spec.ts
+++ b/tests/packages/workers/oembed/image.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+import { OEMBED_BASE_URL } from 'test/constants';
+
+test('should render image if url is provided', async ({ request }) => {
+  const getImage = request.get(`${OEMBED_BASE_URL}/image`, {
+    params: {
+      hash: 'aHR0cHM6Ly9kaXNjb3JkLmNvbS9hc3NldHMvNjUyZjQwNDI3ZTFmNTE4NmFkNTQ4MzYwNzQ4OTgyNzkucG5n',
+      transform: 'large'
+    }
+  });
+
+  const response = await (await getImage).body();
+  expect(response).toBeTruthy();
+});

--- a/tests/packages/workers/oembed/oembed.spec.ts
+++ b/tests/packages/workers/oembed/oembed.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test';
+import { OEMBED_BASE_URL } from 'test/constants';
+
+test('should return false if payload is not provided', async ({ request }) => {
+  const getOembed = request.get(OEMBED_BASE_URL, {});
+  const response = await (await getOembed).json();
+
+  expect(response.success).toBeFalsy();
+});
+
+test('should return valid oembed response if url is provided', async ({
+  request
+}) => {
+  const url = 'https://github.com/lensterxyz/lenster';
+  const getOembed = request.get(OEMBED_BASE_URL, { params: { url } });
+  const response = await (await getOembed).json();
+
+  expect(response.success).toBeTruthy();
+  expect(response.oembed.url).toBe(url);
+  expect(response.oembed.title).toContain('GitHub - lensterxyz/lenster');
+  expect(response.oembed.description).toContain(
+    'Lenster is a decentralized and permissionless social media app'
+  );
+  expect(response.oembed.image).toContain('transform=large');
+  expect(response.oembed.site).toBe('GitHub');
+  expect(response.oembed.isLarge).toBeTruthy();
+  expect(response.oembed.html).toBeNull();
+});
+
+test('should return valid oembed response if url supports iframe is provided', async ({
+  request
+}) => {
+  const url = 'https://www.youtube.com/watch?v=H5v3kku4y6Q';
+  const getOembed = request.get(OEMBED_BASE_URL, { params: { url } });
+  const response = await (await getOembed).json();
+
+  expect(response.success).toBeTruthy();
+  expect(response.oembed.html).toContain(
+    'https://www.youtube.com/embed/H5v3kku4y6Q'
+  );
+});


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5ba3903</samp>

This pull request adds tests for the oembed service using Playwright. It also defines a constant for the oembed service base URL in `tests/constants.ts` based on the environment.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5ba3903</samp>

* Add a constant for the oembed service base URL in `tests/constants.ts` ([link](https://github.com/lensterxyz/lenster/pull/2960/files?diff=unified&w=0#diff-7dabe1ac54eca6fa517ae515d90b772ce087aff5e46bac0687c505b298a58e70R11-R13))
* Add tests for the oembed service in `tests/packages/workers/oembed/oembed.spec.ts` ([link](https://github.com/lensterxyz/lenster/pull/2960/files?diff=unified&w=0#diff-8f97db0e07bfbf75489697e649f83706a10d7067bf068e8f0ac855ebbfe293d6R1-R41))

## Emoji

<!--
copilot:emoji
-->

🌐🧪🎥

<!--
1.  🌐 - This emoji represents the addition of the `OEMBED_BASE_URL` constant, which depends on the environment and is related to the web or the internet.
2.  🧪 - This emoji represents the addition of the tests for the oembed service, which use the Playwright testing framework and verify the functionality of the service.
3.  🎥 - This emoji represents the specific test for the YouTube URL that supports iframe, which is related to video or media.
-->
