### PR TITLE
fix: uniswap warning width and data in it

### DIFF
--- a/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
+++ b/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
@@ -522,7 +522,7 @@ const CollectModule: FC<CollectModuleProps> = ({
                 ) : null
               ) : (
                 <WarningMessage
-                  className="mt-5"
+                  className="mt-5 w-full"
                   message={<Uniswap module={collectModule} />}
                 />
               )

--- a/apps/web/src/components/Shared/Uniswap.tsx
+++ b/apps/web/src/components/Shared/Uniswap.tsx
@@ -11,18 +11,21 @@ interface UniswapProps {
 }
 
 const Uniswap: FC<UniswapProps> = ({ module }) => {
+  const amount = module?.amount?.value ?? module?.fee?.amount?.value;
+  const currency =
+    module?.amount?.asset?.symbol ?? module?.fee?.amount?.asset?.symbol;
+  const assetAddress =
+    module?.amount?.asset?.address ?? module?.fee?.amount?.asset?.address;
+
   return (
     <div className="space-y-1">
       <div className="text-sm">
         <Trans>
-          You don't have enough <b>{module?.amount?.asset?.symbol}</b>
+          You don't have enough <b>{currency}</b>
         </Trans>
       </div>
       <Link
-        href={getUniswapURL(
-          parseFloat(module?.amount?.value),
-          module?.amount?.asset?.address
-        )}
+        href={getUniswapURL(parseFloat(amount), assetAddress)}
         onClick={() => {
           Leafwatch.track(PUBLICATION.COLLECT_MODULE.OPEN_UNISWAP);
         }}


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7b6165</samp>

Refactored the `Uniswap` component to handle different module payment scenarios and improved the layout of the `WarningMessage` component in `CollectModule.tsx`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f7b6165</samp>

*  Refactored `Uniswap` component to handle module amount and fee cases ([link](https://github.com/lensterxyz/lenster/pull/3000/files?diff=unified&w=0#diff-1443e25b247c54d6623eb62d106a6ffbadaa42b48d18fc9dad337c0ae782e660L14-R28))
* Added `w-full` class to `WarningMessage` component to improve layout and alignment ([link](https://github.com/lensterxyz/lenster/pull/3000/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL525-R525))

## Emoji

<!--
copilot:emoji
-->

📏♻️💱

<!--
1.  📏 - This emoji can be used to represent the change of adding the `w-full` class to the `WarningMessage` component, since it implies adjusting the size or dimensions of an element.
2.  ♻️ - This emoji can be used to represent the change of refactoring the `Uniswap` component, since it implies reusing or recycling existing code and logic to handle different cases.
3.  💱 - This emoji can be used to represent the change of using variables to store the amount, currency, and asset address for the Uniswap link, since it implies exchanging or converting one value for another.
-->
