### PR TITLE
refactor: migrate sts-generator to itty router

### DIFF
--- a/packages/workers/ens-resolver/package.json
+++ b/packages/workers/ens-resolver/package.json
@@ -13,7 +13,7 @@
     "worker:deploy": "wrangler deploy"
   },
   "dependencies": {
-    "itty-router": "4.0.9",
+    "itty-router": "^4.0.9",
     "viem": "^0.3.19"
   },
   "devDependencies": {

--- a/packages/workers/leafwatch/.eslintrc.js
+++ b/packages/workers/leafwatch/.eslintrc.js
@@ -3,6 +3,5 @@ module.exports = {
   extends: ['node'],
   rules: {
     'import/no-anonymous-default-export': 'off'
-  },
-  ignorePatterns: ['generated.ts']
+  }
 };

--- a/packages/workers/leafwatch/package.json
+++ b/packages/workers/leafwatch/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@sagi.io/workers-jwt": "^0.0.23",
-    "itty-router": "4.0.9"
+    "itty-router": "^4.0.9"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",

--- a/packages/workers/oembed/.eslintrc.js
+++ b/packages/workers/oembed/.eslintrc.js
@@ -3,6 +3,5 @@ module.exports = {
   extends: ['node'],
   rules: {
     'import/no-anonymous-default-export': 'off'
-  },
-  ignorePatterns: ['generated.ts']
+  }
 };

--- a/packages/workers/oembed/package.json
+++ b/packages/workers/oembed/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@cfworker/base64url": "^1.12.5",
     "@lenster/lib": "workspace:*",
-    "itty-router": "4.0.9",
+    "itty-router": "^4.0.9",
     "linkedom": "^0.14.26"
   },
   "devDependencies": {

--- a/packages/workers/snapshot-relay/package.json
+++ b/packages/workers/snapshot-relay/package.json
@@ -19,7 +19,7 @@
     "@apollo/client": "^3.7.15",
     "@lenster/lib": "workspace:*",
     "@tsndr/cloudflare-worker-jwt": "^2.2.1",
-    "itty-router": "4.0.9",
+    "itty-router": "^4.0.9",
     "viem": "^0.3.19"
   },
   "devDependencies": {

--- a/packages/workers/sts-generator/package.json
+++ b/packages/workers/sts-generator/package.json
@@ -13,7 +13,8 @@
     "worker:deploy": "wrangler deploy"
   },
   "dependencies": {
-    "@aws-sdk/client-sts": "^3.342.0"
+    "@aws-sdk/client-sts": "^3.342.0",
+    "itty-router": "^4.0.9"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",

--- a/packages/workers/sts-generator/src/handlers/getStsToken.ts
+++ b/packages/workers/sts-generator/src/handlers/getStsToken.ts
@@ -53,7 +53,7 @@ export default async (request: IRequest, env: Env) => {
       })
     );
   } catch (error) {
-    console.error('Failed to get oembed data', error);
+    console.error('Failed to get STS data', error);
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/sts-generator/src/handlers/getStsToken.ts
+++ b/packages/workers/sts-generator/src/handlers/getStsToken.ts
@@ -1,0 +1,61 @@
+import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
+import type { IRequest } from 'itty-router';
+
+import type { Env } from '../types';
+
+const bucketName = 'lenster-media';
+const everEndpoint = 'https://endpoint.4everland.co';
+
+const params = {
+  DurationSeconds: 900,
+  Policy: `{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "s3:PutObject",
+          "s3:GetObject"
+        ],
+        "Resource": [
+          "arn:aws:s3:::${bucketName}/*"
+        ]
+      }
+    ]
+  }`
+};
+
+export default async (request: IRequest, env: Env) => {
+  try {
+    const accessKeyId = env.EVER_ACCESS_KEY;
+    const secretAccessKey = env.EVER_ACCESS_SECRET;
+
+    const stsClient = new STSClient({
+      endpoint: everEndpoint,
+      region: 'us-west-2',
+      credentials: { accessKeyId, secretAccessKey }
+    });
+
+    const data = await stsClient.send(
+      new AssumeRoleCommand({
+        ...params,
+        RoleArn: undefined,
+        RoleSessionName: undefined
+      })
+    );
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        accessKeyId: data.Credentials?.AccessKeyId,
+        secretAccessKey: data.Credentials?.SecretAccessKey,
+        sessionToken: data.Credentials?.SessionToken
+      })
+    );
+  } catch (error) {
+    console.error('Failed to get oembed data', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Something went wrong!' })
+    );
+  }
+};

