### PR TITLE
feat: add events for open modal

### DIFF
--- a/apps/web/src/components/Composer/Actions/Giphy/index.tsx
+++ b/apps/web/src/components/Composer/Actions/Giphy/index.tsx
@@ -2,12 +2,14 @@ import Loader from '@components/Shared/Loader';
 import type { IGif } from '@giphy/js-types';
 import { PhotographIcon } from '@heroicons/react/outline';
 import { Modal, Tooltip } from '@lenster/ui';
+import { Leafwatch } from '@lib/leafwatch';
 import { t } from '@lingui/macro';
 import { motion } from 'framer-motion';
 import dynamic from 'next/dynamic';
 import type { FC } from 'react';
 import { useState } from 'react';
 import { usePublicationStore } from 'src/store/publication';
+import { PUBLICATION } from 'src/tracking';
 
 const GifSelector = dynamic(() => import('./GifSelector'), {
   loading: () => <Loader message={t`Loading GIFs`} />
@@ -27,7 +29,10 @@ const Giphy: FC<GiphyProps> = ({ setGifAttachment }) => {
         <motion.button
           whileTap={{ scale: 0.9 }}
           type="button"
-          onClick={() => setShowModal(!showModal)}
+          onClick={() => {
+            setShowModal(!showModal);
+            Leafwatch.track(PUBLICATION.OPEN_GIFS);
+          }}
           disabled={attachments.length >= 4}
           aria-label="Choose GIFs"
         >

--- a/apps/web/src/components/Profile/Followerings.tsx
+++ b/apps/web/src/components/Profile/Followerings.tsx
@@ -2,9 +2,11 @@ import { UsersIcon } from '@heroicons/react/outline';
 import type { Profile } from '@lenster/lens';
 import humanize from '@lenster/lib/humanize';
 import { Modal } from '@lenster/ui';
+import { Leafwatch } from '@lib/leafwatch';
 import { Plural, t } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';
+import { PROFILE } from 'src/tracking';
 
 import Followers from './Followers';
 import Following from './Following';
@@ -22,7 +24,12 @@ const Followerings: FC<FolloweringsProps> = ({ profile }) => {
       <button
         type="button"
         className="text-left"
-        onClick={() => setShowFollowingModal(!showFollowingModal)}
+        onClick={() => {
+          setShowFollowingModal(!showFollowingModal);
+          Leafwatch.track(PROFILE.OPEN_FOLLOWING, {
+            profile_id: profile.id
+          });
+        }}
         data-testid="profile-followings"
       >
         <div className="text-xl">
@@ -40,7 +47,12 @@ const Followerings: FC<FolloweringsProps> = ({ profile }) => {
       <button
         type="button"
         className="text-left"
-        onClick={() => setShowFollowersModal(!showFollowersModal)}
+        onClick={() => {
+          setShowFollowersModal(!showFollowersModal);
+          Leafwatch.track(PROFILE.OPEN_FOLLOWERS, {
+            profile_id: profile.id
+          });
+        }}
         data-testid="profile-followers"
       >
         <div className="text-xl">

--- a/apps/web/src/components/Publication/PublicationStats.tsx
+++ b/apps/web/src/components/Publication/PublicationStats.tsx
@@ -9,9 +9,11 @@ import {
 import type { Publication } from '@lenster/lens';
 import nFormatter from '@lenster/lib/nFormatter';
 import { Modal } from '@lenster/ui';
+import { Leafwatch } from '@lib/leafwatch';
 import { Plural, t } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';
+import { PUBLICATION } from 'src/tracking';
 
 interface PublicationStatsProps {
   publication: Publication;
@@ -54,7 +56,12 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
           </span>
           <button
             type="button"
-            onClick={() => setShowMirrorsModal(true)}
+            onClick={() => {
+              setShowMirrorsModal(true);
+              Leafwatch.track(PUBLICATION.OPEN_MIRRORS, {
+                publication_id: publicationId
+              });
+            }}
             data-testid="mirror-stats"
           >
             <b className="text-black dark:text-white">
@@ -81,7 +88,12 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
         <>
           <button
             type="button"
-            onClick={() => setShowLikesModal(true)}
+            onClick={() => {
+              setShowLikesModal(true);
+              Leafwatch.track(PUBLICATION.OPEN_LIKES, {
+                publication_id: publicationId
+              });
+            }}
             data-testid="like-stats"
           >
             <b className="text-black dark:text-white">
@@ -108,7 +120,12 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
         <>
           <button
             type="button"
-            onClick={() => setShowCollectorsModal(true)}
+            onClick={() => {
+              setShowCollectorsModal(true);
+              Leafwatch.track(PUBLICATION.OPEN_COLLECTORS, {
+                publication_id: publicationId
+              });
+            }}
             data-testid="collect-stats"
           >
             <b className="text-black dark:text-white">

--- a/apps/web/src/tracking.ts
+++ b/apps/web/src/tracking.ts
@@ -15,6 +15,8 @@ export const PROFILE = {
   UNFOLLOW: 'Unfollow profile',
   DISMISS_RECOMMENDED_PROFILE: 'Dismiss recommended profile',
   OPEN_SUPER_FOLLOW: 'Open super follow modal',
+  OPEN_FOLLOWERS: 'Open followers modal',
+  OPEN_FOLLOWING: 'Open following modal',
   SWITCH_PROFILE_FEED_TAB: 'Switch profile feed tab',
   SWITCH_PROFILE: 'Switch profile',
   LOGOUT: 'Profile logout'
@@ -33,6 +35,9 @@ export const PUBLICATION = {
   CLICK_OEMBED: 'Click publication oembed',
   CLICK_HASHTAG: 'Click publication hashtag',
   CLICK_MENTION: 'Click publication mention',
+  OPEN_LIKES: 'Open likes modal',
+  OPEN_MIRRORS: 'Open mirrors modal',
+  OPEN_COLLECTORS: 'Open collectors modal',
   ATTACHMENT: {
     IMAGE: {
       OPEN: 'Open image attachment'

--- a/apps/web/src/tracking.ts
+++ b/apps/web/src/tracking.ts
@@ -38,6 +38,7 @@ export const PUBLICATION = {
   OPEN_LIKES: 'Open likes modal',
   OPEN_MIRRORS: 'Open mirrors modal',
   OPEN_COLLECTORS: 'Open collectors modal',
+  OPEN_GIFS: 'Open GIFs modal',
   ATTACHMENT: {
     IMAGE: {
       OPEN: 'Open image attachment'


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8b8b7a</samp>

Added `Leafwatch` tracking events to profile and publication pages. This allows the app to monitor how users interact with these features and improve them accordingly. Modified `Followerings.tsx`, `PublicationStats.tsx`, and `tracking.ts` to implement the tracking logic.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8b8b7a</samp>

*  Add user event tracking to profile and publication pages using `Leafwatch` module
  * Import `Leafwatch` and event constants from `@lib/leafwatch` and `src/tracking.ts` ([link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-c1b63c5704541e82f960539940f3430fba6bd92d8d003dde2f34b4ad664e6dafL5-R9), [link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-5826830061471498bb1147c05f83995f283dc9023c80c91b16a0aeb5aebe0702L12-R16), [link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-0de632705ed1f05ebcd4fe3b52d970b5c5cbabcddb8c1b9eabd948887cd6eab3R18-R19), [link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-0de632705ed1f05ebcd4fe3b52d970b5c5cbabcddb8c1b9eabd948887cd6eab3R38-R40))
  * Call `Leafwatch.track` with event name and id parameters in `onClick` handlers for buttons that open modals ([link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-c1b63c5704541e82f960539940f3430fba6bd92d8d003dde2f34b4ad664e6dafL25-R32), [link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-c1b63c5704541e82f960539940f3430fba6bd92d8d003dde2f34b4ad664e6dafL43-R55), [link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-5826830061471498bb1147c05f83995f283dc9023c80c91b16a0aeb5aebe0702L57-R64), [link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-5826830061471498bb1147c05f83995f283dc9023c80c91b16a0aeb5aebe0702L84-R96), [link](https://github.com/lensterxyz/lenster/pull/3054/files?diff=unified&w=0#diff-5826830061471498bb1147c05f83995f283dc9023c80c91b16a0aeb5aebe0702L111-R128))

## Emoji

<!--
copilot:emoji
-->

🍃📄👥

<!--
1.  🍃 - This emoji represents the `Leafwatch` tracking service, which is used to send user events from the app. It also matches the name of the service, which is related to leaves and plants.
2.  📄 - This emoji represents the publication page, which is one of the main features of the app where users can view and interact with different publications. It also resembles a paper document, which is a common format for publications.
3.  👥 - This emoji represents the profile page, which is another important feature of the app where users can view and manage their own profile and follow other users. It also depicts two people, which symbolizes the social aspect of the app and the followers and following buttons.
-->
