### PR TITLE
feat: add isLive endpoint for spaces

### DIFF
--- a/apps/web/src/components/Shared/Embed/Space/SpacePlayer.tsx
+++ b/apps/web/src/components/Shared/Embed/Space/SpacePlayer.tsx
@@ -55,7 +55,7 @@ const SpacePlayer: FC<SpacePlayerProps> = ({ publication, space }) => {
   });
 
   useEffectOnce(() => {
-    initialize('KL1r3E1yHfcrRbXsT4mcE-3mK60Yc3YR');
+    initialize('u7iRM97r22gySZASwaz3kqLdZFFJfqE6');
   });
 
   useUpdateEffect(() => {

--- a/packages/workers/spaces/src/handlers/isLive.ts
+++ b/packages/workers/spaces/src/handlers/isLive.ts
@@ -1,0 +1,35 @@
+import type { Env } from '../types';
+
+type IsLiveResponse = {
+  roomId: string;
+};
+
+export default async (spaceId: string, env: Env) => {
+  try {
+    const huddleResponse = await fetch(
+      `http://api.huddle01.com/api/v1/live-meeting?roomId=${spaceId}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-api-key': env.HUDDLE_API_KEY
+        }
+      }
+    );
+
+    const isLiveResponse: IsLiveResponse = await huddleResponse.json();
+    console.log('huddleResponse', isLiveResponse);
+
+    return new Response(
+      JSON.stringify({
+        success: false,
+        isLive: isLiveResponse.roomId === spaceId
+      })
+    );
+  } catch (error) {
+    console.error('Failed to get room isLive', error);
+    return new Response(
+      JSON.stringify({ success: false, error: 'Something went wrong!' })
+    );
+  }
+};

--- a/packages/workers/spaces/src/index.ts
+++ b/packages/workers/spaces/src/index.ts
@@ -1,6 +1,7 @@
 import { createCors, error, json, Router } from 'itty-router';
 
 import createSpace from './handlers/createSpace';
+import isLive from './handlers/isLive';
 import type { Env } from './types';
 
 const { preflight, corsify } = createCors({
@@ -12,6 +13,9 @@ const router = Router();
 
 router.all('*', preflight);
 router.get('/', () => new Response('say gm to spaces service 👋'));
+router.get('/isLive/:spaceId', ({ params }, env) =>
+  isLive(params.spaceId, env)
+);
 router.post('/createSpace', createSpace);
 
 const routerHandleStack = (request: Request, env: Env, ctx: ExecutionContext) =>


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1cddc96</samp>

Added a new feature to check if a space is live using the Huddle API. Updated the `SpacePlayer` component and the spaces worker with a new route, a new handler, and a test API key.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1cddc96</samp>

*  Add a handler to check the live status of a space using the Huddle API ([link](https://github.com/lensterxyz/lenster/pull/3103/files?diff=unified&w=0#diff-faf66de6019d09b52219e0538e8c84cceb7c9a815d6aa0b23b3330545a7f6749R1-R35), [link](https://github.com/lensterxyz/lenster/pull/3103/files?diff=unified&w=0#diff-ed28d2a96123b8294b90b90302fc21bec972692612872af1b4bca9c551d7939eR4), [link](https://github.com/lensterxyz/lenster/pull/3103/files?diff=unified&w=0#diff-ed28d2a96123b8294b90b90302fc21bec972692612872af1b4bca9c551d7939eR16-R18))
* Update the `SpacePlayer` component to use a different Huddle API key for testing ([link](https://github.com/lensterxyz/lenster/pull/3103/files?diff=unified&w=0#diff-492206f51e1e5dcd6e661b3d0377dcba06c10eb11ec6f62794bc71fa649c7adeL58-R58))

## Emoji

<!--
copilot:emoji
-->

🔑🎥🚀

<!--
1.  🔑 - This emoji represents the change of the Huddle API key, which is a key or credential for accessing the video player SDK.
2.  🎥 - This emoji represents the addition of the `isLive` handler and the route to check the live status of a space, which are related to video streaming and broadcasting.
3.  🚀 - This emoji represents the improvement of the user experience by enabling the live feature for spaces, which is a launch or release of a new functionality.
-->