--- a/packages/workers/sts-generator/src/index.ts
+++ b/packages/workers/sts-generator/src/index.ts
@@ -1,75 +1,35 @@
-import { AssumeRoleCommand, STSClient } from '@aws-sdk/client-sts';
+import { createCors, error, json, Router } from 'itty-router';
 
-interface EnvType {
-  EVER_ACCESS_KEY: string;
-  EVER_ACCESS_SECRET: string;
-}
+import getStsToken from './handlers/getStsToken';
+import type { Env } from './types';
 
-const headers = {
-  'Access-Control-Allow-Origin': '*',
-  'Content-Type': 'application/json'
-};
-const bucketName = 'lenster-media';
-const everEndpoint = 'https://endpoint.4everland.co';
+const { preflight, corsify } = createCors({
+  origins: ['*'],
+  methods: ['HEAD', 'GET']
+});
 
-const params = {
-  DurationSeconds: 900,
-  Policy: `{
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Effect": "Allow",
-        "Action": [
-          "s3:PutObject",
-          "s3:GetObject"
-        ],
-        "Resource": [
-          "arn:aws:s3:::${bucketName}/*"
-        ]
-      }
-    ]
-  }`
-};
+const router = Router();
 
-async function handleRequest(request: Request, env: EnvType) {
+router.all('*', preflight);
+router.get('/', getStsToken);
+
+const routerHandleStack = (request: Request, env: Env, ctx: ExecutionContext) =>
+  router.handle(request, env, ctx).then(json);
+
+const handleFetch = async (
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext
+) => {
   try {
-    const accessKeyId = env.EVER_ACCESS_KEY;
-    const secretAccessKey = env.EVER_ACCESS_SECRET;
-
-    const stsClient = new STSClient({
-      endpoint: everEndpoint,
-      region: 'us-west-2',
-      credentials: { accessKeyId, secretAccessKey }
-    });
-
-    const data = await stsClient.send(
-      new AssumeRoleCommand({
-        ...params,
-        RoleArn: undefined,
-        RoleSessionName: undefined
-      })
-    );
-
-    return new Response(
-      JSON.stringify({
-        success: true,
-        accessKeyId: data.Credentials?.AccessKeyId,
-        secretAccessKey: data.Credentials?.SecretAccessKey,
-        sessionToken: data.Credentials?.SessionToken
-      }),
-      { headers }
-    );
-  } catch (error) {
-    console.error('Failed to generate STS token', error);
-    return new Response(
-      JSON.stringify({ success: false, message: 'Something went wrong!' }),
-      { headers }
-    );
+    return await routerHandleStack(request, env, ctx);
+  } catch (error_) {
+    console.error('Failed to handle request', error_);
+    return error(500);
   }
-}
+};
 
 export default {
-  async fetch(request: Request, env: EnvType) {
-    return await handleRequest(request, env);
-  }
+  fetch: (request: Request, env: Env, context: ExecutionContext) =>
+    handleFetch(request, env, context).then(corsify)
 };

