### PR TITLE
feat: use commentsTotal instead of totalAmountOfComments

### DIFF
--- a/apps/prerender/src/components/Shared/SinglePublication.tsx
+++ b/apps/prerender/src/components/Shared/SinglePublication.tsx
@@ -34,8 +34,8 @@ const SinglePublication: FC<PublicationProps> = ({
 
   // Stats
   const commentsCount = isMirror
-    ? publication.mirrorOf.stats.totalAmountOfComments
-    : stats.totalAmountOfComments;
+    ? publication.mirrorOf.stats.commentsTotal
+    : stats.commentsTotal;
   const likesCount = isMirror
     ? publication.mirrorOf.stats.totalUpvotes
     : stats.totalUpvotes;

--- a/apps/web/src/components/Publication/Actions/Comment.tsx
+++ b/apps/web/src/components/Publication/Actions/Comment.tsx
@@ -16,8 +16,8 @@ interface CommentProps {
 const Comment: FC<CommentProps> = ({ publication, showCount }) => {
   const count =
     publication.__typename === 'Mirror'
-      ? publication?.mirrorOf?.stats?.totalAmountOfComments
-      : publication?.stats?.totalAmountOfComments;
+      ? publication?.mirrorOf?.stats?.commentsTotal
+      : publication?.stats?.commentsTotal;
   const iconClassName = showCount
     ? 'w-[17px] sm:w-[20px]'
     : 'w-[15px] sm:w-[18px]';

--- a/apps/web/src/components/Publication/PublicationStats.tsx
+++ b/apps/web/src/components/Publication/PublicationStats.tsx
@@ -26,8 +26,8 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
 
   const isMirror = publication.__typename === 'Mirror';
   const commentsCount = isMirror
-    ? publication?.mirrorOf?.stats?.totalAmountOfComments
-    : publication?.stats?.totalAmountOfComments;
+    ? publication?.mirrorOf?.stats?.commentsTotal
+    : publication?.stats?.commentsTotal;
   const mirrorCount = isMirror
     ? publication?.mirrorOf?.stats?.totalAmountOfMirrors
     : publication?.stats?.totalAmountOfMirrors;

--- a/packages/lens/documents/fragments/StatsFields.graphql
+++ b/packages/lens/documents/fragments/StatsFields.graphql
@@ -2,5 +2,5 @@ fragment StatsFields on PublicationStats {
   totalUpvotes
   totalAmountOfMirrors
   totalAmountOfCollects
-  totalAmountOfComments
+  commentsTotal(customFilters: GARDENERS)
 }

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -23,7 +23,7 @@ export type Incremental<T> =
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string };
+  ID: { input: string; output: string };
   String: { input: string; output: string };
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
@@ -3634,7 +3634,8 @@ export type PublicationStats = {
 
 /** The publication stats */
 export type PublicationStatsCommentsTotalArgs = {
-  forSources: Array<Scalars['Sources']['input']>;
+  customFilters?: InputMaybe<Array<CustomFiltersTypes>>;
+  forSources?: InputMaybe<Array<Scalars['Sources']['input']>>;
 };
 
 /** The publication types */
@@ -4879,7 +4880,7 @@ export type CommentFieldsFragment = {
     totalUpvotes: number;
     totalAmountOfMirrors: number;
     totalAmountOfCollects: number;
-    totalAmountOfComments: number;
+    commentsTotal: number;
   };
   metadata: {
     __typename?: 'MetadataOutput';
@@ -5338,7 +5339,7 @@ export type CommentFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
         mainPost:
           | {
@@ -5546,7 +5547,7 @@ export type CommentFieldsFragment = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -5759,7 +5760,7 @@ export type CommentFieldsFragment = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                   }
                 | {
@@ -5972,7 +5973,7 @@ export type CommentFieldsFragment = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -6315,7 +6316,7 @@ export type CommentFieldsFragment = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -6653,7 +6654,7 @@ export type CommentFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
         metadata: {
           __typename?: 'MetadataOutput';
@@ -6859,7 +6860,7 @@ export type CommentFieldsFragment = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
             }
           | {
@@ -7069,7 +7070,7 @@ export type CommentFieldsFragment = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -7409,7 +7410,7 @@ export type CommentFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
         metadata: {
           __typename?: 'MetadataOutput';
@@ -7865,7 +7866,7 @@ export type MirrorFieldsFragment = {
     totalUpvotes: number;
     totalAmountOfMirrors: number;
     totalAmountOfCollects: number;
-    totalAmountOfComments: number;
+    commentsTotal: number;
   };
   metadata: {
     __typename?: 'MetadataOutput';
@@ -8065,7 +8066,7 @@ export type MirrorFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
       }
     | {
@@ -8272,7 +8273,7 @@ export type MirrorFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
         metadata: {
           __typename?: 'MetadataOutput';
@@ -8620,7 +8621,7 @@ export type PostFieldsFragment = {
     totalUpvotes: number;
     totalAmountOfMirrors: number;
     totalAmountOfCollects: number;
-    totalAmountOfComments: number;
+    commentsTotal: number;
   };
   metadata: {
     __typename?: 'MetadataOutput';
@@ -8839,7 +8840,7 @@ export type StatsFieldsFragment = {
   totalUpvotes: number;
   totalAmountOfMirrors: number;
   totalAmountOfCollects: number;
-  totalAmountOfComments: number;
+  commentsTotal: number;
 };
 
 export type AddProfileInterestMutationVariables = Exact<{
@@ -10430,7 +10431,7 @@ export type CommentFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -10906,7 +10907,7 @@ export type CommentFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 mainPost:
                   | {
@@ -11117,7 +11118,7 @@ export type CommentFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -11336,7 +11337,7 @@ export type CommentFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                           }
                         | {
@@ -11557,7 +11558,7 @@ export type CommentFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                             metadata: {
                               __typename?: 'MetadataOutput';
@@ -11903,7 +11904,7 @@ export type CommentFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -12247,7 +12248,7 @@ export type CommentFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -12460,7 +12461,7 @@ export type CommentFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                     }
                   | {
@@ -12673,7 +12674,7 @@ export type CommentFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -13019,7 +13020,7 @@ export type CommentFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -13399,7 +13400,7 @@ export type ExploreFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -13875,7 +13876,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 mainPost:
                   | {
@@ -14086,7 +14087,7 @@ export type ExploreFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -14305,7 +14306,7 @@ export type ExploreFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                           }
                         | {
@@ -14526,7 +14527,7 @@ export type ExploreFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                             metadata: {
                               __typename?: 'MetadataOutput';
@@ -14872,7 +14873,7 @@ export type ExploreFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -15216,7 +15217,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -15429,7 +15430,7 @@ export type ExploreFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                     }
                   | {
@@ -15642,7 +15643,7 @@ export type ExploreFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -15988,7 +15989,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -16327,7 +16328,7 @@ export type ExploreFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -16540,7 +16541,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
               }
             | {
@@ -16753,7 +16754,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -17093,7 +17094,7 @@ export type ExploreFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -17448,7 +17449,7 @@ export type FeedHighlightsQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -17924,7 +17925,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 mainPost:
                   | {
@@ -18135,7 +18136,7 @@ export type FeedHighlightsQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -18354,7 +18355,7 @@ export type FeedHighlightsQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                           }
                         | {
@@ -18575,7 +18576,7 @@ export type FeedHighlightsQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                             metadata: {
                               __typename?: 'MetadataOutput';
@@ -18921,7 +18922,7 @@ export type FeedHighlightsQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -19265,7 +19266,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -19478,7 +19479,7 @@ export type FeedHighlightsQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                     }
                   | {
@@ -19691,7 +19692,7 @@ export type FeedHighlightsQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -20037,7 +20038,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -20376,7 +20377,7 @@ export type FeedHighlightsQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -20589,7 +20590,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
               }
             | {
@@ -20802,7 +20803,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -21142,7 +21143,7 @@ export type FeedHighlightsQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -21631,7 +21632,7 @@ export type ForYouQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -22107,7 +22108,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 mainPost:
                   | {
@@ -22318,7 +22319,7 @@ export type ForYouQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -22537,7 +22538,7 @@ export type ForYouQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                           }
                         | {
@@ -22758,7 +22759,7 @@ export type ForYouQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                             metadata: {
                               __typename?: 'MetadataOutput';
@@ -23104,7 +23105,7 @@ export type ForYouQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -23448,7 +23449,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -23661,7 +23662,7 @@ export type ForYouQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                     }
                   | {
@@ -23874,7 +23875,7 @@ export type ForYouQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -24220,7 +24221,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -24559,7 +24560,7 @@ export type ForYouQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -24772,7 +24773,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
               }
             | {
@@ -24985,7 +24986,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -25325,7 +25326,7 @@ export type ForYouQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -26768,7 +26769,7 @@ export type ProfileFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -27244,7 +27245,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 mainPost:
                   | {
@@ -27455,7 +27456,7 @@ export type ProfileFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -27674,7 +27675,7 @@ export type ProfileFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                           }
                         | {
@@ -27895,7 +27896,7 @@ export type ProfileFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
-                              totalAmountOfComments: number;
+                              commentsTotal: number;
                             };
                             metadata: {
                               __typename?: 'MetadataOutput';
@@ -28241,7 +28242,7 @@ export type ProfileFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -28585,7 +28586,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -28798,7 +28799,7 @@ export type ProfileFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                     }
                   | {
@@ -29011,7 +29012,7 @@ export type ProfileFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
-                        totalAmountOfComments: number;
+                        commentsTotal: number;
                       };
                       metadata: {
                         __typename?: 'MetadataOutput';
@@ -29357,7 +29358,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -29696,7 +29697,7 @@ export type ProfileFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -29909,7 +29910,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
               }
             | {
@@ -30122,7 +30123,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
-                  totalAmountOfComments: number;
+                  commentsTotal: number;
                 };
                 metadata: {
                   __typename?: 'MetadataOutput';
@@ -30462,7 +30463,7 @@ export type ProfileFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
-            totalAmountOfComments: number;
+            commentsTotal: number;
           };
           metadata: {
             __typename?: 'MetadataOutput';
@@ -30947,7 +30948,7 @@ export type PublicationQuery = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
         metadata: {
           __typename?: 'MetadataOutput';
@@ -31416,7 +31417,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               mainPost:
                 | {
@@ -31627,7 +31628,7 @@ export type PublicationQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -31840,7 +31841,7 @@ export type PublicationQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
-                            totalAmountOfComments: number;
+                            commentsTotal: number;
                           };
                         }
                       | {
@@ -32053,7 +32054,7 @@ export type PublicationQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
-                            totalAmountOfComments: number;
+                            commentsTotal: number;
                           };
                           metadata: {
                             __typename?: 'MetadataOutput';
@@ -32399,7 +32400,7 @@ export type PublicationQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -32740,7 +32741,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -32953,7 +32954,7 @@ export type PublicationQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                   }
                 | {
@@ -33166,7 +33167,7 @@ export type PublicationQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -33509,7 +33510,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -33854,7 +33855,7 @@ export type PublicationQuery = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
         metadata: {
           __typename?: 'MetadataOutput';
@@ -34060,7 +34061,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
             }
           | {
@@ -34270,7 +34271,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -34616,7 +34617,7 @@ export type PublicationQuery = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
         metadata: {
           __typename?: 'MetadataOutput';
@@ -35117,7 +35118,7 @@ export type SearchPublicationsQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -35593,7 +35594,7 @@ export type SearchPublicationsQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     mainPost:
                       | {
@@ -35804,7 +35805,7 @@ export type SearchPublicationsQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
-                            totalAmountOfComments: number;
+                            commentsTotal: number;
                           };
                           metadata: {
                             __typename?: 'MetadataOutput';
@@ -36029,7 +36030,7 @@ export type SearchPublicationsQuery = {
                                   totalUpvotes: number;
                                   totalAmountOfMirrors: number;
                                   totalAmountOfCollects: number;
-                                  totalAmountOfComments: number;
+                                  commentsTotal: number;
                                 };
                               }
                             | {
@@ -36262,7 +36263,7 @@ export type SearchPublicationsQuery = {
                                   totalUpvotes: number;
                                   totalAmountOfMirrors: number;
                                   totalAmountOfCollects: number;
-                                  totalAmountOfComments: number;
+                                  commentsTotal: number;
                                 };
                                 metadata: {
                                   __typename?: 'MetadataOutput';
@@ -36615,7 +36616,7 @@ export type SearchPublicationsQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
-                            totalAmountOfComments: number;
+                            commentsTotal: number;
                           };
                           metadata: {
                             __typename?: 'MetadataOutput';
@@ -36959,7 +36960,7 @@ export type SearchPublicationsQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -37172,7 +37173,7 @@ export type SearchPublicationsQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
-                            totalAmountOfComments: number;
+                            commentsTotal: number;
                           };
                         }
                       | {
@@ -37385,7 +37386,7 @@ export type SearchPublicationsQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
-                            totalAmountOfComments: number;
+                            commentsTotal: number;
                           };
                           metadata: {
                             __typename?: 'MetadataOutput';
@@ -37731,7 +37732,7 @@ export type SearchPublicationsQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -38075,7 +38076,7 @@ export type SearchPublicationsQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -38843,7 +38844,7 @@ export type TimelineQuery = {
               totalUpvotes: number;
               totalAmountOfMirrors: number;
               totalAmountOfCollects: number;
-              totalAmountOfComments: number;
+              commentsTotal: number;
             };
             metadata: {
               __typename?: 'MetadataOutput';
@@ -39319,7 +39320,7 @@ export type TimelineQuery = {
                     totalUpvotes: number;
                     totalAmountOfMirrors: number;
                     totalAmountOfCollects: number;
-                    totalAmountOfComments: number;
+                    commentsTotal: number;
                   };
                   mainPost:
                     | {
@@ -39530,7 +39531,7 @@ export type TimelineQuery = {
                           totalUpvotes: number;
                           totalAmountOfMirrors: number;
                           totalAmountOfCollects: number;
-                          totalAmountOfComments: number;
+                          commentsTotal: number;
                         };
                         metadata: {
                           __typename?: 'MetadataOutput';
@@ -39753,7 +39754,7 @@ export type TimelineQuery = {
                                 totalUpvotes: number;
                                 totalAmountOfMirrors: number;
                                 totalAmountOfCollects: number;
-                                totalAmountOfComments: number;
+                                commentsTotal: number;
                               };
                             }
                           | {
@@ -39982,7 +39983,7 @@ export type TimelineQuery = {
                                 totalUpvotes: number;
                                 totalAmountOfMirrors: number;
                                 totalAmountOfCollects: number;
-                                totalAmountOfComments: number;
+                                commentsTotal: number;
                               };
                               metadata: {
                                 __typename?: 'MetadataOutput';
@@ -40328,7 +40329,7 @@ export type TimelineQuery = {
                           totalUpvotes: number;
                           totalAmountOfMirrors: number;
                           totalAmountOfCollects: number;
-                          totalAmountOfComments: number;
+                          commentsTotal: number;
                         };
                         metadata: {
                           __typename?: 'MetadataOutput';
@@ -40672,7 +40673,7 @@ export type TimelineQuery = {
                     totalUpvotes: number;
                     totalAmountOfMirrors: number;
                     totalAmountOfCollects: number;
-                    totalAmountOfComments: number;
+                    commentsTotal: number;
                   };
                   metadata: {
                     __typename?: 'MetadataOutput';
@@ -40885,7 +40886,7 @@ export type TimelineQuery = {
                           totalUpvotes: number;
                           totalAmountOfMirrors: number;
                           totalAmountOfCollects: number;
-                          totalAmountOfComments: number;
+                          commentsTotal: number;
                         };
                       }
                     | {
@@ -41098,7 +41099,7 @@ export type TimelineQuery = {
                           totalUpvotes: number;
                           totalAmountOfMirrors: number;
                           totalAmountOfCollects: number;
-                          totalAmountOfComments: number;
+                          commentsTotal: number;
                         };
                         metadata: {
                           __typename?: 'MetadataOutput';
@@ -41444,7 +41445,7 @@ export type TimelineQuery = {
                     totalUpvotes: number;
                     totalAmountOfMirrors: number;
                     totalAmountOfCollects: number;
-                    totalAmountOfComments: number;
+                    commentsTotal: number;
                   };
                   metadata: {
                     __typename?: 'MetadataOutput';
@@ -41785,7 +41786,7 @@ export type TimelineQuery = {
               totalUpvotes: number;
               totalAmountOfMirrors: number;
               totalAmountOfCollects: number;
-              totalAmountOfComments: number;
+              commentsTotal: number;
             };
             metadata: {
               __typename?: 'MetadataOutput';
@@ -42338,7 +42339,7 @@ export type TimelineQuery = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
-          totalAmountOfComments: number;
+          commentsTotal: number;
         };
         metadata: {
           __typename?: 'MetadataOutput';
@@ -42807,7 +42808,7 @@ export type TimelineQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               mainPost:
                 | {
@@ -43018,7 +43019,7 @@ export type TimelineQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -43231,7 +43232,7 @@ export type TimelineQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
-                            totalAmountOfComments: number;
+                            commentsTotal: number;
                           };
                         }
                       | {
@@ -43444,7 +43445,7 @@ export type TimelineQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
-                            totalAmountOfComments: number;
+                            commentsTotal: number;
                           };
                           metadata: {
                             __typename?: 'MetadataOutput';
@@ -43790,7 +43791,7 @@ export type TimelineQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -44131,7 +44132,7 @@ export type TimelineQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -44344,7 +44345,7 @@ export type TimelineQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                   }
                 | {
@@ -44557,7 +44558,7 @@ export type TimelineQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
-                      totalAmountOfComments: number;
+                      commentsTotal: number;
                     };
                     metadata: {
                       __typename?: 'MetadataOutput';
@@ -44900,7 +44901,7 @@ export type TimelineQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
-                totalAmountOfComments: number;
+                commentsTotal: number;
               };
               metadata: {
                 __typename?: 'MetadataOutput';
@@ -45277,7 +45278,7 @@ export const StatsFieldsFragmentDoc = gql`
     totalUpvotes
     totalAmountOfMirrors
     totalAmountOfCollects
-    totalAmountOfComments
+    commentsTotal(customFilters: GARDENERS)
   }
 `;
 export const SimpleConditionFieldsFragmentDoc = gql`

--- a/packages/workers/snapshot-relay/generated.ts
+++ b/packages/workers/snapshot-relay/generated.ts
@@ -23,7 +23,7 @@ export type Incremental<T> =
 const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string };
+  ID: { input: string; output: string };
   String: { input: string; output: string };
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
@@ -442,6 +442,7 @@ export type Statement = {
   __typename?: 'Statement';
   about?: Maybe<Scalars['String']['output']>;
   created: Scalars['Int']['output'];
+  delegate?: Maybe<Scalars['String']['output']>;
   id: Scalars['String']['output'];
   ipfs: Scalars['String']['output'];
   space: Scalars['String']['output'];
@@ -456,6 +457,8 @@ export type StatementsWhere = {
   created_in?: InputMaybe<Array<InputMaybe<Scalars['Int']['input']>>>;
   created_lt?: InputMaybe<Scalars['Int']['input']>;
   created_lte?: InputMaybe<Scalars['Int']['input']>;
+  delegate?: InputMaybe<Scalars['String']['input']>;
+  delegate_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   id?: InputMaybe<Scalars['String']['input']>;
   id_in?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
   ipfs?: InputMaybe<Scalars['String']['input']>;


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a4cdcb2</samp>

Added `delegate` field to snapshot-relay types to support voting delegation. Updated various components and fragments to use the new `commentsTotal` field from the `Stats` type to filter comments by custom criteria.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a4cdcb2</samp>

*  Update the `commentsCount` variable to use the new `commentsTotal` field from the `Stats` type in three components: `SinglePublication`, `Comment`, and `PublicationStats` ([link](https://github.com/lensterxyz/lenster/pull/3149/files?diff=unified&w=0#diff-6e795da8cb06fb5316f3c91b8cc21cb973029f189395f24ea074b55ba5ada4bdL37-R38), [link](https://github.com/lensterxyz/lenster/pull/3149/files?diff=unified&w=0#diff-70fe66bde59a112f9744f8d17ace3a65dae57ecdc0f68fd06fda794891e88d7eL19-R20), [link](https://github.com/lensterxyz/lenster/pull/3149/files?diff=unified&w=0#diff-5826830061471498bb1147c05f83995f283dc9023c80c91b16a0aeb5aebe0702L29-R30))
*  Update the `StatsFields` fragment to use the new `commentsTotal` field from the `Stats` type in the `packages/lens/documents/fragments/StatsFields.graphql` file ([link](https://github.com/lensterxyz/lenster/pull/3149/files?diff=unified&w=0#diff-c6c86eab17ce37b830416df4af6ca327336e7c6210cdc9a919f4c379814b3a76L5-R5))
*  Add the `delegate` field to the `Statement` type and the `delegate` and `delegate_in` fields to the `StatementsWhere` type in the `packages/workers/snapshot-relay/generated.ts` file ([link](https://github.com/lensterxyz/lenster/pull/3149/files?diff=unified&w=0#diff-43feb3a80edbbd54002d5ac3c183aa36164c954cde635fcf6d94a626dbff6856R445), [link](https://github.com/lensterxyz/lenster/pull/3149/files?diff=unified&w=0#diff-43feb3a80edbbd54002d5ac3c183aa36164c954cde635fcf6d94a626dbff6856R460-R461))
*  Format the `Scalars` type in the `packages/workers/snapshot-relay/generated.ts` file according to the prettier configuration of the prerender app ([link](https://github.com/lensterxyz/lenster/pull/3149/files?diff=unified&w=0#diff-43feb3a80edbbd54002d5ac3c183aa36164c954cde635fcf6d94a626dbff6856L26-R26))

## Emoji

<!--
copilot:emoji
-->

📊💬🗳️

<!--
1.  📊 This emoji represents the addition of the new `commentsTotal` field to the `Stats` type, which allows more flexibility and granularity in querying the publication stats. It also represents the updates to the various components and queries that use the `Stats` type and the `StatsFields` fragment.
2. 💬 This emoji represents the updates to the `commentsCount` and `count` variables that use the new `commentsTotal` field to filter the comments by custom criteria. It also represents the changes to the UI components that display the comment count on the publication details and actions.
3. 🗳️ This emoji represents the addition of the `delegate` field to the `Statement` and `StatementsWhere` types, which allows delegation of voting power on snapshot spaces. It also represents the changes to the snapshot integration and the voting logic.
-->
