### PR TITLE
feat: init tags explorer

### DIFF
--- a/apps/web/src/components/Explore/index.tsx
+++ b/apps/web/src/components/Explore/index.tsx
@@ -1,5 +1,6 @@
 import MetaTags from '@components/Common/MetaTags';
 import RecommendedProfiles from '@components/Home/RecommendedProfiles';
+import Tags from '@components/Home/Tags';
 import Trending from '@components/Home/Trending';
 import Footer from '@components/Shared/Footer';
 import { Tab } from '@headlessui/react';
@@ -27,6 +28,7 @@ const Explore: NextPage = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [focus, setFocus] = useState<PublicationMainFocus>();
   const isTrendingWidgetEnabled = isFeatureEnabled(FeatureFlag.TrendingWidget);
+  const isExploreTagsEnabled = isFeatureEnabled(FeatureFlag.ExploreTags);
 
   useEffectOnce(() => {
     Leafwatch.track(PAGEVIEW, { page: 'explore' });
@@ -93,6 +95,7 @@ const Explore: NextPage = () => {
       </GridItemEight>
       <GridItemFour>
         {isTrendingWidgetEnabled && <Trending />}
+        {isExploreTagsEnabled && <Tags />}
         {currentProfile ? <RecommendedProfiles /> : null}
         <Footer />
       </GridItemFour>

--- a/apps/web/src/components/Home/Tags.tsx
+++ b/apps/web/src/components/Home/Tags.tsx
@@ -1,0 +1,80 @@
+import TrendingTagShimmer from '@components/Shared/Shimmer/TrendingTagShimmer';
+import { TrendingUpIcon } from '@heroicons/react/solid';
+import type { TagResult } from '@lenster/lens';
+import { TagSortCriteria, useTrendingQuery } from '@lenster/lens';
+import nFormatter from '@lenster/lib/nFormatter';
+import { Card, ErrorMessage } from '@lenster/ui';
+import { Leafwatch } from '@lib/leafwatch';
+import { Plural, t, Trans } from '@lingui/macro';
+import Link from 'next/link';
+import type { FC } from 'react';
+import { MISCELLANEOUS } from 'src/tracking';
+
+const Title = () => {
+  return (
+    <div className="mb-2 flex items-center gap-2 px-5 sm:px-0">
+      <TrendingUpIcon className="h-4 w-4 text-green-500" />
+      <div>
+        <Trans>Trending</Trans>
+      </div>
+    </div>
+  );
+};
+
+const Tags: FC = () => {
+  const { data, loading, error } = useTrendingQuery({
+    variables: { request: { limit: 7, sort: TagSortCriteria.MostPopular } }
+  });
+
+  if (loading) {
+    return (
+      <>
+        <Title />
+        <Card className="mb-4 space-y-4 p-5">
+          <TrendingTagShimmer />
+          <TrendingTagShimmer />
+          <TrendingTagShimmer />
+          <TrendingTagShimmer />
+          <TrendingTagShimmer />
+          <TrendingTagShimmer />
+        </Card>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Title />
+      <Card as="aside" className="mb-4 space-y-4 p-5">
+        <ErrorMessage title={t`Failed to load trending`} error={error} />
+        {data?.allPublicationsTags?.items?.map((tag: TagResult) =>
+          tag?.tag !== '{}' ? (
+            <div key={tag?.tag}>
+              <Link
+                href={`/search?q=${tag?.tag}&type=pubs`}
+                onClick={() =>
+                  Leafwatch.track(MISCELLANEOUS.OPEN_TRENDING_TAG, {
+                    trending_tag: tag?.tag
+                  })
+                }
+              >
+                <div className="font-bold">{tag?.tag}</div>
+                <div className="lt-text-gray-500 text-[12px]">
+                  {nFormatter(tag?.total)}{' '}
+                  <Plural
+                    value={tag?.total}
+                    zero="Publication"
+                    one="Publication"
+                    other="Publications"
+                  />
+                </div>
+              </Link>
+            </div>
+          ) : null
+        )}
+      </Card>
+    </>
+  );
+};
+
+export default Tags;

--- a/apps/web/src/components/StaffTools/Panels/MetaDetails.tsx
+++ b/apps/web/src/components/StaffTools/Panels/MetaDetails.tsx
@@ -1,4 +1,5 @@
 import { t } from '@lingui/macro';
+import clsx from 'clsx';
 import type { FC, ReactNode } from 'react';
 import { toast } from 'react-hot-toast';
 
@@ -7,25 +8,37 @@ interface MetaDetailsProps {
   title?: string;
   value: string;
   icon: ReactNode;
+  noFlex?: boolean;
 }
 
 const MetaDetails: FC<MetaDetailsProps> = ({
   children,
   title,
   value,
-  icon
+  icon,
+  noFlex = false
 }) => (
   <div
-    className="linkify flex cursor-pointer items-center gap-1 text-sm font-bold"
+    className={clsx(
+      noFlex ? '' : 'flex items-center gap-1',
+      'linkify cursor-pointer text-sm font-bold'
+    )}
     onClick={async () => {
       await navigator.clipboard.writeText(value);
       toast.success(t`Copied to clipboard!`);
     }}
     aria-hidden="true"
   >
-    {icon}
-    {title ? <div className="lt-text-gray-500">{title}:</div> : null}
-    <div>{children}</div>
+    <div className="flex items-center gap-1">
+      {icon}
+      {title ? (
+        <div className="lt-text-gray-500">
+          {title}
+          {noFlex ? '' : ':'}
+        </div>
+      ) : null}
+    </div>
+    <div className={clsx(noFlex ? 'mt-1' : '')}>{children}</div>
   </div>
 );
 

--- a/apps/web/src/components/StaffTools/Panels/Publication.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Publication.tsx
@@ -1,4 +1,4 @@
-import { CollectionIcon, HashtagIcon } from '@heroicons/react/outline';
+import { CollectionIcon, HashtagIcon, TagIcon } from '@heroicons/react/outline';
 import { ShieldCheckIcon } from '@heroicons/react/solid';
 import type { Publication } from '@lenster/lens';
 import { Card } from '@lenster/ui';
@@ -48,6 +48,16 @@ const PublicationStaffTool: FC<PublicationStaffToolProps> = ({
             title={t`Collect module`}
           >
             {publication?.collectModule?.type}
+          </MetaDetails>
+        ) : null}
+        {publication?.metadata.tags ? (
+          <MetaDetails
+            icon={<TagIcon className="lt-text-gray-500 h-4 w-4" />}
+            value={JSON.stringify(publication?.metadata?.tags)}
+            title={t`Tags`}
+            noFlex
+          >
+            {JSON.stringify(publication?.metadata?.tags)}
           </MetaDetails>
         ) : null}
       </div>

--- a/apps/web/src/store/explore.ts
+++ b/apps/web/src/store/explore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+interface ExploreState {
+  selectedTag: string;
+  setSelectedTag: (selectedTag: string) => void;
+}
+
+export const useExploreStore = create<ExploreState>((set) => ({
+  selectedTag: '',
+  setSelectedTag: (selectedTag) => set(() => ({ selectedTag }))
+}));

--- a/packages/data/feature-flags.ts
+++ b/packages/data/feature-flags.ts
@@ -9,7 +9,8 @@ export enum FeatureFlag {
   Polls = 'polls',
   Spaces = 'spaces',
   ForYou = 'for-you',
-  WTF2 = 'wtf2'
+  WTF2 = 'wtf2',
+  ExploreTags = 'explore-tags'
 }
 
 export const featureFlags = [
@@ -43,6 +44,10 @@ export const featureFlags = [
   },
   {
     key: FeatureFlag.WTF2,
+    enabledFor: [...mainnetStaffs, ...mainnetLensTeamMembers]
+  },
+  {
+    key: FeatureFlag.ExploreTags,
     enabledFor: [...mainnetStaffs, ...mainnetLensTeamMembers]
   }
 ];

--- a/packages/lens/documents/fragments/MetadataFields.graphql
+++ b/packages/lens/documents/fragments/MetadataFields.graphql
@@ -2,6 +2,7 @@ fragment MetadataFields on MetadataOutput {
   name
   content
   image
+  tags
   attributes {
     traitType
     value

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -4886,6 +4886,7 @@ export type CommentFieldsFragment = {
     name?: string | null;
     content?: any | null;
     image?: any | null;
+    tags: Array<string>;
     attributes: Array<{
       __typename?: 'MetadataAttributeOutput';
       traitType?: string | null;
@@ -5209,6 +5210,7 @@ export type CommentFieldsFragment = {
           name?: string | null;
           content?: any | null;
           image?: any | null;
+          tags: Array<string>;
           attributes: Array<{
             __typename?: 'MetadataAttributeOutput';
             traitType?: string | null;
@@ -5551,6 +5553,7 @@ export type CommentFieldsFragment = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -5976,6 +5979,7 @@ export type CommentFieldsFragment = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -6318,6 +6322,7 @@ export type CommentFieldsFragment = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -6655,6 +6660,7 @@ export type CommentFieldsFragment = {
           name?: string | null;
           content?: any | null;
           image?: any | null;
+          tags: Array<string>;
           attributes: Array<{
             __typename?: 'MetadataAttributeOutput';
             traitType?: string | null;
@@ -7070,6 +7076,7 @@ export type CommentFieldsFragment = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -7409,6 +7416,7 @@ export type CommentFieldsFragment = {
           name?: string | null;
           content?: any | null;
           image?: any | null;
+          tags: Array<string>;
           attributes: Array<{
             __typename?: 'MetadataAttributeOutput';
             traitType?: string | null;
@@ -7540,6 +7548,7 @@ export type MetadataFieldsFragment = {
   name?: string | null;
   content?: any | null;
   image?: any | null;
+  tags: Array<string>;
   attributes: Array<{
     __typename?: 'MetadataAttributeOutput';
     traitType?: string | null;
@@ -7863,6 +7872,7 @@ export type MirrorFieldsFragment = {
     name?: string | null;
     content?: any | null;
     image?: any | null;
+    tags: Array<string>;
     attributes: Array<{
       __typename?: 'MetadataAttributeOutput';
       traitType?: string | null;
@@ -8269,6 +8279,7 @@ export type MirrorFieldsFragment = {
           name?: string | null;
           content?: any | null;
           image?: any | null;
+          tags: Array<string>;
           attributes: Array<{
             __typename?: 'MetadataAttributeOutput';
             traitType?: string | null;
@@ -8616,6 +8627,7 @@ export type PostFieldsFragment = {
     name?: string | null;
     content?: any | null;
     image?: any | null;
+    tags: Array<string>;
     attributes: Array<{
       __typename?: 'MetadataAttributeOutput';
       traitType?: string | null;
@@ -10425,6 +10437,7 @@ export type CommentFeedQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -10761,6 +10774,7 @@ export type CommentFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -11110,6 +11124,7 @@ export type CommentFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -11549,6 +11564,7 @@ export type CommentFeedQuery = {
                               name?: string | null;
                               content?: any | null;
                               image?: any | null;
+                              tags: Array<string>;
                               attributes: Array<{
                                 __typename?: 'MetadataAttributeOutput';
                                 traitType?: string | null;
@@ -11894,6 +11910,7 @@ export type CommentFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -12237,6 +12254,7 @@ export type CommentFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -12662,6 +12680,7 @@ export type CommentFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -13007,6 +13026,7 @@ export type CommentFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -13386,6 +13406,7 @@ export type ExploreFeedQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -13722,6 +13743,7 @@ export type ExploreFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -14071,6 +14093,7 @@ export type ExploreFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -14510,6 +14533,7 @@ export type ExploreFeedQuery = {
                               name?: string | null;
                               content?: any | null;
                               image?: any | null;
+                              tags: Array<string>;
                               attributes: Array<{
                                 __typename?: 'MetadataAttributeOutput';
                                 traitType?: string | null;
@@ -14855,6 +14879,7 @@ export type ExploreFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -15198,6 +15223,7 @@ export type ExploreFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -15623,6 +15649,7 @@ export type ExploreFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -15968,6 +15995,7 @@ export type ExploreFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -16306,6 +16334,7 @@ export type ExploreFeedQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -16731,6 +16760,7 @@ export type ExploreFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -17070,6 +17100,7 @@ export type ExploreFeedQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -17424,6 +17455,7 @@ export type FeedHighlightsQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -17760,6 +17792,7 @@ export type FeedHighlightsQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -18109,6 +18142,7 @@ export type FeedHighlightsQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -18548,6 +18582,7 @@ export type FeedHighlightsQuery = {
                               name?: string | null;
                               content?: any | null;
                               image?: any | null;
+                              tags: Array<string>;
                               attributes: Array<{
                                 __typename?: 'MetadataAttributeOutput';
                                 traitType?: string | null;
@@ -18893,6 +18928,7 @@ export type FeedHighlightsQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -19236,6 +19272,7 @@ export type FeedHighlightsQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -19661,6 +19698,7 @@ export type FeedHighlightsQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -20006,6 +20044,7 @@ export type FeedHighlightsQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -20344,6 +20383,7 @@ export type FeedHighlightsQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -20769,6 +20809,7 @@ export type FeedHighlightsQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -21108,6 +21149,7 @@ export type FeedHighlightsQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -21596,6 +21638,7 @@ export type ForYouQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -21932,6 +21975,7 @@ export type ForYouQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -22281,6 +22325,7 @@ export type ForYouQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -22720,6 +22765,7 @@ export type ForYouQuery = {
                               name?: string | null;
                               content?: any | null;
                               image?: any | null;
+                              tags: Array<string>;
                               attributes: Array<{
                                 __typename?: 'MetadataAttributeOutput';
                                 traitType?: string | null;
@@ -23065,6 +23111,7 @@ export type ForYouQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -23408,6 +23455,7 @@ export type ForYouQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -23833,6 +23881,7 @@ export type ForYouQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -24178,6 +24227,7 @@ export type ForYouQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -24516,6 +24566,7 @@ export type ForYouQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -24941,6 +24992,7 @@ export type ForYouQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -25280,6 +25332,7 @@ export type ForYouQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -26722,6 +26775,7 @@ export type ProfileFeedQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -27058,6 +27112,7 @@ export type ProfileFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -27407,6 +27462,7 @@ export type ProfileFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -27846,6 +27902,7 @@ export type ProfileFeedQuery = {
                               name?: string | null;
                               content?: any | null;
                               image?: any | null;
+                              tags: Array<string>;
                               attributes: Array<{
                                 __typename?: 'MetadataAttributeOutput';
                                 traitType?: string | null;
@@ -28191,6 +28248,7 @@ export type ProfileFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -28534,6 +28592,7 @@ export type ProfileFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -28959,6 +29018,7 @@ export type ProfileFeedQuery = {
                         name?: string | null;
                         content?: any | null;
                         image?: any | null;
+                        tags: Array<string>;
                         attributes: Array<{
                           __typename?: 'MetadataAttributeOutput';
                           traitType?: string | null;
@@ -29304,6 +29364,7 @@ export type ProfileFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -29642,6 +29703,7 @@ export type ProfileFeedQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -30067,6 +30129,7 @@ export type ProfileFeedQuery = {
                   name?: string | null;
                   content?: any | null;
                   image?: any | null;
+                  tags: Array<string>;
                   attributes: Array<{
                     __typename?: 'MetadataAttributeOutput';
                     traitType?: string | null;
@@ -30406,6 +30469,7 @@ export type ProfileFeedQuery = {
             name?: string | null;
             content?: any | null;
             image?: any | null;
+            tags: Array<string>;
             attributes: Array<{
               __typename?: 'MetadataAttributeOutput';
               traitType?: string | null;
@@ -30890,6 +30954,7 @@ export type PublicationQuery = {
           name?: string | null;
           content?: any | null;
           image?: any | null;
+          tags: Array<string>;
           attributes: Array<{
             __typename?: 'MetadataAttributeOutput';
             traitType?: string | null;
@@ -31219,6 +31284,7 @@ export type PublicationQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -31568,6 +31634,7 @@ export type PublicationQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -31993,6 +32060,7 @@ export type PublicationQuery = {
                             name?: string | null;
                             content?: any | null;
                             image?: any | null;
+                            tags: Array<string>;
                             attributes: Array<{
                               __typename?: 'MetadataAttributeOutput';
                               traitType?: string | null;
@@ -32338,6 +32406,7 @@ export type PublicationQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -32678,6 +32747,7 @@ export type PublicationQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -33103,6 +33173,7 @@ export type PublicationQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -33445,6 +33516,7 @@ export type PublicationQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -33789,6 +33861,7 @@ export type PublicationQuery = {
           name?: string | null;
           content?: any | null;
           image?: any | null;
+          tags: Array<string>;
           attributes: Array<{
             __typename?: 'MetadataAttributeOutput';
             traitType?: string | null;
@@ -34204,6 +34277,7 @@ export type PublicationQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -34549,6 +34623,7 @@ export type PublicationQuery = {
           name?: string | null;
           content?: any | null;
           image?: any | null;
+          tags: Array<string>;
           attributes: Array<{
             __typename?: 'MetadataAttributeOutput';
             traitType?: string | null;
@@ -35049,6 +35124,7 @@ export type SearchPublicationsQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -35385,6 +35461,7 @@ export type SearchPublicationsQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -35734,6 +35811,7 @@ export type SearchPublicationsQuery = {
                             name?: string | null;
                             content?: any | null;
                             image?: any | null;
+                            tags: Array<string>;
                             attributes: Array<{
                               __typename?: 'MetadataAttributeOutput';
                               traitType?: string | null;
@@ -36191,6 +36269,7 @@ export type SearchPublicationsQuery = {
                                   name?: string | null;
                                   content?: any | null;
                                   image?: any | null;
+                                  tags: Array<string>;
                                   attributes: Array<{
                                     __typename?: 'MetadataAttributeOutput';
                                     traitType?: string | null;
@@ -36543,6 +36622,7 @@ export type SearchPublicationsQuery = {
                             name?: string | null;
                             content?: any | null;
                             image?: any | null;
+                            tags: Array<string>;
                             attributes: Array<{
                               __typename?: 'MetadataAttributeOutput';
                               traitType?: string | null;
@@ -36886,6 +36966,7 @@ export type SearchPublicationsQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -37311,6 +37392,7 @@ export type SearchPublicationsQuery = {
                             name?: string | null;
                             content?: any | null;
                             image?: any | null;
+                            tags: Array<string>;
                             attributes: Array<{
                               __typename?: 'MetadataAttributeOutput';
                               traitType?: string | null;
@@ -37656,6 +37738,7 @@ export type SearchPublicationsQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -37999,6 +38082,7 @@ export type SearchPublicationsQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -38766,6 +38850,7 @@ export type TimelineQuery = {
               name?: string | null;
               content?: any | null;
               image?: any | null;
+              tags: Array<string>;
               attributes: Array<{
                 __typename?: 'MetadataAttributeOutput';
                 traitType?: string | null;
@@ -39102,6 +39187,7 @@ export type TimelineQuery = {
                     name?: string | null;
                     content?: any | null;
                     image?: any | null;
+                    tags: Array<string>;
                     attributes: Array<{
                       __typename?: 'MetadataAttributeOutput';
                       traitType?: string | null;
@@ -39451,6 +39537,7 @@ export type TimelineQuery = {
                           name?: string | null;
                           content?: any | null;
                           image?: any | null;
+                          tags: Array<string>;
                           attributes: Array<{
                             __typename?: 'MetadataAttributeOutput';
                             traitType?: string | null;
@@ -39902,6 +39989,7 @@ export type TimelineQuery = {
                                 name?: string | null;
                                 content?: any | null;
                                 image?: any | null;
+                                tags: Array<string>;
                                 attributes: Array<{
                                   __typename?: 'MetadataAttributeOutput';
                                   traitType?: string | null;
@@ -40247,6 +40335,7 @@ export type TimelineQuery = {
                           name?: string | null;
                           content?: any | null;
                           image?: any | null;
+                          tags: Array<string>;
                           attributes: Array<{
                             __typename?: 'MetadataAttributeOutput';
                             traitType?: string | null;
@@ -40590,6 +40679,7 @@ export type TimelineQuery = {
                     name?: string | null;
                     content?: any | null;
                     image?: any | null;
+                    tags: Array<string>;
                     attributes: Array<{
                       __typename?: 'MetadataAttributeOutput';
                       traitType?: string | null;
@@ -41015,6 +41105,7 @@ export type TimelineQuery = {
                           name?: string | null;
                           content?: any | null;
                           image?: any | null;
+                          tags: Array<string>;
                           attributes: Array<{
                             __typename?: 'MetadataAttributeOutput';
                             traitType?: string | null;
@@ -41360,6 +41451,7 @@ export type TimelineQuery = {
                     name?: string | null;
                     content?: any | null;
                     image?: any | null;
+                    tags: Array<string>;
                     attributes: Array<{
                       __typename?: 'MetadataAttributeOutput';
                       traitType?: string | null;
@@ -41700,6 +41792,7 @@ export type TimelineQuery = {
               name?: string | null;
               content?: any | null;
               image?: any | null;
+              tags: Array<string>;
               attributes: Array<{
                 __typename?: 'MetadataAttributeOutput';
                 traitType?: string | null;
@@ -42252,6 +42345,7 @@ export type TimelineQuery = {
           name?: string | null;
           content?: any | null;
           image?: any | null;
+          tags: Array<string>;
           attributes: Array<{
             __typename?: 'MetadataAttributeOutput';
             traitType?: string | null;
@@ -42581,6 +42675,7 @@ export type TimelineQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -42930,6 +43025,7 @@ export type TimelineQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -43355,6 +43451,7 @@ export type TimelineQuery = {
                             name?: string | null;
                             content?: any | null;
                             image?: any | null;
+                            tags: Array<string>;
                             attributes: Array<{
                               __typename?: 'MetadataAttributeOutput';
                               traitType?: string | null;
@@ -43700,6 +43797,7 @@ export type TimelineQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -44040,6 +44138,7 @@ export type TimelineQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -44465,6 +44564,7 @@ export type TimelineQuery = {
                       name?: string | null;
                       content?: any | null;
                       image?: any | null;
+                      tags: Array<string>;
                       attributes: Array<{
                         __typename?: 'MetadataAttributeOutput';
                         traitType?: string | null;
@@ -44807,6 +44907,7 @@ export type TimelineQuery = {
                 name?: string | null;
                 content?: any | null;
                 image?: any | null;
+                tags: Array<string>;
                 attributes: Array<{
                   __typename?: 'MetadataAttributeOutput';
                   traitType?: string | null;
@@ -45211,6 +45312,7 @@ export const MetadataFieldsFragmentDoc = gql`
     name
     content
     image
+    tags
     attributes {
       traitType
       value

--- a/packages/workers/metadata/wrangler.toml
+++ b/packages/workers/metadata/wrangler.toml
@@ -8,6 +8,9 @@ routes = [
 	{ pattern = "metadata.lenster.xyz", custom_domain = true }
 ]
 
+[placement]
+mode = "smart"
+
 [env.production.vars]
 BUNDLR_PRIVATE_KEY = ""
 HUGGINGFACE_API_KEY = ""


### PR DESCRIPTION
- feat: add tag explorer-beta
- feat: add tags in staff panel

## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e067a0</samp>

This pull request adds the functionality to show trending tags on the explore page of the web app, using a feature flag and a Zustand store. It also enhances the staff tool to display tags and metadata in a better way, and improves the performance of the metadata Workers. It modifies several files in the `apps/web`, `packages/data`, `packages/lens`, and `packages/workers` directories.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e067a0</samp>

*  Add a Tags component to display the trending tags on the explore page ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-49d6c54d244b4e97adc8e686f8e1df80d7e1faa45ee2aec4906ad9e0649421d7R1-R80),[link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-9a8aa377a2ed1754402e0069f3eccca11601757f2a949b4556aac28966ada6c8R3),[link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-9a8aa377a2ed1754402e0069f3eccca11601757f2a949b4556aac28966ada6c8R31),[link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-9a8aa377a2ed1754402e0069f3eccca11601757f2a949b4556aac28966ada6c8R98))
*  Use the `useTrendingQuery` hook to fetch the tags from the GraphQL API and handle loading, error, and translation states ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-49d6c54d244b4e97adc8e686f8e1df80d7e1faa45ee2aec4906ad9e0649421d7R1-R80))
*  Use the `Leafwatch` module to track the user clicks on the tags and the `nFormatter` function to format the tag counts ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-49d6c54d244b4e97adc8e686f8e1df80d7e1faa45ee2aec4906ad9e0649421d7R1-R80))
*  Use the `TagIcon`, `TrendingUpIcon`, and `Link` components to render the tags with icons and links to the search page ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-49d6c54d244b4e97adc8e686f8e1df80d7e1faa45ee2aec4906ad9e0649421d7R1-R80))
*  Add a `useExploreStore` hook to create a Zustand store for managing the explore state, including the selected tag ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-c119e4a458f50bb0a8623bb9790be97f718f53647a7ff69dcfdbb4996c258831R1-R11))
*  Add a `ExploreTags` feature flag to toggle the display of the tags on the explore page and enable it for some user groups ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-e06e181e3ef331e886fe8bfb4b664826e1a3ae2d1f22097dd7273c0e917c566eL12-R13),[link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-e06e181e3ef331e886fe8bfb4b664826e1a3ae2d1f22097dd7273c0e917c566eR48-R51))
*  Add a `tags` field to the `MetadataFields` GraphQL fragment to query the tags of a publication ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-8fef386395c2e54ad852d5a41b468837494b1c3052d8fdfcef06b3a845726763R5))
*  Add a `MetaDetails` component to the `PublicationStaffTool` component to show the tags of a publication with a different layout ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-3ab4dcc6ca39b36ae7890598cfacc5a2c7c379e92f67705be89cf6a3fe364adfR53-R62),[link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-553dd43eb665bb3636657a88a3df3373e9f24009d2a5013d22cdfddd2d2f0839R2),[link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-553dd43eb665bb3636657a88a3df3373e9f24009d2a5013d22cdfddd2d2f0839R11),[link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-553dd43eb665bb3636657a88a3df3373e9f24009d2a5013d22cdfddd2d2f0839L16-R25),[link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-553dd43eb665bb3636657a88a3df3373e9f24009d2a5013d22cdfddd2d2f0839L26-R41))
*  Replace the `HashtagIcon` with the `TagIcon` in the `PublicationStaffTool` component for consistency ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-3ab4dcc6ca39b36ae7890598cfacc5a2c7c379e92f67705be89cf6a3fe364adfL1-R1))
*  Add a `[placement]` section to the `wrangler.toml` file to use the `smart` mode for deploying the Workers to the closest data center ([link](https://github.com/lensterxyz/lenster/pull/3139/files?diff=unified&w=0#diff-1155a7f6231fa0bb8235ed5b55c3dde070a7015f590374ed395945bd7977426fR11-R13))

## Emoji

<!--
copilot:emoji
-->

🏷️🚀🔍

<!--
1.  🏷️ - This emoji represents the tags feature and the Tags component, which are the main focus of these changes. It also conveys the idea of labeling and categorizing publications by tags.
2.  🚀 - This emoji represents the performance improvement and the smart mode for the Cloudflare Workers, which are a significant enhancement for the user experience and the scalability of the platform. It also conveys the idea of speed and launching new features.
3.  🔍 - This emoji represents the explore page and the search functionality, which are the main use cases for the tags feature and the selectedTag state. It also conveys the idea of discovery and curiosity.
-->
