### PR TITLE
feat: add mirror dropdown

### DIFF
--- a/apps/web/src/components/Composer/Actions/Attachment.tsx
+++ b/apps/web/src/components/Composer/Actions/Attachment.tsx
@@ -94,8 +94,8 @@ const Attachment: FC = () => {
       <MenuTransition show={showMenu}>
         <Menu.Items
           ref={dropdownRef}
-          static
           className="absolute z-[5] mt-2 rounded-xl border bg-white py-1 shadow-sm focus:outline-none dark:border-gray-700 dark:bg-gray-900"
+          static
         >
           <Menu.Item
             as="label"

--- a/apps/web/src/components/Publication/Actions/Share/Mirror.tsx
+++ b/apps/web/src/components/Publication/Actions/Share/Mirror.tsx
@@ -29,17 +29,15 @@ import { useContractWrite, useSignTypedData } from 'wagmi';
 
 interface DeleteProps {
   publication: Publication;
+  setIsLoading: (isLoading: boolean) => void;
+  isLoading: boolean;
 }
 
-const Mirror: FC<DeleteProps> = ({ publication }) => {
+const Mirror: FC<DeleteProps> = ({ publication, setIsLoading, isLoading }) => {
   const isMirror = publication.__typename === 'Mirror';
   const userSigNonce = useNonceStore((state) => state.userSigNonce);
   const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
   const currentProfile = useAppStore((state) => state.currentProfile);
-  const [isLoading, setIsLoading] = useState(false);
-  const count = isMirror
-    ? publication?.mirrorOf?.stats?.totalAmountOfMirrors
-    : publication?.stats?.totalAmountOfMirrors;
   const [mirrored, setMirrored] = useState(
     isMirror
       ? publication?.mirrorOf?.mirrors?.length > 0

--- a/apps/web/src/components/Publication/Actions/Share/Mirror.tsx
+++ b/apps/web/src/components/Publication/Actions/Share/Mirror.tsx
@@ -1,7 +1,7 @@
+import { Menu } from '@headlessui/react';
 import { SwitchHorizontalIcon } from '@heroicons/react/outline';
 import { LensHub } from '@lenster/abis';
-import { Errors } from '@lenster/data';
-import { LENSHUB_PROXY } from '@lenster/data/constants';
+import { Errors, LENSHUB_PROXY } from '@lenster/data';
 import type {
   CreateDataAvailabilityMirrorRequest,
   CreateMirrorRequest,
@@ -16,28 +16,22 @@ import {
 import { useApolloClient } from '@lenster/lens/apollo';
 import { publicationKeyFields } from '@lenster/lens/apollo/lib';
 import getSignature from '@lenster/lib/getSignature';
-import humanize from '@lenster/lib/humanize';
-import nFormatter from '@lenster/lib/nFormatter';
-import { Spinner, Tooltip } from '@lenster/ui';
 import errorToast from '@lib/errorToast';
 import { Leafwatch } from '@lib/leafwatch';
-import { t } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import clsx from 'clsx';
-import { motion } from 'framer-motion';
-import type { FC } from 'react';
-import { useState } from 'react';
-import toast from 'react-hot-toast';
+import { type FC, useState } from 'react';
+import { toast } from 'react-hot-toast';
 import { useAppStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
 import { PUBLICATION } from 'src/tracking';
 import { useContractWrite, useSignTypedData } from 'wagmi';
 
-interface MirrorProps {
+interface DeleteProps {
   publication: Publication;
-  showCount: boolean;
 }
 
-const Mirror: FC<MirrorProps> = ({ publication, showCount }) => {
+const Mirror: FC<DeleteProps> = ({ publication }) => {
   const isMirror = publication.__typename === 'Mirror';
   const userSigNonce = useNonceStore((state) => state.userSigNonce);
   const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
@@ -62,6 +56,7 @@ const Mirror: FC<MirrorProps> = ({ publication, showCount }) => {
     cache.modify({
       id: publicationKeyFields(isMirror ? publication?.mirrorOf : publication),
       fields: {
+        mirrors: (mirrors) => [...mirrors, currentProfile?.id],
         stats: (stats) => ({
           ...stats,
           totalAmountOfMirrors: stats.totalAmountOfMirrors + 1
@@ -210,46 +205,24 @@ const Mirror: FC<MirrorProps> = ({ publication, showCount }) => {
     }
   };
 
-  const iconClassName = showCount
-    ? 'w-[17px] sm:w-[20px]'
-    : 'w-[15px] sm:w-[18px]';
-
   return (
-    <div
-      className={clsx(
-        mirrored ? 'text-green-500' : 'text-brand',
-        'flex items-center space-x-1'
-      )}
+    <Menu.Item
+      as="div"
+      className={({ active }) =>
+        clsx(
+          { 'dropdown-active': active },
+          mirrored ? 'text-green-500' : 'text-brand',
+          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm'
+        )
+      }
+      onClick={createMirror}
+      disabled={isLoading}
     >
-      <motion.button
-        whileTap={{ scale: 0.9 }}
-        onClick={createMirror}
-        disabled={isLoading}
-        aria-label="Mirror"
-      >
-        <div
-          className={clsx(
-            mirrored ? 'hover:bg-green-300/20' : 'hover:bg-brand-300/20',
-            'rounded-full p-1.5'
-          )}
-        >
-          {isLoading ? (
-            <Spinner variant={mirrored ? 'success' : 'primary'} size="xs" />
-          ) : (
-            <Tooltip
-              placement="top"
-              content={count > 0 ? t`${humanize(count)} Mirrors` : t`Mirror`}
-              withDelay
-            >
-              <SwitchHorizontalIcon className={iconClassName} />
-            </Tooltip>
-          )}
-        </div>
-      </motion.button>
-      {count > 0 && !showCount && (
-        <span className="text-[11px] sm:text-xs">{nFormatter(count)}</span>
-      )}
-    </div>
+      <div className="flex items-center space-x-2">
+        <SwitchHorizontalIcon className="h-4 w-4" />
+        <div>{mirrored ? <Trans>Unmirror</Trans> : <Trans>Mirror</Trans>}</div>
+      </div>
+    </Menu.Item>
   );
 };
 

--- a/apps/web/src/components/Publication/Actions/Share/index.tsx
+++ b/apps/web/src/components/Publication/Actions/Share/index.tsx
@@ -5,12 +5,11 @@ import type { Publication } from '@lenster/lens';
 import humanize from '@lenster/lib/humanize';
 import nFormatter from '@lenster/lib/nFormatter';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
-import { Tooltip } from '@lenster/ui';
+import { Spinner, Tooltip } from '@lenster/ui';
 import { t } from '@lingui/macro';
 import clsx from 'clsx';
 import type { FC } from 'react';
-import { Fragment, useRef, useState } from 'react';
-import { useOnClickOutside } from 'usehooks-ts';
+import { Fragment, useState } from 'react';
 
 import Mirror from './Mirror';
 
@@ -20,8 +19,7 @@ interface PublicationMenuProps {
 }
 
 const ShareMenu: FC<PublicationMenuProps> = ({ publication, showCount }) => {
-  const [showMenu, setShowMenu] = useState(false);
-  const dropdownRef = useRef(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const isMirror = publication.__typename === 'Mirror';
   const count = isMirror
@@ -32,8 +30,6 @@ const ShareMenu: FC<PublicationMenuProps> = ({ publication, showCount }) => {
     : // @ts-expect-error
       publication?.mirrors?.length > 0;
   const iconClassName = 'w-[15px] sm:w-[18px]';
-
-  useOnClickOutside(dropdownRef, () => setShowMenu(false));
 
   return (
     <div
@@ -46,28 +42,36 @@ const ShareMenu: FC<PublicationMenuProps> = ({ publication, showCount }) => {
         <Menu.Button as={Fragment}>
           <button
             className="rounded-full p-1.5 hover:bg-gray-300/20"
-            onClick={(event) => {
-              stopEventPropagation(event);
-              setShowMenu(!showMenu);
-            }}
+            onClick={stopEventPropagation}
             aria-label="Mirror"
           >
-            <Tooltip
-              placement="top"
-              content={count > 0 ? t`${humanize(count)} Mirrors` : t`Mirror`}
-              withDelay
-            >
-              <SwitchHorizontalIcon className={iconClassName} />
-            </Tooltip>
+            {isLoading ? (
+              <Spinner
+                variant={mirrored ? 'success' : 'primary'}
+                size="xs"
+                className="mr-0.5"
+              />
+            ) : (
+              <Tooltip
+                placement="top"
+                content={count > 0 ? t`${humanize(count)} Mirrors` : t`Mirror`}
+                withDelay
+              >
+                <SwitchHorizontalIcon className={iconClassName} />
+              </Tooltip>
+            )}
           </button>
         </Menu.Button>
-        <MenuTransition show={showMenu}>
+        <MenuTransition>
           <Menu.Items
-            ref={dropdownRef}
             className="absolute z-[5] mt-1 w-max rounded-xl border bg-white shadow-sm focus:outline-none dark:border-gray-700 dark:bg-gray-900"
             static
           >
-            <Mirror publication={publication} />
+            <Mirror
+              publication={publication}
+              setIsLoading={setIsLoading}
+              isLoading={isLoading}
+            />
           </Menu.Items>
         </MenuTransition>
       </Menu>

--- a/apps/web/src/components/Publication/Actions/Share/index.tsx
+++ b/apps/web/src/components/Publication/Actions/Share/index.tsx
@@ -1,0 +1,81 @@
+import MenuTransition from '@components/Shared/MenuTransition';
+import { Menu } from '@headlessui/react';
+import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import type { Publication } from '@lenster/lens';
+import humanize from '@lenster/lib/humanize';
+import nFormatter from '@lenster/lib/nFormatter';
+import stopEventPropagation from '@lenster/lib/stopEventPropagation';
+import { Tooltip } from '@lenster/ui';
+import { t } from '@lingui/macro';
+import clsx from 'clsx';
+import type { FC } from 'react';
+import { Fragment, useRef, useState } from 'react';
+import { useOnClickOutside } from 'usehooks-ts';
+
+import Mirror from './Mirror';
+
+interface PublicationMenuProps {
+  publication: Publication;
+  showCount: boolean;
+}
+
+const ShareMenu: FC<PublicationMenuProps> = ({ publication, showCount }) => {
+  const [showMenu, setShowMenu] = useState(false);
+  const dropdownRef = useRef(null);
+
+  const isMirror = publication.__typename === 'Mirror';
+  const count = isMirror
+    ? publication?.mirrorOf?.stats?.totalAmountOfMirrors
+    : publication?.stats?.totalAmountOfMirrors;
+  const mirrored = isMirror
+    ? publication?.mirrorOf?.mirrors?.length > 0
+    : // @ts-expect-error
+      publication?.mirrors?.length > 0;
+  const iconClassName = 'w-[15px] sm:w-[18px]';
+
+  useOnClickOutside(dropdownRef, () => setShowMenu(false));
+
+  return (
+    <div
+      className={clsx(
+        mirrored ? 'text-green-500' : 'text-brand',
+        'flex items-center space-x-1'
+      )}
+    >
+      <Menu as="div" className="relative">
+        <Menu.Button as={Fragment}>
+          <button
+            className="rounded-full p-1.5 hover:bg-gray-300/20"
+            onClick={(event) => {
+              stopEventPropagation(event);
+              setShowMenu(!showMenu);
+            }}
+            aria-label="Mirror"
+          >
+            <Tooltip
+              placement="top"
+              content={count > 0 ? t`${humanize(count)} Mirrors` : t`Mirror`}
+              withDelay
+            >
+              <SwitchHorizontalIcon className={iconClassName} />
+            </Tooltip>
+          </button>
+        </Menu.Button>
+        <MenuTransition show={showMenu}>
+          <Menu.Items
+            ref={dropdownRef}
+            className="absolute z-[5] mt-1 w-max rounded-xl border bg-white shadow-sm focus:outline-none dark:border-gray-700 dark:bg-gray-900"
+            static
+          >
+            <Mirror publication={publication} />
+          </Menu.Items>
+        </MenuTransition>
+      </Menu>
+      {count > 0 && !showCount && (
+        <span className="text-[11px] sm:text-xs">{nFormatter(count)}</span>
+      )}
+    </div>
+  );
+};
+
+export default ShareMenu;

--- a/apps/web/src/components/Publication/Actions/index.tsx
+++ b/apps/web/src/components/Publication/Actions/index.tsx
@@ -7,8 +7,8 @@ import { useAppStore } from 'src/store/app';
 import Collect from './Collect';
 import Comment from './Comment';
 import Like from './Like';
-import Mirror from './Mirror';
 import Mod from './Mod';
+import ShareMenu from './Share';
 
 interface PublicationActionsProps {
   publication: Publication;
@@ -33,7 +33,9 @@ const PublicationActions: FC<PublicationActionsProps> = ({
       aria-hidden="true"
     >
       <Comment publication={publication} showCount={showCount} />
-      {canMirror && <Mirror publication={publication} showCount={showCount} />}
+      {canMirror && (
+        <ShareMenu publication={publication} showCount={showCount} />
+      )}
       <Like publication={publication} showCount={showCount} />
       {collectModuleType !== 'RevertCollectModuleSettings' && (
         <Collect

--- a/apps/web/src/components/Publication/PublicationBody.tsx
+++ b/apps/web/src/components/Publication/PublicationBody.tsx
@@ -18,11 +18,13 @@ import DecryptedPublicationBody from './DecryptedPublicationBody';
 interface PublicationBodyProps {
   publication: Publication;
   showMore?: boolean;
+  nestedEmbeds?: boolean;
 }
 
 const PublicationBody: FC<PublicationBodyProps> = ({
   publication,
-  showMore = false
+  showMore = false,
+  nestedEmbeds = true
 }) => {
   const canShowMore = publication?.metadata?.content?.length > 450 && showMore;
   const urls = getURLs(publication?.metadata?.content);
@@ -49,7 +51,7 @@ const PublicationBody: FC<PublicationBodyProps> = ({
 
   const showAttachments = publication?.metadata?.media?.length > 0;
   const showSnapshot = snapshotProposalId;
-  const showPublicationEmbed = renderPublications.length > 0;
+  const showPublicationEmbed = renderPublications.length > 0 && nestedEmbeds;
   const showOembed =
     hasURLs && !showAttachments && !showSnapshot && !showPublicationEmbed;
 

--- a/apps/web/src/components/Publication/PublicationBody.tsx
+++ b/apps/web/src/components/Publication/PublicationBody.tsx
@@ -1,5 +1,5 @@
 import Attachments from '@components/Shared/Attachments';
-import Profile from '@components/Shared/Embed/Publication';
+import Quote from '@components/Shared/Embed/Quote';
 import Markup from '@components/Shared/Markup';
 import Oembed from '@components/Shared/Oembed';
 import Snapshot from '@components/Shared/Snapshot';
@@ -79,7 +79,7 @@ const PublicationBody: FC<PublicationBodyProps> = ({
         />
       ) : null}
       {showPublicationEmbed ? (
-        <Profile publicationIds={renderPublications} />
+        <Quote publicationIds={renderPublications} />
       ) : null}
       {showSnapshot ? <Snapshot proposalId={snapshotProposalId} /> : null}
       {showOembed ? <Oembed url={urls[0]} /> : null}

--- a/apps/web/src/components/Publication/QuotedPublication.tsx
+++ b/apps/web/src/components/Publication/QuotedPublication.tsx
@@ -1,0 +1,44 @@
+import type { Publication } from '@lenster/lens';
+import { useRouter } from 'next/router';
+import type { FC } from 'react';
+
+import HiddenPublication from './HiddenPublication';
+import PublicationBody from './PublicationBody';
+import PublicationHeader from './PublicationHeader';
+
+interface QuotedPublicationProps {
+  publication: Publication;
+}
+
+const QuotedPublication: FC<QuotedPublicationProps> = ({ publication }) => {
+  const { push } = useRouter();
+
+  return (
+    <article
+      className="cursor-pointer p-5 first:rounded-t-xl last:rounded-b-xl hover:bg-gray-100 dark:hover:bg-gray-900"
+      onClick={() => {
+        const selection = window.getSelection();
+        if (!selection || selection.toString().length === 0) {
+          push(`/posts/${publication?.id}`);
+        }
+      }}
+      data-testid={`publication-${publication.id}`}
+      aria-hidden="true"
+    >
+      <PublicationHeader publication={publication} />
+      <div className="ml-[53px]">
+        {publication?.hidden ? (
+          <HiddenPublication type={publication.__typename} />
+        ) : (
+          <PublicationBody
+            publication={publication}
+            showMore
+            nestedEmbeds={false}
+          />
+        )}
+      </div>
+    </article>
+  );
+};
+
+export default QuotedPublication;

--- a/apps/web/src/components/Publication/QuotedPublication.tsx
+++ b/apps/web/src/components/Publication/QuotedPublication.tsx
@@ -1,5 +1,5 @@
+import PublicationWrapper from '@components/Shared/PublicationWrapper';
 import type { Publication } from '@lenster/lens';
-import { useRouter } from 'next/router';
 import type { FC } from 'react';
 
 import HiddenPublication from './HiddenPublication';
@@ -11,19 +11,10 @@ interface QuotedPublicationProps {
 }
 
 const QuotedPublication: FC<QuotedPublicationProps> = ({ publication }) => {
-  const { push } = useRouter();
-
   return (
-    <article
+    <PublicationWrapper
       className="cursor-pointer p-5 first:rounded-t-xl last:rounded-b-xl hover:bg-gray-100 dark:hover:bg-gray-900"
-      onClick={() => {
-        const selection = window.getSelection();
-        if (!selection || selection.toString().length === 0) {
-          push(`/posts/${publication?.id}`);
-        }
-      }}
-      data-testid={`publication-${publication.id}`}
-      aria-hidden="true"
+      publication={publication}
     >
       <PublicationHeader publication={publication} />
       <div className="ml-[53px]">
@@ -37,7 +28,7 @@ const QuotedPublication: FC<QuotedPublicationProps> = ({ publication }) => {
           />
         )}
       </div>
-    </article>
+    </PublicationWrapper>
   );
 };
 

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -1,6 +1,6 @@
 import ActionType from '@components/Home/Timeline/EventType';
+import PublicationWrapper from '@components/Shared/PublicationWrapper';
 import type { ElectedMirror, FeedItem, Publication } from '@lenster/lens';
-import { useRouter } from 'next/router';
 import type { FC } from 'react';
 
 import PublicationActions from './Actions';
@@ -29,7 +29,6 @@ const SinglePublication: FC<SinglePublicationProps> = ({
   showThread = true,
   showMore = true
 }) => {
-  const { push } = useRouter();
   const firstComment = feedItem?.comments && feedItem.comments[0];
   const rootPublication = feedItem
     ? firstComment
@@ -38,16 +37,9 @@ const SinglePublication: FC<SinglePublicationProps> = ({
     : publication;
 
   return (
-    <article
+    <PublicationWrapper
       className="cursor-pointer p-5 first:rounded-t-xl last:rounded-b-xl hover:bg-gray-100 dark:hover:bg-gray-900"
-      onClick={() => {
-        const selection = window.getSelection();
-        if (!selection || selection.toString().length === 0) {
-          push(`/posts/${rootPublication?.id}`);
-        }
-      }}
-      data-testid={`publication-${publication.id}`}
-      aria-hidden="true"
+      publication={publication}
     >
       {feedItem ? (
         <ActionType feedItem={feedItem} />
@@ -83,7 +75,7 @@ const SinglePublication: FC<SinglePublicationProps> = ({
           </>
         )}
       </div>
-    </article>
+    </PublicationWrapper>
   );
 };
 

--- a/apps/web/src/components/Publication/ThreadBody.tsx
+++ b/apps/web/src/components/Publication/ThreadBody.tsx
@@ -1,5 +1,5 @@
+import PublicationWrapper from '@components/Shared/PublicationWrapper';
 import type { Publication } from '@lenster/lens';
-import { useRouter } from 'next/router';
 import type { FC } from 'react';
 
 import PublicationActions from './Actions';
@@ -12,18 +12,8 @@ interface ThreadBodyProps {
 }
 
 const ThreadBody: FC<ThreadBodyProps> = ({ publication }) => {
-  const { push } = useRouter();
-
   return (
-    <article
-      onClick={() => {
-        const selection = window.getSelection();
-        if (!selection || selection.toString().length === 0) {
-          push(`/posts/${publication?.id}`);
-        }
-      }}
-      aria-hidden="true"
-    >
+    <PublicationWrapper publication={publication}>
       <PublicationHeader publication={publication} />
       <div className="flex">
         <div className="-my-6 ml-5 mr-8 border-[0.8px] border-gray-300 bg-gray-300 dark:border-gray-700 dark:bg-gray-700" />
@@ -38,7 +28,7 @@ const ThreadBody: FC<ThreadBodyProps> = ({ publication }) => {
           )}
         </div>
       </div>
-    </article>
+    </PublicationWrapper>
   );
 };
 

--- a/apps/web/src/components/Shared/Embed/Quote.tsx
+++ b/apps/web/src/components/Shared/Embed/Quote.tsx
@@ -1,4 +1,4 @@
-import SinglePublication from '@components/Publication/SinglePublication';
+import QuotedPublication from '@components/Publication/QuotedPublication';
 import type { Publication } from '@lenster/lens';
 import { usePublicationQuery } from '@lenster/lens';
 import type { FC } from 'react';
@@ -29,13 +29,7 @@ const Quote: FC<PublicationProps> = ({ publicationIds }) => {
 
   return (
     <Wrapper zeroPadding>
-      <SinglePublication
-        publication={data.publication as Publication}
-        showThread={false}
-        showType={false}
-        showActions={false}
-        showMore
-      />
+      <QuotedPublication publication={data.publication as Publication} />
     </Wrapper>
   );
 };

--- a/apps/web/src/components/Shared/Embed/Quote.tsx
+++ b/apps/web/src/components/Shared/Embed/Quote.tsx
@@ -1,5 +1,6 @@
 import SinglePublication from '@components/Publication/SinglePublication';
-import { Publication, usePublicationQuery } from '@lenster/lens';
+import type { Publication } from '@lenster/lens';
+import { usePublicationQuery } from '@lenster/lens';
 import type { FC } from 'react';
 
 import PublicationShimmer from '../Shimmer/PublicationShimmer';
@@ -9,7 +10,7 @@ interface PublicationProps {
   publicationIds: string[];
 }
 
-const Publication: FC<PublicationProps> = ({ publicationIds }) => {
+const Quote: FC<PublicationProps> = ({ publicationIds }) => {
   const { data, loading, error } = usePublicationQuery({
     variables: { request: { publicationId: publicationIds[0] } }
   });
@@ -39,4 +40,4 @@ const Publication: FC<PublicationProps> = ({ publicationIds }) => {
   );
 };
 
-export default Publication;
+export default Quote;

--- a/apps/web/src/components/Shared/PublicationWrapper.tsx
+++ b/apps/web/src/components/Shared/PublicationWrapper.tsx
@@ -1,0 +1,36 @@
+import type { Publication } from '@lenster/lens';
+import clsx from 'clsx';
+import { useRouter } from 'next/router';
+import type { FC, ReactNode } from 'react';
+
+interface PublicationWrapperProps {
+  publication: Publication;
+  className?: string;
+  children: ReactNode[];
+}
+
+const PublicationWrapper: FC<PublicationWrapperProps> = ({
+  publication,
+  className = '',
+  children
+}) => {
+  const { push } = useRouter();
+
+  return (
+    <article
+      className={clsx(className)}
+      onClick={() => {
+        const selection = window.getSelection();
+        if (!selection || selection.toString().length === 0) {
+          push(`/posts/${publication?.id}`);
+        }
+      }}
+      data-testid={`publication-${publication.id}`}
+      aria-hidden="true"
+    >
+      {children}
+    </article>
+  );
+};
+
+export default PublicationWrapper;

--- a/apps/web/src/locales/en/messages.po
+++ b/apps/web/src/locales/en/messages.po
@@ -313,7 +313,7 @@ msgid "What's happening?"
 msgstr ""
 
 #: src/components/Composer/NewPublication.tsx
-#: src/components/Publication/Actions/Mirror.tsx
+#: src/components/Publication/Actions/Share/Mirror.tsx
 msgid "Momoka is currently in beta - during this time certain actions are not available to all profiles."
 msgstr "Momoka is currently in beta - during this time certain actions are not available to all profiles."
 
@@ -1547,18 +1547,6 @@ msgstr ""
 msgid "Translate"
 msgstr ""
 
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Post has been mirrored!"
-msgstr "Post has been mirrored!"
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "{0} Mirrors"
-msgstr ""
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Mirror"
-msgstr ""
-
 #: src/components/Publication/Actions/Mod.tsx
 #: src/components/Shared/GlobalAlerts.tsx
 msgid "Mod actions"
@@ -1575,6 +1563,23 @@ msgstr "Poor content"
 #: src/components/Publication/Actions/ModAction/index.tsx
 msgid "Stop Sponsor"
 msgstr "Stop Sponsor"
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Post has been mirrored!"
+msgstr "Post has been mirrored!"
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Unmirror"
+msgstr "Unmirror"
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "Mirror"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "{0} Mirrors"
+msgstr ""
 
 #: src/components/Publication/DecryptedPublicationBody.tsx
 msgid "To view this..."
@@ -2741,8 +2746,8 @@ msgid "Unfollow"
 msgstr ""
 
 #: src/components/Shared/Uniswap.tsx
-msgid "You don't have enough <0>{0}</0>"
-msgstr ""
+msgid "You don't have enough <0>{currency}</0>"
+msgstr "You don't have enough <0>{currency}</0>"
 
 #: src/components/Shared/Uniswap.tsx
 msgid "Swap in Uniswap"

--- a/apps/web/src/locales/fr/messages.po
+++ b/apps/web/src/locales/fr/messages.po
@@ -313,7 +313,7 @@ msgid "What's happening?"
 msgstr ""
 
 #: src/components/Composer/NewPublication.tsx
-#: src/components/Publication/Actions/Mirror.tsx
+#: src/components/Publication/Actions/Share/Mirror.tsx
 msgid "Momoka is currently in beta - during this time certain actions are not available to all profiles."
 msgstr ""
 
@@ -1547,18 +1547,6 @@ msgstr ""
 msgid "Translate"
 msgstr ""
 
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Post has been mirrored!"
-msgstr ""
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "{0} Mirrors"
-msgstr ""
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Mirror"
-msgstr ""
-
 #: src/components/Publication/Actions/Mod.tsx
 #: src/components/Shared/GlobalAlerts.tsx
 msgid "Mod actions"
@@ -1574,6 +1562,23 @@ msgstr ""
 
 #: src/components/Publication/Actions/ModAction/index.tsx
 msgid "Stop Sponsor"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Post has been mirrored!"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Unmirror"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "Mirror"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "{0} Mirrors"
 msgstr ""
 
 #: src/components/Publication/DecryptedPublicationBody.tsx
@@ -2741,7 +2746,7 @@ msgid "Unfollow"
 msgstr ""
 
 #: src/components/Shared/Uniswap.tsx
-msgid "You don't have enough <0>{0}</0>"
+msgid "You don't have enough <0>{currency}</0>"
 msgstr ""
 
 #: src/components/Shared/Uniswap.tsx
@@ -2903,4 +2908,3 @@ msgstr ""
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr ""
-

--- a/apps/web/src/locales/ru/messages.po
+++ b/apps/web/src/locales/ru/messages.po
@@ -313,7 +313,7 @@ msgid "What's happening?"
 msgstr "Что происходит?"
 
 #: src/components/Composer/NewPublication.tsx
-#: src/components/Publication/Actions/Mirror.tsx
+#: src/components/Publication/Actions/Share/Mirror.tsx
 msgid "Momoka is currently in beta - during this time certain actions are not available to all profiles."
 msgstr ""
 
@@ -1547,18 +1547,6 @@ msgstr "Скопировано в буфер обмена!"
 msgid "Translate"
 msgstr "Перевести"
 
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Post has been mirrored!"
-msgstr ""
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "{0} Mirrors"
-msgstr ""
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Mirror"
-msgstr ""
-
 #: src/components/Publication/Actions/Mod.tsx
 #: src/components/Shared/GlobalAlerts.tsx
 msgid "Mod actions"
@@ -1575,6 +1563,23 @@ msgstr "Некачественный контент"
 #: src/components/Publication/Actions/ModAction/index.tsx
 msgid "Stop Sponsor"
 msgstr "Прекратить спонсорство"
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Post has been mirrored!"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Unmirror"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "Mirror"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "{0} Mirrors"
+msgstr ""
 
 #: src/components/Publication/DecryptedPublicationBody.tsx
 msgid "To view this..."
@@ -2741,8 +2746,8 @@ msgid "Unfollow"
 msgstr "Отписаться"
 
 #: src/components/Shared/Uniswap.tsx
-msgid "You don't have enough <0>{0}</0>"
-msgstr "Вам не хватает <0>{0}</0>"
+msgid "You don't have enough <0>{currency}</0>"
+msgstr ""
 
 #: src/components/Shared/Uniswap.tsx
 msgid "Swap in Uniswap"
@@ -2903,4 +2908,3 @@ msgstr "Похоже, что-то пошло не так!"
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr "Мы автоматически отслеживаем эти ошибки, но если проблема не устранена, не стесняйтесь обращаться к нам. А пока попробуйте обновить страницу."
-

--- a/apps/web/src/locales/ta/messages.po
+++ b/apps/web/src/locales/ta/messages.po
@@ -313,7 +313,7 @@ msgid "What's happening?"
 msgstr "என்ன நடக்கிறது?"
 
 #: src/components/Composer/NewPublication.tsx
-#: src/components/Publication/Actions/Mirror.tsx
+#: src/components/Publication/Actions/Share/Mirror.tsx
 msgid "Momoka is currently in beta - during this time certain actions are not available to all profiles."
 msgstr ""
 
@@ -1547,18 +1547,6 @@ msgstr "கிளிப்போர்டுக்கு நகலெடுக�
 msgid "Translate"
 msgstr "மொழிபெயர்"
 
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Post has been mirrored!"
-msgstr "இடுகை மிரர் செய்யப்பட்டது!"
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "{0} Mirrors"
-msgstr "{0} மிரர்கள்"
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Mirror"
-msgstr "மிரர்"
-
 #: src/components/Publication/Actions/Mod.tsx
 #: src/components/Shared/GlobalAlerts.tsx
 msgid "Mod actions"
@@ -1575,6 +1563,23 @@ msgstr ""
 #: src/components/Publication/Actions/ModAction/index.tsx
 msgid "Stop Sponsor"
 msgstr "ஸ்பான்சரை நிறுத்து"
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Post has been mirrored!"
+msgstr "இடுகை மிரர் செய்யப்பட்டது!"
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Unmirror"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "Mirror"
+msgstr "மிரர்"
+
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "{0} Mirrors"
+msgstr "{0} மிரர்கள்"
 
 #: src/components/Publication/DecryptedPublicationBody.tsx
 msgid "To view this..."
@@ -2741,8 +2746,8 @@ msgid "Unfollow"
 msgstr "பின்தொடராதே"
 
 #: src/components/Shared/Uniswap.tsx
-msgid "You don't have enough <0>{0}</0>"
-msgstr "உங்களிடம் போதுமான <0>{0}</0> இல்லை"
+msgid "You don't have enough <0>{currency}</0>"
+msgstr ""
 
 #: src/components/Shared/Uniswap.tsx
 msgid "Swap in Uniswap"
@@ -2903,4 +2908,3 @@ msgstr "ஏதோ தவறாகிவிட்டது போல் தெர
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr "இந்தப் பிழைகளைத் தானாகக் கண்காணிக்கிறோம், ஆனால் சிக்கல் தொடர்ந்தால், எங்களைத் தொடர்பு கொள்ளலாம். இதற்கிடையில், புதுப்பித்து முயற்சிக்கவும்."
-

--- a/apps/web/src/locales/zh/messages.po
+++ b/apps/web/src/locales/zh/messages.po
@@ -313,7 +313,7 @@ msgid "What's happening?"
 msgstr "正在发生什么？"
 
 #: src/components/Composer/NewPublication.tsx
-#: src/components/Publication/Actions/Mirror.tsx
+#: src/components/Publication/Actions/Share/Mirror.tsx
 msgid "Momoka is currently in beta - during this time certain actions are not available to all profiles."
 msgstr ""
 
@@ -1547,18 +1547,6 @@ msgstr "已复制到剪贴板！"
 msgid "Translate"
 msgstr "翻译"
 
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Post has been mirrored!"
-msgstr "帖子已被转发！"
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "{0} Mirrors"
-msgstr "{0} 次转发"
-
-#: src/components/Publication/Actions/Mirror.tsx
-msgid "Mirror"
-msgstr "转发"
-
 #: src/components/Publication/Actions/Mod.tsx
 #: src/components/Shared/GlobalAlerts.tsx
 msgid "Mod actions"
@@ -1575,6 +1563,23 @@ msgstr ""
 #: src/components/Publication/Actions/ModAction/index.tsx
 msgid "Stop Sponsor"
 msgstr ""
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Post has been mirrored!"
+msgstr "帖子已被转发！"
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+msgid "Unmirror"
+msgstr ""
+
+#: src/components/Publication/Actions/Share/Mirror.tsx
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "Mirror"
+msgstr "转发"
+
+#: src/components/Publication/Actions/Share/index.tsx
+msgid "{0} Mirrors"
+msgstr "{0} 次转发"
 
 #: src/components/Publication/DecryptedPublicationBody.tsx
 msgid "To view this..."
@@ -2741,8 +2746,8 @@ msgid "Unfollow"
 msgstr "取消关注"
 
 #: src/components/Shared/Uniswap.tsx
-msgid "You don't have enough <0>{0}</0>"
-msgstr "您没有足够的 <0>{0}</0>"
+msgid "You don't have enough <0>{currency}</0>"
+msgstr ""
 
 #: src/components/Shared/Uniswap.tsx
 msgid "Swap in Uniswap"
@@ -2903,4 +2908,3 @@ msgstr "系统似乎出现了故障！"
 #: src/pages/500.tsx
 msgid "We track these errors automatically, but if the problem persists feel free to contact us. In the meantime, try refreshing."
 msgstr "我们会自动追踪这些错误，但如果问题仍然存在，请随时与我们联系。 与此同时，您可以尝试刷新页面。"
-


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e88a46f</samp>

Refactored the `Mirror` component to be part of a `ShareMenu` component that provides a dropdown menu for updating and viewing publication mirrors. Moved and renamed some files and components to improve the folder structure and code readability. Fixed some minor props ordering issues.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e88a46f</samp>

* Create a `ShareMenu` component that wraps the `Mirror` component in a dropdown menu ([link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-fe3133b014cbead6d4e8701cfda260911fa3a3403aa8d39887236f90c489c630R1-R81), [link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-62afa772382218b438f99bec5d9a172fc9beafa2de0ef1f667ca3cc06be8d699L10-R11), [link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-62afa772382218b438f99bec5d9a172fc9beafa2de0ef1f667ca3cc06be8d699L36-R38))
* Move the `Mirror` component to a subfolder and refactor it to render a `Menu.Item` instead of a `motion.button` ([link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-4240d7e3152a99edc7ce5b40d6f6b9025ba441e0cf8032de9ff6b8d093cc91f3L1-R4), [link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-4240d7e3152a99edc7ce5b40d6f6b9025ba441e0cf8032de9ff6b8d093cc91f3L19-R24), [link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-4240d7e3152a99edc7ce5b40d6f6b9025ba441e0cf8032de9ff6b8d093cc91f3L35-R34), [link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-4240d7e3152a99edc7ce5b40d6f6b9025ba441e0cf8032de9ff6b8d093cc91f3R59), [link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-4240d7e3152a99edc7ce5b40d6f6b9025ba441e0cf8032de9ff6b8d093cc91f3L213-R225))
* Update the `mirrors` field of the publication when creating a mirror ([link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-4240d7e3152a99edc7ce5b40d6f6b9025ba441e0cf8032de9ff6b8d093cc91f3R59))
* Move the `static` prop of the `Menu.Items` component to the end of the props list in `Attachment.tsx` ([link](https://github.com/lensterxyz/lenster/pull/3017/files?diff=unified&w=0#diff-dc7f47a750043dfcca0d0bca34caa131ec068b8537fbe5ba40dd64efcb5718ceL97-R98))

## Emoji

<!--
copilot:emoji
-->

🔀📁🖱️

<!--
1.  🔀 - This emoji represents the change of moving the `static` prop to the end of the props list, as well as the refactoring of the `Mirror` component to be part of a share menu. The emoji conveys the idea of switching or rearranging something.
2. 📁 - This emoji represents the creation of a new file and folder for the `ShareMenu` component. The emoji conveys the idea of organizing or grouping something.
3. 🖱️ - This emoji represents the improvement of the UI by adding a dropdown menu and a count of mirrors to the share button. The emoji conveys the idea of interacting or clicking something.
-->
