### PR TITLE
feat: rich render publication aka quotes mvp

### DIFF
--- a/apps/web/src/components/Publication/PublicationBody.tsx
+++ b/apps/web/src/components/Publication/PublicationBody.tsx
@@ -25,13 +25,19 @@ const PublicationBody: FC<PublicationBodyProps> = ({
   showMore = false
 }) => {
   const canShowMore = publication?.metadata?.content?.length > 450 && showMore;
-  const hasURLs = getURLs(publication?.metadata?.content)?.length > 0;
-  const snapshotProposalId =
-    hasURLs && getSnapshotProposalId(getURLs(publication?.metadata?.content));
+  const urls = getURLs(publication?.metadata?.content);
+  const hasURLs = urls?.length > 0;
+  const snapshotProposalId = hasURLs && getSnapshotProposalId(urls);
+  const renderPublications = getLensPublicationIdsFromUrls(urls);
+
   let content = publication?.metadata?.content;
-  if (snapshotProposalId) {
-    for (const url of getURLs(publication?.metadata?.content)) {
-      if (url.includes(snapshotProposalId)) {
+  const filterId =
+    snapshotProposalId ||
+    (renderPublications.length > 0 && renderPublications[0]);
+
+  if (filterId) {
+    for (const url of urls) {
+      if (url.includes(filterId)) {
         content = content?.replace(url, '');
       }
     }
@@ -41,7 +47,6 @@ const PublicationBody: FC<PublicationBodyProps> = ({
     return <DecryptedPublicationBody encryptedPublication={publication} />;
   }
 
-  const renderPublications = getLensPublicationIdsFromUrls(content);
   const showAttachments = publication?.metadata?.media?.length > 0;
   const showSnapshot = snapshotProposalId;
   const showPublicationEmbed = renderPublications.length > 0;
@@ -77,9 +82,7 @@ const PublicationBody: FC<PublicationBodyProps> = ({
         <Profile publicationIds={renderPublications} />
       ) : null}
       {showSnapshot ? <Snapshot proposalId={snapshotProposalId} /> : null}
-      {showOembed ? (
-        <Oembed url={getURLs(publication?.metadata?.content)[0]} />
-      ) : null}
+      {showOembed ? <Oembed url={urls[0]} /> : null}
     </div>
   );
 };

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -17,6 +17,7 @@ interface SinglePublicationProps {
   showActions?: boolean;
   showModActions?: boolean;
   showThread?: boolean;
+  showMore?: boolean;
 }
 
 const SinglePublication: FC<SinglePublicationProps> = ({
@@ -25,7 +26,8 @@ const SinglePublication: FC<SinglePublicationProps> = ({
   showType = true,
   showActions = true,
   showModActions = false,
-  showThread = true
+  showThread = true,
+  showMore = true
 }) => {
   const { push } = useRouter();
   const firstComment = feedItem?.comments && feedItem.comments[0];
@@ -62,7 +64,10 @@ const SinglePublication: FC<SinglePublicationProps> = ({
           <HiddenPublication type={publication.__typename} />
         ) : (
           <>
-            <PublicationBody publication={rootPublication} />
+            <PublicationBody
+              publication={rootPublication}
+              showMore={showMore}
+            />
             {showActions && (
               <PublicationActions
                 publication={rootPublication}

--- a/apps/web/src/components/Shared/Embed/Publication.tsx
+++ b/apps/web/src/components/Shared/Embed/Publication.tsx
@@ -1,8 +1,9 @@
 import SinglePublication from '@components/Publication/SinglePublication';
 import { Publication, usePublicationQuery } from '@lenster/lens';
-import stopEventPropagation from '@lenster/lib/stopEventPropagation';
-import { Card } from '@lenster/ui';
 import type { FC } from 'react';
+
+import PublicationShimmer from '../Shimmer/PublicationShimmer';
+import Wrapper from './Wrapper';
 
 interface PublicationProps {
   publicationIds: string[];
@@ -14,7 +15,11 @@ const Publication: FC<PublicationProps> = ({ publicationIds }) => {
   });
 
   if (loading) {
-    return null;
+    return (
+      <Wrapper zeroPadding>
+        <PublicationShimmer showActions={false} />
+      </Wrapper>
+    );
   }
 
   if (error || !data) {
@@ -22,11 +27,7 @@ const Publication: FC<PublicationProps> = ({ publicationIds }) => {
   }
 
   return (
-    <Card
-      className="mt-3 cursor-auto"
-      forceRounded
-      onClick={stopEventPropagation}
-    >
+    <Wrapper zeroPadding>
       <SinglePublication
         publication={data.publication as Publication}
         showThread={false}
@@ -34,7 +35,7 @@ const Publication: FC<PublicationProps> = ({ publicationIds }) => {
         showActions={false}
         showMore
       />
-    </Card>
+    </Wrapper>
   );
 };
 

--- a/apps/web/src/components/Shared/Embed/Publication.tsx
+++ b/apps/web/src/components/Shared/Embed/Publication.tsx
@@ -1,0 +1,41 @@
+import SinglePublication from '@components/Publication/SinglePublication';
+import { Publication, usePublicationQuery } from '@lenster/lens';
+import stopEventPropagation from '@lenster/lib/stopEventPropagation';
+import { Card } from '@lenster/ui';
+import type { FC } from 'react';
+
+interface PublicationProps {
+  publicationIds: string[];
+}
+
+const Publication: FC<PublicationProps> = ({ publicationIds }) => {
+  const { data, loading, error } = usePublicationQuery({
+    variables: { request: { publicationId: publicationIds[0] } }
+  });
+
+  if (loading) {
+    return null;
+  }
+
+  if (error || !data) {
+    return null;
+  }
+
+  return (
+    <Card
+      className="mt-3 cursor-auto"
+      forceRounded
+      onClick={stopEventPropagation}
+    >
+      <SinglePublication
+        publication={data.publication as Publication}
+        showThread={false}
+        showType={false}
+        showActions={false}
+        showMore
+      />
+    </Card>
+  );
+};
+
+export default Publication;

--- a/apps/web/src/components/Shared/Embed/Wrapper.tsx
+++ b/apps/web/src/components/Shared/Embed/Wrapper.tsx
@@ -1,0 +1,26 @@
+import stopEventPropagation from '@lenster/lib/stopEventPropagation';
+import { Card } from '@lenster/ui';
+import clsx from 'clsx';
+import type { FC, ReactNode } from 'react';
+
+interface WrapperProps {
+  children: ReactNode;
+  dataTestId?: string;
+  zeroPadding?: boolean;
+}
+
+const Wrapper: FC<WrapperProps> = ({
+  children,
+  dataTestId = '',
+  zeroPadding = false
+}) => (
+  <Card
+    className={clsx('mt-3 cursor-auto', { 'p-5': !zeroPadding })}
+    dataTestId={dataTestId}
+    onClick={stopEventPropagation}
+  >
+    {children}
+  </Card>
+);
+
+export default Wrapper;

--- a/apps/web/src/components/Shared/Shimmer/PublicationShimmer.tsx
+++ b/apps/web/src/components/Shared/Shimmer/PublicationShimmer.tsx
@@ -2,7 +2,13 @@ import type { FC } from 'react';
 
 import UserProfileShimmer from './UserProfileShimmer';
 
-const PublicationShimmer: FC = () => {
+interface PublicationShimmerProps {
+  showActions?: boolean;
+}
+
+const PublicationShimmer: FC<PublicationShimmerProps> = ({
+  showActions = true
+}) => {
   return (
     <div className="space-y-4 p-5">
       <div className="flex justify-between">
@@ -14,11 +20,13 @@ const PublicationShimmer: FC = () => {
           <div className="shimmer h-3 w-7/12 rounded-lg" />
           <div className="shimmer h-3 w-1/3 rounded-lg" />
         </div>
-        <div className="flex gap-7 pt-3">
-          <div className="shimmer h-5 w-5 rounded-lg" />
-          <div className="shimmer h-5 w-5 rounded-lg" />
-          <div className="shimmer h-5 w-5 rounded-lg" />
-        </div>
+        {showActions && (
+          <div className="flex gap-7 pt-3">
+            <div className="shimmer h-5 w-5 rounded-lg" />
+            <div className="shimmer h-5 w-5 rounded-lg" />
+            <div className="shimmer h-5 w-5 rounded-lg" />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/Shared/Snapshot/index.tsx
+++ b/apps/web/src/components/Shared/Snapshot/index.tsx
@@ -1,32 +1,18 @@
 import { LENSTER_POLLS_SPACE, ZERO_ADDRESS } from '@lenster/data';
 import generateSnapshotAccount from '@lenster/lib/generateSnapshotAccount';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
-import { Card, Spinner } from '@lenster/ui';
+import { Spinner } from '@lenster/ui';
 import getSnapshotProposal from '@lib/getSnapshotProposal';
 import getSnapshotSpace from '@lib/getSnapshotSpace';
 import { useQuery } from '@tanstack/react-query';
 import type { Proposal, Vote } from '@workers/snapshot-relay';
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import { useState } from 'react';
 import { useAppStore } from 'src/store/app';
 
+import Wrapper from '../Embed/Wrapper';
 import Choices from './Choices';
 import Header from './Header';
-
-interface WrapperProps {
-  children: ReactNode;
-  dataTestId?: string;
-}
-
-const Wrapper: FC<WrapperProps> = ({ children, dataTestId = '' }) => (
-  <Card
-    className="mt-3 cursor-auto p-5"
-    dataTestId={dataTestId}
-    onClick={stopEventPropagation}
-  >
-    {children}
-  </Card>
-);
 
 interface SnapshotProps {
   proposalId: string;

--- a/apps/web/src/components/Shared/UserProfile.tsx
+++ b/apps/web/src/components/Shared/UserProfile.tsx
@@ -119,7 +119,7 @@ const UserProfile: FC<UserProfileProps> = ({
         followStatusLoading={followStatusLoading}
         showUserPreview={showUserPreview}
       >
-        <div className="flex items-center space-x-3">
+        <div className="mr-8 flex items-center space-x-3">
           <UserAvatar />
           <div>
             <UserName />

--- a/packages/lib/getLensPublicationIdsFromUrls.ts
+++ b/packages/lib/getLensPublicationIdsFromUrls.ts
@@ -1,0 +1,49 @@
+interface Pattern {
+  regex: RegExp;
+}
+
+interface PatternWithFormat extends Pattern {
+  format?: (match: string) => string;
+}
+
+/**
+ * Get Lens publication IDs from URLs
+ * @param content Text containing URLs
+ * @returns Lens publication IDs
+ */
+const getLensPublicationIdsFromUrls = (content: string): string[] => {
+  try {
+    const patterns: PatternWithFormat[] = [
+      { regex: /https?:\/\/localhost:4783\/posts\/([^/]+)/ },
+      {
+        regex:
+          /https?:\/\/(?:testnet\.|staging\.|sandbox\.|staging-sandbox\.)?lenster\.xyz\/posts\/([^/]+)/
+      },
+      { regex: /https?:\/\/orb\.ac\/post\/([^./]+)/ }
+    ];
+
+    const publicationIds: string[] = [];
+    const urlRegex = /(https?:\/\/\S+)/g;
+    const urls = content.match(urlRegex);
+
+    if (urls) {
+      for (const url of urls) {
+        for (const pattern of patterns) {
+          const match = url.match(pattern.regex);
+          if (match && match[1]) {
+            const publicationId = match[1];
+            publicationIds.push(publicationId);
+            break;
+          }
+        }
+      }
+    }
+
+    return publicationIds;
+  } catch (error) {
+    console.error('Failed to parse URL', error);
+    return [];
+  }
+};
+
+export default getLensPublicationIdsFromUrls;

--- a/packages/lib/getLensPublicationIdsFromUrls.ts
+++ b/packages/lib/getLensPublicationIdsFromUrls.ts
@@ -1,3 +1,5 @@
+import formatHandle from './formatHandle';
+
 interface Pattern {
   regex: RegExp;
 }
@@ -8,10 +10,10 @@ interface PatternWithFormat extends Pattern {
 
 /**
  * Get Lens publication IDs from URLs
- * @param content Text containing URLs
+ * @param urls Publication URLs
  * @returns Lens publication IDs
  */
-const getLensPublicationIdsFromUrls = (content: string): string[] => {
+const getLensPublicationIdsFromUrls = (urls: string[]): string[] => {
   try {
     const patterns: PatternWithFormat[] = [
       { regex: /https?:\/\/localhost:4783\/posts\/([^/]+)/ },
@@ -23,18 +25,14 @@ const getLensPublicationIdsFromUrls = (content: string): string[] => {
     ];
 
     const publicationIds: string[] = [];
-    const urlRegex = /(https?:\/\/\S+)/g;
-    const urls = content.match(urlRegex);
 
-    if (urls) {
-      for (const url of urls) {
-        for (const pattern of patterns) {
-          const match = url.match(pattern.regex);
-          if (match && match[1]) {
-            const publicationId = match[1];
-            publicationIds.push(publicationId);
-            break;
-          }
+    for (const url of urls) {
+      for (const pattern of patterns) {
+        const match = url.match(pattern.regex);
+        if (match && match[1]) {
+          const publicationId = match[1];
+          publicationIds.push(formatHandle(publicationId));
+          break;
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f712f4d</samp>

This pull request adds the feature to embed publications from other Lens users in the publication content, using a new `Publication` component and a `getLensPublicationIdsFromUrls` function. It also improves the readability and interactivity of the publication body, by adding the option to truncate and expand the content, and by styling and handling the click events on the embedded publications.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f712f4d</samp>

*  Add `Publication` component to render embedded publications from other Lens users ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-4ed2b3e7ff95cca850e6a5aa55045a856f8a3bebb3925adccbaa506c0c93c37cR1-R41))
*  Import `Publication` component and `getLensPublicationIdsFromUrls` function in `PublicationBody` component ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1R2), [link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1R8))
*  Add `showMore` prop to `PublicationBody` and `SinglePublication` components to control truncation and expansion of publication content ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1L19-R27), [link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9R20), [link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9L28-R30), [link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9L65-R70))
*  Extract publication IDs from URLs in publication content using `getLensPublicationIdsFromUrls` function and store them in `renderPublications` variable ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1L41-R49))
*  Rename `showMore` variable to `canShowMore` to avoid confusion with prop of same name ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1L41-R49), [link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1L49-R55), [link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1L55-R61))
*  Remove unused `useRouter` import from `PublicationBody` component ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1L12))
*  Conditionally render `Profile` component with `renderPublications` prop to embed publications in publication body ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-cf87c96f430fb044b052837b8732058bdc59aba03cba72f7f7c43143622ffae1R76-R78))
*  Add margin-right to user profile div in `UserProfile` component to create space between user profile and embedded publication ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-76ec0042feeee3e7c5b48571fa583a0224d6d991cc43d81004753a2c461f38a9L122-R122))
*  Add `getLensPublicationIdsFromUrls` function to extract publication IDs from URLs in publication content ([link](https://github.com/lensterxyz/lenster/pull/3016/files?diff=unified&w=0#diff-68bbcce0f89b79c00f11397b2b536d4544b5950432133e678c1a0453d30ec082R1-R49))

## Emoji

<!--
copilot:emoji
-->

📰🖊️🐛

<!--
1.  📰 - This emoji represents the publication component and the functionality to embed publications from other Lens users. It is also a common symbol for news and media, which relates to the purpose of Lens as a platform for sharing research and insights.
2.  🖊️ - This emoji represents the editing and formatting of the publication content, as well as the option to truncate and expand the content. It is also a common symbol for writing and authorship, which relates to the core activity of Lens users.
3.  🐛 - This emoji represents the bug fixes and error handling that were done in the getLensPublicationIdsFromUrls function and the publication component. It is also a common symbol for software development and debugging, which relates to the quality and reliability of the code.
-->
