### PR TITLE
feat: add getImage and getOembed test cases

### DIFF
--- a/packages/workers/oembed/package.json
+++ b/packages/workers/oembed/package.json
@@ -11,6 +11,7 @@
     "prettier:fix": "prettier --write \"**/*.{js,ts,tsx,md}\"  --cache",
     "start": "pnpm dev",
     "typecheck": "tsc --pretty",
+    "test:dev": "vitest --run",
     "worker:deploy": "wrangler deploy"
   },
   "dependencies": {
@@ -23,6 +24,7 @@
     "@cloudflare/workers-types": "^4.20230518.0",
     "@lenster/config": "workspace:*",
     "typescript": "^5.1.3",
+    "vitest": "^0.32.2",
     "wrangler": "^3.1.1"
   }
 }

--- a/packages/workers/oembed/src/constants.ts
+++ b/packages/workers/oembed/src/constants.ts
@@ -1,0 +1,1 @@
+export const TEST_URL = 'http://127.0.0.1:8087';

--- a/packages/workers/oembed/src/handlers/getImage.spec.ts
+++ b/packages/workers/oembed/src/handlers/getImage.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest';
+
+import { TEST_URL } from '../constants';
+
+describe('getImage', () => {
+  test('should render image if url is provided', async () => {
+    const getRequest = await fetch(
+      `${TEST_URL}/image?hash=aHR0cHM6Ly9kaXNjb3JkLmNvbS9hc3NldHMvNjUyZjQwNDI3ZTFmNTE4NmFkNTQ4MzYwNzQ4OTgyNzkucG5n&transform=large`
+    );
+    const response: any = await getRequest.body;
+
+    expect(response).toBeTruthy();
+  });
+});

--- a/packages/workers/oembed/src/handlers/getOembed.spec.ts
+++ b/packages/workers/oembed/src/handlers/getOembed.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+
+import { TEST_URL } from '../constants';
+
+describe('getOembed', () => {
+  test('should return valid oembed response if url is provided', async () => {
+    const url = 'https://github.com/lensterxyz/lenster';
+    const getRequest = await fetch(`${TEST_URL}/?url=${url}`);
+    const response: any = await getRequest.json();
+
+    expect(response.success).toBeTruthy();
+    expect(response.oembed.url).toBe(url);
+    expect(response.oembed.title).toContain('GitHub - lensterxyz/lenster');
+    expect(response.oembed.description).toContain(
+      'Lenster is a decentralized and permissionless social media app'
+    );
+    expect(response.oembed.image).toContain('transform=large');
+    expect(response.oembed.site).toBe('GitHub');
+    expect(response.oembed.isLarge).toBeTruthy();
+    expect(response.oembed.html).toBeNull();
+  });
+
+  test('should return valid oembed response if url supports iframe is provided', async () => {
+    const url = 'https://www.youtube.com/watch?v=H5v3kku4y6Q';
+    const getRequest = await fetch(`${TEST_URL}/?url=${url}`);
+    const response: any = await getRequest.json();
+
+    expect(response.success).toBeTruthy();
+    expect(response.oembed.html).toContain(
+      'https://www.youtube.com/embed/H5v3kku4y6Q'
+    );
+  });
+});

--- a/packages/workers/oembed/vitest.config.ts
+++ b/packages/workers/oembed/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { globals: true }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -651,6 +651,9 @@ importers:
       typescript:
         specifier: ^5.1.3
         version: 5.1.3
+      vitest:
+        specifier: ^0.32.2
+        version: 0.32.2
       wrangler:
         specifier: ^3.1.1
         version: 3.1.1


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eaca2d1</samp>

This pull request adds vitest as a testing framework for the `oembed` worker package and creates test files for the `getImage` and `getOembed` handlers. It also updates the `package.json`, `constants.ts`, `vitest.config.ts`, and `pnpm-lock.yaml` files accordingly.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eaca2d1</samp>

*  Add vitest dependency and script to `packages/workers/oembed/package.json` ([link](https://github.com/lensterxyz/lenster/pull/3161/files?diff=unified&w=0#diff-07adc5b8ee6d78359ba934d4ab323b7382e1f42091079350b365f99d2964774aR14), [link](https://github.com/lensterxyz/lenster/pull/3161/files?diff=unified&w=0#diff-07adc5b8ee6d78359ba934d4ab323b7382e1f42091079350b365f99d2964774aR27), [link](https://github.com/lensterxyz/lenster/pull/3161/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR654-R656))
*  Enable globals option for vitest in `packages/workers/oembed/vitest.config.ts` ([link](https://github.com/lensterxyz/lenster/pull/3161/files?diff=unified&w=0#diff-cb87f18246a17efb9d8971a32420829a3a1aafac185359c45ccaa9d1116e445cR1-R5))
*  Define test URL constant for oembed worker in `packages/workers/oembed/src/constants.ts` ([link](https://github.com/lensterxyz/lenster/pull/3161/files?diff=unified&w=0#diff-26d89f71cd4e4a52262e0325ca763f41be2203a9bc934eda0d4053d1084f72dcR1))
*  Add test suite for getImage handler using fetch and expect in `packages/workers/oembed/src/handlers/getImage.spec.ts` ([link](https://github.com/lensterxyz/lenster/pull/3161/files?diff=unified&w=0#diff-84018f5f539b094bea0747fa9521a94e8d35db54245e81b2eeae29ed2d2516e0R1-R14))
*  Add test suite for getOembed handler using fetch and expect in `packages/workers/oembed/src/handlers/getOembed.spec.ts` ([link](https://github.com/lensterxyz/lenster/pull/3161/files?diff=unified&w=0#diff-26c831543dbc02434de250a535b28d6b5d0c2755696d5b810e51e2f00ad27109R1-R33))

## Emoji

<!--
copilot:emoji
-->

🧪🖼️🌐

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate that the changes involve adding or improving tests for the oembed worker package.
2.  🖼️ - This emoji represents an image, a picture, or a frame, and can be used to indicate that the changes involve rendering or embedding images in the oembed worker package.
3.  🌐 - This emoji represents the world, the internet, or the web, and can be used to indicate that the changes involve using the fetch API or the oembed protocol in the oembed worker package.
-->