--- a/packages/workers/sts-generator/src/types.ts
+++ b/packages/workers/sts-generator/src/types.ts
@@ -1,0 +1,4 @@
+export interface Env {
+  EVER_ACCESS_KEY: string;
+  EVER_ACCESS_SECRET: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -756,6 +756,9 @@ importers:
       '@aws-sdk/client-sts':
         specifier: ^3.342.0
         version: 3.342.0
+      itty-router:
+        specifier: 4.0.9
+        version: 4.0.9
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20230518.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -566,7 +566,7 @@ importers:
   packages/workers/ens-resolver:
     dependencies:
       itty-router:
-        specifier: 4.0.9
+        specifier: ^4.0.9
         version: 4.0.9
       viem:
         specifier: ^0.3.19
@@ -612,7 +612,7 @@ importers:
         specifier: ^0.0.23
         version: 0.0.23
       itty-router:
-        specifier: 4.0.9
+        specifier: ^4.0.9
         version: 4.0.9
     devDependencies:
       '@cloudflare/workers-types':
@@ -662,7 +662,7 @@ importers:
         specifier: workspace:*
         version: link:../../lib
       itty-router:
-        specifier: 4.0.9
+        specifier: ^4.0.9
         version: 4.0.9
       linkedom:
         specifier: ^0.14.26
@@ -714,7 +714,7 @@ importers:
         specifier: ^2.2.1
         version: 2.2.1
       itty-router:
-        specifier: 4.0.9
+        specifier: ^4.0.9
         version: 4.0.9
       viem:
         specifier: ^0.3.19
@@ -757,7 +757,7 @@ importers:
         specifier: ^3.342.0
         version: 3.342.0
       itty-router:
-        specifier: 4.0.9
+        specifier: ^4.0.9
         version: 4.0.9
     devDependencies:
       '@cloudflare/workers-types':


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce12ab4</samp>

This pull request updates the `itty-router` dependency to use a caret range in several packages and adds a new `sts-generator` package that uses the `itty-router` library to create a handler for generating STS tokens for accessing 4everland. The pull request also removes some unnecessary `ignorePatterns` properties from the `.eslintrc.js` files.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ce12ab4</samp>

*  Update `itty-router` dependency to use caret range in four packages ([link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-81b512c61d0f2313dfb42f88dfb5a205ef0f583a353fe3b1153e29caca87a24dL16-R16), [link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-d6eceeaa41a110c82b1184a9a83211a40d36be567c021bdb3eb166e3b95af3f0L17-R17), [link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-07adc5b8ee6d78359ba934d4ab323b7382e1f42091079350b365f99d2964774aL19-R19), [link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-190bb47eeddf0230d5d8ffdab97e4336f1b2e254b608c0818fa4478c44686a74L22-R22))
*  Remove unnecessary `ignorePatterns` property from `.eslintrc.js` files in two packages ([link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-b41eeb96e0f80316123a7867235b21f96d8b8e16aa7394ea67b685fe5dfe7871L6-R6), [link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-4d2ffe32c613a20b980487482b4644bdefa32b499c7a741e21899f0ecc012bfcL6-R6))
*  Add `itty-router` dependency to `sts-generator` package ([link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-ac247611b89638693301f44640877cb2abb599a619665a9bd84591deb9ae5520L16-R17), [link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR759-R761))
*  Add `getStsToken` handler to generate temporary STS tokens for 4everland access in `sts-generator` package ([link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-635be0c3e1e548dafe6346ddb35124b145292541683841e2e4998499e06ba7dfR1-R61), [link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-505c2c7e4a6d90f44a9130d2e9310c496d87047bb0f16a533f4600c69c995c9fR1-R4))
*  Rewrite `index.ts` file in `sts-generator` package to use `itty-router` and `getStsToken` handler ([link](https://github.com/lensterxyz/lenster/pull/2985/files?diff=unified&w=0#diff-a2f47aa568e35c7f555b137ca5eec6b42de81b61e12c74bebfce3ea635e63f32L1-R34))

## Emoji

<!--
copilot:emoji
-->

📦🛠️🚀

<!--
1.  📦 - This emoji represents the addition or update of a dependency in the package.json file. It can be used for the changes in F0L14R14, F2L15R15, F4L17R17 and F6L19R19.
2.  🛠️ - This emoji represents the removal or modification of a configuration or tooling file. It can be used for the changes in F1L4R4 and F7L21R21.
3.  🚀 - This emoji represents the addition or improvement of a feature or functionality in the source code. It can be used for the changes in F5L18R18, F8L22R22 and F9L23R23.
-->
