### PR TITLE
chore: update space design

### DIFF
--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -711,7 +711,7 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
           traitType: 'space',
           displayType: PublicationMetadataDisplayTypes.String,
           value: JSON.stringify({
-            id: 'sso-tdfr-ths',
+            id: 'fci-ggbe-bxl',
             host: '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3'
           })
         },

--- a/apps/web/src/components/Shared/Embed/Space/SpaceUser.tsx
+++ b/apps/web/src/components/Shared/Embed/Space/SpaceUser.tsx
@@ -9,10 +9,18 @@ import { Image } from '@lenster/ui';
 import { type FC } from 'react';
 
 interface SpaceUserProps {
-  profileId: string;
+  peer: {
+    peerId: string;
+    role: any;
+    mic: MediaStreamTrack;
+    cam: MediaStreamTrack;
+    displayName: string;
+  };
 }
 
-const SpaceUser: FC<SpaceUserProps> = ({ profileId }) => {
+const SpaceUser: FC<SpaceUserProps> = ({ peer }) => {
+  const profileId = peer.displayName;
+
   const { data, loading } = useProfileQuery({
     variables: { request: { profileId } },
     skip: !profileId || profileId === 'Guest'
@@ -51,7 +59,12 @@ const SpaceUser: FC<SpaceUserProps> = ({ profileId }) => {
   return (
     <div className="flex flex-col items-center space-y-2">
       <UserAvatar />
-      <UserName />
+      <div className="space-y-1 text-center">
+        <UserName />
+        <div className="lt-text-gray-500 text-xs">
+          {peer.role === 'host' ? 'Host' : 'Listener'}
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6fbb333</samp>

Updated the `SpacePlayer` and `SpaceUser` components to use a custom hook for meeting state and improve the UI. Changed a mock publication ID in `NewPublication.tsx` for testing.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6fbb333</samp>

*  Import and use `useMeetingMachine` hook to manage meeting logic and events ([link](https://github.com/lensterxyz/lenster/pull/3063/files?diff=unified&w=0#diff-492206f51e1e5dcd6e661b3d0377dcba06c10eb11ec6f62794bc71fa649c7adeR10), [link](https://github.com/lensterxyz/lenster/pull/3063/files?diff=unified&w=0#diff-492206f51e1e5dcd6e661b3d0377dcba06c10eb11ec6f62794bc71fa649c7adeR46), [link](https://github.com/lensterxyz/lenster/pull/3063/files?diff=unified&w=0#diff-492206f51e1e5dcd6e661b3d0377dcba06c10eb11ec6f62794bc71fa649c7adeL78-R154))
*  Modify `SpacePlayer` component to render audio and video tracks of peers in a grid and show their roles ([link](https://github.com/lensterxyz/lenster/pull/3063/files?diff=unified&w=0#diff-492206f51e1e5dcd6e661b3d0377dcba06c10eb11ec6f62794bc71fa649c7adeL78-R154))
*  Add buttons for talking, muting, and leaving the space and send events to the state machine on user interaction ([link](https://github.com/lensterxyz/lenster/pull/3063/files?diff=unified&w=0#diff-492206f51e1e5dcd6e661b3d0377dcba06c10eb11ec6f62794bc71fa649c7adeL78-R154))
*  Change `SpaceUser` component props from `profileId` to `peer` object with peer ID, role, mic, cam, and display name ([link](https://github.com/lensterxyz/lenster/pull/3063/files?diff=unified&w=0#diff-1ae8874e5efec79043c61351398b93c230fd92fbe4da144b6ae37181445532ecL12-R23))
*  Show the role of each peer below the user name in `SpaceUser` component ([link](https://github.com/lensterxyz/lenster/pull/3063/files?diff=unified&w=0#diff-1ae8874e5efec79043c61351398b93c230fd92fbe4da144b6ae37181445532ecL54-R67))
*  Change the publication ID from 'sso-tdfr-ths' to 'fci-ggbe-bxl' in `NewPublication.tsx` for testing purposes ([link](https://github.com/lensterxyz/lenster/pull/3063/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L714-R714))

## Emoji

<!--
copilot:emoji
-->

🆔🎛️👥

<!--
1.  🆔 - This emoji can be used to indicate a change in the publication ID, which is a unique identifier for the space. It also suggests the idea of authentication or identity, which is related to the SSO feature.
2. 🎛️ - This emoji can be used to indicate a change in the `SpacePlayer` component, which handles the meeting logic and the user controls. It suggests the idea of adjusting or tuning the settings or parameters of the meeting, as well as the interaction with the UI elements.
3. 👥 - This emoji can be used to indicate a change in the `SpaceUser` component, which displays the peers in the meeting. It suggests the idea of collaboration or communication among the participants, as well as the role or status of each peer.
-->
