### PR TITLE
fix: use native index for border radius than css for better DX

### DIFF
--- a/apps/web/src/components/Comment/Feed.tsx
+++ b/apps/web/src/components/Comment/Feed.tsx
@@ -15,7 +15,7 @@ import {
 } from '@lenster/lens';
 import { Card, EmptyState, ErrorMessage } from '@lenster/ui';
 import { t } from '@lingui/macro';
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 import { useState } from 'react';
 import { useInView } from 'react-cool-inview';
 import { OptmisticPublicationType } from 'src/enums';
@@ -87,50 +87,75 @@ const Feed: FC<FeedProps> = ({ publication }) => {
     }
   });
 
-  return (
-    <>
-      {currentProfile && !publication?.hidden ? (
-        canComment ? (
-          <NewPublication publication={publication} />
-        ) : (
-          <CommentWarning />
-        )
-      ) : null}
-      {loading && <PublicationsShimmer />}
-      {!publication?.hidden && !loading && totalComments === 0 && (
+  const Wrapper = ({ children }: { children: ReactNode }) => {
+    return (
+      <>
+        {currentProfile && !publication?.hidden ? (
+          canComment ? (
+            <NewPublication publication={publication} />
+          ) : (
+            <CommentWarning />
+          )
+        ) : null}
+        {children}
+      </>
+    );
+  };
+
+  if (loading) {
+    return (
+      <Wrapper>
+        <PublicationsShimmer />
+      </Wrapper>
+    );
+  }
+
+  if (error) {
+    return (
+      <Wrapper>
+        <ErrorMessage title={t`Failed to load comment feed`} error={error} />
+      </Wrapper>
+    );
+  }
+
+  if (!publication?.hidden && totalComments === 0) {
+    return (
+      <Wrapper>
         <EmptyState
           message={t`Be the first one to comment!`}
           icon={<ChatAlt2Icon className="text-brand h-8 w-8" />}
         />
+      </Wrapper>
+    );
+  }
+
+  return (
+    <Card
+      className="divide-y-[1px] dark:divide-gray-700"
+      dataTestId="comments-feed"
+    >
+      {txnQueue.map(
+        (txn) =>
+          txn?.type === OptmisticPublicationType.NewComment &&
+          txn?.parent === publication?.id && (
+            <div key={txn.id}>
+              <QueuedPublication txn={txn} />
+            </div>
+          )
       )}
-      <ErrorMessage title={t`Failed to load comment feed`} error={error} />
-      {!error && !loading && totalComments !== 0 && (
-        <Card
-          className="divide-y-[1px] dark:divide-gray-700"
-          dataTestId="comments-feed"
-        >
-          {txnQueue.map(
-            (txn) =>
-              txn?.type === OptmisticPublicationType.NewComment &&
-              txn?.parent === publication?.id && (
-                <div key={txn.id}>
-                  <QueuedPublication txn={txn} />
-                </div>
-              )
-          )}
-          {comments?.map((comment, index) =>
-            comment?.__typename === 'Comment' && comment.hidden ? null : (
-              <SinglePublication
-                key={`${publicationId}_${index}`}
-                publication={comment as Comment}
-                showType={false}
-              />
-            )
-          )}
-          {hasMore && <span ref={observe} />}
-        </Card>
+      {comments?.map((comment, index) =>
+        comment?.__typename === 'Comment' && comment.hidden ? null : (
+          <SinglePublication
+            key={`${publicationId}_${index}`}
+            isFirst={index === 0}
+            isLast={index === comments.length - 1}
+            publication={comment as Comment}
+            showType={false}
+          />
+        )
       )}
-    </>
+      {hasMore && <span ref={observe} />}
+    </Card>
   );
 };
 

--- a/apps/web/src/components/Comment/NoneRelevantFeed.tsx
+++ b/apps/web/src/components/Comment/NoneRelevantFeed.tsx
@@ -95,6 +95,8 @@ const NoneRelevantFeed: FC<NoneRelevantFeedProps> = ({ publication }) => {
             comment?.__typename === 'Comment' && comment.hidden ? null : (
               <SinglePublication
                 key={`${publicationId}_${index}`}
+                isFirst={index === 0}
+                isLast={index === comments.length - 1}
                 publication={comment as Comment}
                 showType={false}
               />

--- a/apps/web/src/components/Explore/Feed.tsx
+++ b/apps/web/src/components/Explore/Feed.tsx
@@ -95,6 +95,8 @@ const Feed: FC<FeedProps> = ({
       {publications?.map((publication, index) => (
         <SinglePublication
           key={`${publication.id}_${index}`}
+          isFirst={index === 0}
+          isLast={index === publications.length - 1}
           publication={publication as Publication}
         />
       ))}

--- a/apps/web/src/components/Home/Highlights.tsx
+++ b/apps/web/src/components/Home/Highlights.tsx
@@ -83,6 +83,8 @@ const Highlights: FC = () => {
       {publications?.map((publication, index) => (
         <SinglePublication
           key={`${publication?.id}_${index}`}
+          isFirst={index === 0}
+          isLast={index === publications.length - 1}
           publication={publication as Publication}
         />
       ))}

--- a/apps/web/src/components/Home/Timeline/index.tsx
+++ b/apps/web/src/components/Home/Timeline/index.tsx
@@ -112,6 +112,8 @@ const Timeline: FC = () => {
       {publications?.map((publication, index) => (
         <SinglePublication
           key={`${publication?.root.id}_${index}`}
+          isFirst={index === 0}
+          isLast={index === publications.length - 1}
           feedItem={publication as FeedItem}
           publication={publication.root as Publication}
         />

--- a/apps/web/src/components/Mod/Feed.tsx
+++ b/apps/web/src/components/Mod/Feed.tsx
@@ -105,6 +105,8 @@ const Feed: FC<FeedProps> = ({
       {publications?.map((publication, index) => (
         <SinglePublication
           key={`${publication.id}_${index}`}
+          isFirst={index === 0}
+          isLast={index === publications.length - 1}
           publication={publication as Publication}
           showThread={false}
           showActions={false}

--- a/apps/web/src/components/Profile/Feed.tsx
+++ b/apps/web/src/components/Profile/Feed.tsx
@@ -154,6 +154,8 @@ const Feed: FC<FeedProps> = ({ profile, type }) => {
       {publications?.map((publication, index) => (
         <SinglePublication
           key={`${publication.id}_${index}`}
+          isFirst={index === 0}
+          isLast={index === publications.length - 1}
           publication={publication as Publication}
           showThread={
             type !== ProfileFeedType.Media && type !== ProfileFeedType.Collects

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -1,6 +1,7 @@
 import ActionType from '@components/Home/Timeline/EventType';
 import PublicationWrapper from '@components/Shared/PublicationWrapper';
 import type { ElectedMirror, FeedItem, Publication } from '@lenster/lens';
+import clsx from 'clsx';
 import type { FC } from 'react';
 
 import PublicationActions from './Actions';
@@ -18,6 +19,8 @@ interface SinglePublicationProps {
   showModActions?: boolean;
   showThread?: boolean;
   showMore?: boolean;
+  isFirst?: boolean;
+  isLast?: boolean;
 }
 
 const SinglePublication: FC<SinglePublicationProps> = ({
@@ -27,7 +30,9 @@ const SinglePublication: FC<SinglePublicationProps> = ({
   showActions = true,
   showModActions = false,
   showThread = true,
-  showMore = true
+  showMore = true,
+  isFirst = false,
+  isLast = false
 }) => {
   const firstComment = feedItem?.comments && feedItem.comments[0];
   const rootPublication = feedItem
@@ -38,7 +43,11 @@ const SinglePublication: FC<SinglePublicationProps> = ({
 
   return (
     <PublicationWrapper
-      className="cursor-pointer p-5 first:rounded-t-xl last:rounded-b-xl hover:bg-gray-100 dark:hover:bg-gray-900"
+      className={clsx(
+        isFirst && 'rounded-t-xl',
+        isLast && 'rounded-b-xl',
+        'cursor-pointer p-5 hover:bg-gray-100 dark:hover:bg-gray-900'
+      )}
       publication={rootPublication}
     >
       {feedItem ? (


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34cf0f4</samp>

Refactored the `Feed` component for comments to use a common `Wrapper` component. Added `isFirst` and `isLast` props to the `SinglePublication` component and used them in various components that render publication lists to apply rounded corners to the first and last items. This improves the code quality and the UI consistency of the publication list views.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 34cf0f4</samp>

*  Refactor `Feed` component to use `Wrapper` component for common elements and simplify conditional rendering logic ([link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-92573b726b084d05a197c040a5ec0f3a357331fdbe006100cc17662f002ee7f9L18-R18), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-92573b726b084d05a197c040a5ec0f3a357331fdbe006100cc17662f002ee7f9L90-R158))
*  Add `isFirst` and `isLast` props to `SinglePublication` component and use `clsx` to conditionally apply rounded corners to the first and last publications in a list ([link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9R4), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9R22-R23), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9L30-R35), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9L41-R50))
*  Pass `isFirst` and `isLast` props to `SinglePublication` component in various components that render lists of publications, such as `NoneRelevantFeed`, `Feed`, `Highlights`, `Timeline`, and `Mod/Feed` ([link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-a723bb0728607b24fb3f3136980c85acbbac968c920e62ab44129478e3bd769fR98-R99), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-91b8a03cf0576eccd727dc531886c16eab0b27440da8250ffc770694666a9790R98-R99), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-f1d914bec117253e3b7c15315d31e486b91c54ca9a76032225ac70eb924e16d0R86-R87), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-77c1f224dc344d814158048dcfa273b2cd34abbffe4ff264bcd4e420e340d0d5R115-R116), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-5b0f1e4e58cbb931cf2d813a50520a75df01037dc208d5409fc40dd5189fd498R108-R109), [link](https://github.com/lensterxyz/lenster/pull/3118/files?diff=unified&w=0#diff-4f1019d968a6c4b10b6415e98ae00761530df83bd2b1c38c98bf5837dc40393cR157-R158))

## Emoji

<!--
copilot:emoji
-->

🎨🧹📦

<!--
1.  🎨 - This emoji represents the UI improvement of adding rounded corners to the first and last publications in the list, which enhances the visual appeal and user experience of the app.
2.  🧹 - This emoji represents the code refactoring of the `Feed` component, which cleans up the code and makes it more modular and reusable.
3.  📦 - This emoji represents the addition of the `clsx` library and new props to the `SinglePublication` component, which packages the logic and styling of the rounded corners in a more concise and flexible way.
-->
