### PR TITLE
feat: add CLICK_HASHTAG and CLICK_MENTION event

### DIFF
--- a/apps/web/src/components/Shared/Markup/MarkupLink/Hashtag.tsx
+++ b/apps/web/src/components/Shared/Markup/MarkupLink/Hashtag.tsx
@@ -2,8 +2,10 @@ import { hashflags, prideHashtags } from '@lenster/data';
 import { STATIC_IMAGES_URL } from '@lenster/data/constants';
 import isPrimeMonth from '@lenster/lib/isPrideMonth';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
+import { Leafwatch } from '@lib/leafwatch';
 import Link from 'next/link';
 import type { FC } from 'react';
+import { PUBLICATION } from 'src/tracking';
 import type { MarkupLinkProps } from 'src/types';
 
 const Hashtag: FC<MarkupLinkProps> = ({ href, title = href }) => {
@@ -20,7 +22,12 @@ const Hashtag: FC<MarkupLinkProps> = ({ href, title = href }) => {
       <span>
         <Link
           href={`/search?q=${title.slice(1)}&type=pubs&src=link_click`}
-          onClick={stopEventPropagation}
+          onClick={(event) => {
+            stopEventPropagation(event);
+            Leafwatch.track(PUBLICATION.CLICK_HASHTAG, {
+              hashtag: title.slice(1)
+            });
+          }}
         >
           {isPrideHashtag ? <span className="pride-text">{title}</span> : title}
         </Link>

--- a/apps/web/src/components/Shared/Markup/MarkupLink/Mention.tsx
+++ b/apps/web/src/components/Shared/Markup/MarkupLink/Mention.tsx
@@ -1,8 +1,10 @@
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
+import { Leafwatch } from '@lib/leafwatch';
 import Link from 'next/link';
 import type { FC } from 'react';
+import { PUBLICATION } from 'src/tracking';
 import type { MarkupLinkProps } from 'src/types';
 
 import Slug from '../../Slug';
@@ -23,7 +25,13 @@ const Mention: FC<MarkupLinkProps> = ({ href, title = href }) => {
   };
 
   return (
-    <Link href={`/u/${formatHandle(handle)}`} onClick={stopEventPropagation}>
+    <Link
+      href={`/u/${formatHandle(handle)}`}
+      onClick={(event) => {
+        stopEventPropagation(event);
+        Leafwatch.track(PUBLICATION.CLICK_MENTION, { handle });
+      }}
+    >
       {profile?.handle ? (
         <UserPreview
           isBig={false}

--- a/apps/web/src/components/Shared/Oembed/Embed.tsx
+++ b/apps/web/src/components/Shared/Oembed/Embed.tsx
@@ -22,7 +22,9 @@ const Embed: FC<EmbedProps> = ({ og }) => {
         href={og.url}
         onClick={(event) => {
           stopEventPropagation(event);
-          Leafwatch.track(PUBLICATION.OEMBED_CLICK);
+          Leafwatch.track(PUBLICATION.CLICK_OEMBED, {
+            url: og.url
+          });
         }}
         target={og.url.includes(location.host) ? '_self' : '_blank'}
         rel="noreferrer noopener"

--- a/apps/web/src/tracking.ts
+++ b/apps/web/src/tracking.ts
@@ -30,7 +30,9 @@ export const PUBLICATION = {
   TRANSLATE: 'Translate publication',
   DELETE: 'Delete publication',
   REPORT: 'Report publication',
-  OEMBED_CLICK: 'Click publication oembed',
+  CLICK_OEMBED: 'Click publication oembed',
+  CLICK_HASHTAG: 'Click publication hashtag',
+  CLICK_MENTION: 'Click publication mention',
   ATTACHMENT: {
     IMAGE: {
       OPEN: 'Open image attachment'

--- a/packages/data/verified.ts
+++ b/packages/data/verified.ts
@@ -2,6 +2,7 @@ import { aaveMembers } from './aave-members';
 import { mainnetStaffs } from './staffs';
 
 export const mainnetVerified = [
+  '0x01cc3a', // zonday
   '0x01c8b6', // alchemy
   '0x01a7a3', // bundlr-network
   '0x01c7d4', // messari


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3445c2</samp>

Added analytics for user interactions with hashtags, mentions and oembeds in publications. Used `Leafwatch.track` to send specific events with relevant parameters from `Hashtag.tsx`, `Mention.tsx` and `Embed.tsx`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3445c2</samp>

*  Add `@lib/leafwatch` module and `PUBLICATION` constant imports to `Hashtag.tsx` and `Mention.tsx` files ([link](https://github.com/lensterxyz/lenster/pull/3013/files?diff=unified&w=0#diff-43b384d7cbfdf0f39e49dcc2e2f09154173506a90f06fdef0e193c3038ea022cL5-R8), [link](https://github.com/lensterxyz/lenster/pull/3013/files?diff=unified&w=0#diff-d804356b9c601c69be5726eede745e3aa74a6ef3ff8115b100c413ba7c1f64a6L4-R7))
*  Modify `onClick` handlers for `Link` components wrapping hashtags and mentions to call `Leafwatch.track` with specific events and parameters, and stop event propagation ([link](https://github.com/lensterxyz/lenster/pull/3013/files?diff=unified&w=0#diff-43b384d7cbfdf0f39e49dcc2e2f09154173506a90f06fdef0e193c3038ea022cL23-R30), [link](https://github.com/lensterxyz/lenster/pull/3013/files?diff=unified&w=0#diff-d804356b9c601c69be5726eede745e3aa74a6ef3ff8115b100c413ba7c1f64a6L26-R34))
*  Modify `onClick` handler for `a` element wrapping oembed to call `Leafwatch.track` with specific event and parameter, instead of generic event ([link](https://github.com/lensterxyz/lenster/pull/3013/files?diff=unified&w=0#diff-8c4edf59668cb216096d225df3729857825195df650e04d9ebd8d6f6358bfaebL25-R27))
*  Update `PUBLICATION` constant in `tracking.ts` file to include new events for clicking hashtags, mentions and oembeds ([link](https://github.com/lensterxyz/lenster/pull/3013/files?diff=unified&w=0#diff-0de632705ed1f05ebcd4fe3b52d970b5c5cbabcddb8c1b9eabd948887cd6eab3L33-R35))

## Emoji

<!--
copilot:emoji
-->

🖱️🏷️🎥

<!--
1.  🖱️ - This emoji represents the mouse click action that triggers the analytics events for oembeds, hashtags and mentions.
2.  🏷️ - This emoji represents the hashtags and mentions that are tracked as part of the publication content.
3.  🎥 - This emoji represents the oembeds that are embedded in the publications, such as videos or other media.
-->
