### PR TITLE
feat: use useReadLocalStorage hook for getting accessToken

### DIFF
--- a/apps/web/src/components/Shared/Snapshot/Choices.tsx
+++ b/apps/web/src/components/Shared/Snapshot/Choices.tsx
@@ -20,6 +20,7 @@ import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useAppStore } from 'src/store/app';
 import { PUBLICATION } from 'src/tracking';
+import { useReadLocalStorage } from 'usehooks-ts';
 
 import New from '../Badges/New';
 import VoteProposal from './VoteProposal';
@@ -44,6 +45,7 @@ const Choices: FC<ChoicesProps> = ({
     show: false,
     position: 0
   });
+  const accessToken = useReadLocalStorage('accessToken');
 
   const { id, choices, symbol, scores, scores_total, state, type, end } =
     proposal;
@@ -101,7 +103,7 @@ const Choices: FC<ChoicesProps> = ({
         method: 'POST',
         data: {
           isMainnet: IS_MAINNET,
-          accessToken: localStorage.getItem('accessToken'),
+          accessToken,
           choice: position,
           profileId: currentProfile.id,
           snapshotId: id

--- a/apps/web/src/components/utils/hooks/useCreateSpace.tsx
+++ b/apps/web/src/components/utils/hooks/useCreateSpace.tsx
@@ -1,9 +1,11 @@
 import { IS_MAINNET, SPACES_WORKER_URL } from '@lenster/data';
 import axios from 'axios';
+import { useReadLocalStorage } from 'usehooks-ts';
 
 type CreateSpaceResponse = string;
 
 const useCreateSpace = (): [createPoll: () => Promise<CreateSpaceResponse>] => {
+  const accessToken = useReadLocalStorage('accessToken');
   const createSpace = async (): Promise<CreateSpaceResponse> => {
     try {
       const response = await axios({
@@ -11,7 +13,7 @@ const useCreateSpace = (): [createPoll: () => Promise<CreateSpaceResponse>] => {
         method: 'POST',
         data: {
           isMainnet: IS_MAINNET,
-          accessToken: localStorage.getItem('accessToken')
+          accessToken
         }
       });
 

--- a/apps/web/src/lib/getIsAuthTokensAvailable.ts
+++ b/apps/web/src/lib/getIsAuthTokensAvailable.ts
@@ -1,11 +1,13 @@
+import { Localstorage } from '@lenster/data';
+
 /**
  * Checks if the access token and refresh token are available in local storage
  *
  * @returns True if the access token and refresh token are available, `false` otherwise
  */
 const getIsAuthTokensAvailable = () => {
-  const accessToken = localStorage.getItem('accessToken');
-  const refreshToken = localStorage.getItem('refreshToken');
+  const accessToken = localStorage.getItem(Localstorage.AccessToken);
+  const refreshToken = localStorage.getItem(Localstorage.RefreshToken);
   return accessToken !== 'undefined' && refreshToken !== 'undefined';
 };
 

--- a/packages/data/storage.ts
+++ b/packages/data/storage.ts
@@ -1,5 +1,7 @@
 // Localstorage keys
 export const Localstorage = {
+  AccessToken: 'accessToken',
+  RefreshToken: 'refreshToken',
   AttachmentStore: 'attachment.store',
   AttachmentCache: 'attachment-cache.store',
   LensterStore: 'lenster.store',

--- a/packages/lens/apollo/authLink.ts
+++ b/packages/lens/apollo/authLink.ts
@@ -25,7 +25,7 @@ const clearStorage = () => {
 };
 
 const authLink = new ApolloLink((operation, forward) => {
-  const accessToken = localStorage.getItem('accessToken');
+  const accessToken = localStorage.getItem(Localstorage.AccessToken);
 
   if (!accessToken || accessToken === 'undefined') {
     clearStorage();
@@ -52,7 +52,9 @@ const authLink = new ApolloLink((operation, forward) => {
         operationName: 'Refresh',
         query: REFRESH_AUTHENTICATION_MUTATION,
         variables: {
-          request: { refreshToken: localStorage.getItem('refreshToken') }
+          request: {
+            refreshToken: localStorage.getItem(Localstorage.RefreshToken)
+          }
         }
       })
     })


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d8e732</samp>

This pull request refactors several components and functions to use a custom hook and a shared enum for accessing local storage. This improves the readability, consistency, and performance of the code. The affected files are `Choices.tsx`, `useCreateSpace.tsx`, `getIsAuthTokensAvailable.ts`, `authLink.ts`, and `storage.ts`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5d8e732</samp>

*  Simplify reading local storage values by using `useReadLocalStorage` hook from `usehooks-ts` ([link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3R23), [link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3R48), [link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-d4a7f0433f5143276917237b3177a4ae10673fb7a110483e91e41fbc1ce0a800L3-R8), [link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-d4a7f0433f5143276917237b3177a4ae10673fb7a110483e91e41fbc1ce0a800L14-R16))
*  Move `useCreateSpace` hook from `usehooks.tsx` to `Choices.tsx` to be used in the same file as the `Choices` component ([link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-d4a7f0433f5143276917237b3177a4ae10673fb7a110483e91e41fbc1ce0a800L3-R8))
*  Use `Localstorage` enum from `@lenster/data` to ensure consistent keys for local storage items across files ([link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-11cb8d90f72090b1f16a9b7dd84f9651f929d363cec4daa88536df4185e58328R1-R2), [link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-11cb8d90f72090b1f16a9b7dd84f9651f929d363cec4daa88536df4185e58328L7-R10), [link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-711bcbb5c6e354cff3bc54fe8552c04f0a0245182c2afb5a7d6f8b74e7ae122cR3-R4), [link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-9ece279eff1dad573246c3c6de9849b57007ca6e46322e6a58088f4f1e3f1603L28-R28), [link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-9ece279eff1dad573246c3c6de9849b57007ca6e46322e6a58088f4f1e3f1603L55-R57))
*  Use `accessToken` variable instead of calling `localStorage.getItem('accessToken')` in `Choices` component and `useCreateSpace` hook when sending requests to worker URLs ([link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3L104-R106), [link](https://github.com/lensterxyz/lenster/pull/3119/files?diff=unified&w=0#diff-d4a7f0433f5143276917237b3177a4ae10673fb7a110483e91e41fbc1ce0a800L14-R16))

## Emoji

<!--
copilot:emoji
-->

🗃️🎣🛠️

<!--
1.  🗃️ - This emoji represents the update of the `Localstorage` enum, which is related to data storage and organization.
2.  🎣 - This emoji represents the refactoring of the `Choices` and `useCreateSpace` components to use custom hooks, which are a common pattern in React for extracting and reusing logic.
3.  🛠️ - This emoji represents the refactoring of the `getIsAuthTokensAvailable` and `authLink` functions to use the shared enum and improve the code quality. This emoji conveys the idea of fixing or improving something.
-->
