### PR TITLE
feat: add postMetadata test cases

### DIFF
--- a/packages/workers/ens-resolver/src/handlers/resolveEns.spec.ts
+++ b/packages/workers/ens-resolver/src/handlers/resolveEns.spec.ts
@@ -1,30 +1,32 @@
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { TEST_URL } from '../constants';
 
-test('should return welcome message', async () => {
-  const getRequest = await fetch(TEST_URL);
-  const response = await getRequest.text();
+describe('resolveEns', () => {
+  test('should return welcome message', async () => {
+    const getRequest = await fetch(TEST_URL);
+    const response = await getRequest.text();
 
-  expect(response).toContain('gm, ens resolver service 👋');
-});
-
-test('should return resolved address', async () => {
-  const postRequest = await fetch(TEST_URL, {
-    method: 'POST',
-    body: JSON.stringify({
-      addresses: [
-        '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3',
-        '0x01d79BcEaEaaDfb8fD2F2f53005289CFcF483464',
-        '0x82aae03e76290a4aed2c63ed7740ab5ef7c07b66',
-        '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
-      ]
-    })
+    expect(response).toContain('gm, ens resolver service 👋');
   });
-  const response = await postRequest.json();
 
-  expect(response).toEqual({
-    success: true,
-    data: ['yoginth.eth', 'sasi.eth', '', 'vitalik.eth']
+  test('should return resolved address', async () => {
+    const postRequest = await fetch(TEST_URL, {
+      method: 'POST',
+      body: JSON.stringify({
+        addresses: [
+          '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3',
+          '0x01d79BcEaEaaDfb8fD2F2f53005289CFcF483464',
+          '0x82aae03e76290a4aed2c63ed7740ab5ef7c07b66',
+          '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045'
+        ]
+      })
+    });
+    const response = await postRequest.json();
+
+    expect(response).toEqual({
+      success: true,
+      data: ['yoginth.eth', 'sasi.eth', '', 'vitalik.eth']
+    });
   });
 });

--- a/packages/workers/metadata/package.json
+++ b/packages/workers/metadata/package.json
@@ -10,6 +10,7 @@
     "prettier": "prettier --check \"**/*.{js,ts,tsx,md}\"  --cache",
     "prettier:fix": "prettier --write \"**/*.{js,ts,tsx,md}\"  --cache",
     "start": "pnpm dev",
+    "test:dev": "vitest --run",
     "typecheck": "tsc --pretty",
     "worker:deploy": "wrangler deploy"
   },
@@ -22,6 +23,7 @@
     "@cloudflare/workers-types": "^4.20230518.0",
     "@lenster/config": "workspace:*",
     "typescript": "^5.1.3",
+    "vitest": "^0.32.2",
     "wrangler": "^3.1.1"
   }
 }

--- a/packages/workers/metadata/src/constants.ts
+++ b/packages/workers/metadata/src/constants.ts
@@ -1,0 +1,1 @@
+export const TEST_URL = 'http://127.0.0.1:8083';

--- a/packages/workers/metadata/src/handlers/postMetadata.spec.ts
+++ b/packages/workers/metadata/src/handlers/postMetadata.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest';
+
+import { TEST_URL } from '../constants';
+
+describe('postMetadata', () => {
+  test('should return welcome message', async () => {
+    const getRequest = await fetch(TEST_URL);
+    const response = await getRequest.text();
+
+    expect(response).toContain('gm, to metadata service 👋');
+  });
+
+  test('should return resolved address', async () => {
+    const postRequest = await fetch(TEST_URL, {
+      method: 'POST',
+      body: JSON.stringify({
+        content: 'gm, running test from lenster codebase'
+      })
+    });
+    const response: any = await postRequest.json();
+
+    expect(response.success).toBeTruthy();
+    expect(response.metadata).toEqual({
+      content: 'gm, running test from lenster codebase',
+      tags: ['science_&_technology', 'learning_&_educational'],
+      locale: 'en'
+    });
+  });
+});

--- a/packages/workers/metadata/vitest.config.ts
+++ b/packages/workers/metadata/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { globals: true }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,6 +620,9 @@ importers:
       typescript:
         specifier: ^5.1.3
         version: 5.1.3
+      vitest:
+        specifier: ^0.32.2
+        version: 0.32.2
       wrangler:
         specifier: ^3.1.1
         version: 3.1.1


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf44a28</samp>

Added `vitest` as a testing framework for the `metadata` service and wrote tests for the `resolveEns` and `postMetadata` handlers. Created a `constants.ts` file to store the test URL and a `vitest.config.ts` file to set the testing options. Updated the `pnpm-lock.yaml` file with the new dependency.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cf44a28</samp>

*  Add `vitest` testing framework for `metadata` service ([link](https://github.com/lensterxyz/lenster/pull/3159/files?diff=unified&w=0#diff-fe9f7f73c59cba6fc4d588090077cd14ed6b853300be17ed13a1d045beafbc9cR13), [link](https://github.com/lensterxyz/lenster/pull/3159/files?diff=unified&w=0#diff-fe9f7f73c59cba6fc4d588090077cd14ed6b853300be17ed13a1d045beafbc9cR26), [link](https://github.com/lensterxyz/lenster/pull/3159/files?diff=unified&w=0#diff-117d42029a2e4a59bbc57f3322e92b03fd2f62cfb20908d56abd7d76fba3ac5fR1-R5), [link](https://github.com/lensterxyz/lenster/pull/3159/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR623-R625))
*  Create `constants.ts` file to export `TEST_URL` for `metadata` service ([link](https://github.com/lensterxyz/lenster/pull/3159/files?diff=unified&w=0#diff-1d00c2b19780b0b7c15c9d158eccdf281b3d17dcc063e3a033eeb0e7760b2cabR1))
*  Implement and test `postMetadata` handler to return metadata object from content string ([link](https://github.com/lensterxyz/lenster/pull/3159/files?diff=unified&w=0#diff-28c596dab30062f61a81fe79dd161025a5ebb4984667cc8c770900643c8bff23R1-R29))
*  Refactor `resolveEns.spec.ts` file to use `describe` blocks for `resolveEns` handler tests ([link](https://github.com/lensterxyz/lenster/pull/3159/files?diff=unified&w=0#diff-3b5865cbd4e77377bc230306e2fed48657a1fa7a3a4d64390c85735894bc12baL1-R30))

## Emoji

<!--
copilot:emoji
-->

🧪🏷️🌐

<!--
1.  🧪 - This emoji represents testing, experimentation, or science. It can be used to indicate that the changes involve adding or updating tests for the `metadata` service.
2.  🏷️ - This emoji represents labels, tags, or categories. It can be used to indicate that the changes involve creating or returning metadata objects with tags and locale for the content strings.
3.  🌐 - This emoji represents the world, the internet, or globalization. It can be used to indicate that the changes involve using the `fetch` API to make requests to the `metadata` service or resolving ENS names to IPFS hashes.
-->
