### PR TITLE
feat: add bookmarks

### DIFF
--- a/apps/web/src/components/Bookmarks/Feed.tsx
+++ b/apps/web/src/components/Bookmarks/Feed.tsx
@@ -1,0 +1,101 @@
+import SinglePublication from '@components/Publication/SinglePublication';
+import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
+import { BookmarkIcon } from '@heroicons/react/outline';
+import type {
+  Publication,
+  PublicationMainFocus,
+  PublicationsProfileBookmarkedQueryRequest
+} from '@lenster/lens';
+import { usePublicationsProfileBookmarksQuery } from '@lenster/lens';
+import { Card, EmptyState, ErrorMessage } from '@lenster/ui';
+import { t } from '@lingui/macro';
+import type { FC } from 'react';
+import { useState } from 'react';
+import { useInView } from 'react-cool-inview';
+import { useAppStore } from 'src/store/app';
+
+interface FeedProps {
+  focus?: PublicationMainFocus;
+}
+
+const Feed: FC<FeedProps> = ({ focus }) => {
+  const currentProfile = useAppStore((state) => state.currentProfile);
+  const [hasMore, setHasMore] = useState(true);
+
+  // Variables
+  const request: PublicationsProfileBookmarkedQueryRequest = {
+    profileId: currentProfile?.id,
+    metadata: {
+      ...(focus && { mainContentFocus: [focus] })
+    },
+    limit: 10
+  };
+  const reactionRequest = currentProfile
+    ? { profileId: currentProfile?.id }
+    : null;
+  const profileId = currentProfile?.id ?? null;
+
+  const { data, loading, error, fetchMore } =
+    usePublicationsProfileBookmarksQuery({
+      variables: { request, reactionRequest, profileId }
+    });
+
+  const publications = data?.publicationsProfileBookmarks?.items;
+  const pageInfo = data?.publicationsProfileBookmarks?.pageInfo;
+
+  const { observe } = useInView({
+    onChange: async ({ inView }) => {
+      if (!inView || !hasMore) {
+        return;
+      }
+
+      await fetchMore({
+        variables: {
+          request: { ...request, cursor: pageInfo?.next },
+          reactionRequest,
+          profileId
+        }
+      }).then(({ data }) => {
+        setHasMore(data?.publicationsProfileBookmarks?.items?.length > 0);
+      });
+    }
+  });
+
+  if (loading) {
+    return <PublicationsShimmer />;
+  }
+
+  if (publications?.length === 0) {
+    return (
+      <EmptyState
+        message={t`No bookmarks yet!`}
+        icon={<BookmarkIcon className="text-brand h-8 w-8" />}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <ErrorMessage title={t`Failed to load bookmark feed`} error={error} />
+    );
+  }
+
+  return (
+    <Card
+      className="divide-y-[1px] dark:divide-gray-700"
+      dataTestId="explore-feed"
+    >
+      {publications?.map((publication, index) => (
+        <SinglePublication
+          key={`${publication.id}_${index}`}
+          isFirst={index === 0}
+          isLast={index === publications.length - 1}
+          publication={publication as Publication}
+        />
+      ))}
+      {hasMore && <span ref={observe} />}
+    </Card>
+  );
+};
+
+export default Feed;

--- a/apps/web/src/components/Bookmarks/index.tsx
+++ b/apps/web/src/components/Bookmarks/index.tsx
@@ -1,0 +1,46 @@
+import MetaTags from '@components/Common/MetaTags';
+import RecommendedProfiles from '@components/Home/RecommendedProfiles';
+import Trending from '@components/Home/Trending';
+import FeedFocusType from '@components/Shared/FeedFocusType';
+import Footer from '@components/Shared/Footer';
+import { FeatureFlag } from '@lenster/data';
+import { APP_NAME } from '@lenster/data/constants';
+import { PAGEVIEW } from '@lenster/data/tracking';
+import type { PublicationMainFocus } from '@lenster/lens';
+import isFeatureEnabled from '@lenster/lib/isFeatureEnabled';
+import { GridItemEight, GridItemFour, GridLayout } from '@lenster/ui';
+import { Mixpanel } from '@lib/mixpanel';
+import { t } from '@lingui/macro';
+import type { NextPage } from 'next';
+import { useState } from 'react';
+import { useAppStore } from 'src/store/app';
+import { useEffectOnce } from 'usehooks-ts';
+
+import Feed from './Feed';
+
+const Bookmarks: NextPage = () => {
+  const currentProfile = useAppStore((state) => state.currentProfile);
+  const [focus, setFocus] = useState<PublicationMainFocus>();
+  const isTrendingWidgetEnabled = isFeatureEnabled(FeatureFlag.TrendingWidget);
+
+  useEffectOnce(() => {
+    Mixpanel.track(PAGEVIEW, { page: 'bookmarks' });
+  });
+
+  return (
+    <GridLayout>
+      <MetaTags title={t`Bookmarks • ${APP_NAME}`} />
+      <GridItemEight className="space-y-5">
+        <FeedFocusType setFocus={setFocus} focus={focus} />
+        <Feed focus={focus} />
+      </GridItemEight>
+      <GridItemFour>
+        {isTrendingWidgetEnabled && <Trending />}
+        {currentProfile ? <RecommendedProfiles /> : null}
+        <Footer />
+      </GridItemFour>
+    </GridLayout>
+  );
+};
+
+export default Bookmarks;

--- a/apps/web/src/components/Explore/index.tsx
+++ b/apps/web/src/components/Explore/index.tsx
@@ -2,6 +2,7 @@ import MetaTags from '@components/Common/MetaTags';
 import RecommendedProfiles from '@components/Home/RecommendedProfiles';
 import Tags from '@components/Home/Tags';
 import Trending from '@components/Home/Trending';
+import FeedFocusType from '@components/Shared/FeedFocusType';
 import Footer from '@components/Shared/Footer';
 import { Tab } from '@headlessui/react';
 import { FeatureFlag } from '@lenster/data';
@@ -21,7 +22,6 @@ import { useAppStore } from 'src/store/app';
 import { useEffectOnce } from 'usehooks-ts';
 
 import Feed from './Feed';
-import FeedType from './FeedType';
 
 const Explore: NextPage = () => {
   const router = useRouter();
@@ -83,7 +83,7 @@ const Explore: NextPage = () => {
               </Tab>
             ))}
           </Tab.List>
-          <FeedType setFocus={setFocus} focus={focus} />
+          <FeedFocusType setFocus={setFocus} focus={focus} />
           <Tab.Panels>
             {tabs.map((tab) => (
               <Tab.Panel key={tab.type}>

--- a/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
@@ -41,7 +41,15 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
 
     cache.modify({
       id: publicationKeyFields(bookmarkedPublications),
-      fields: { bookmarked: () => bookmarked }
+      fields: {
+        bookmarked: () => bookmarked,
+        stats: (stats) => ({
+          ...stats,
+          totalBookmarks: bookmarked
+            ? stats.totalBookmarks + 1
+            : stats.totalBookmarks - 1
+        })
+      }
     });
 
     // Remove bookmarked publication from bookmarks feed

--- a/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
@@ -1,0 +1,99 @@
+import { Menu } from '@headlessui/react';
+import { BookmarkIcon as BookmarkIconOutline } from '@heroicons/react/outline';
+import { BookmarkIcon as BookmarkIconSolid } from '@heroicons/react/solid';
+import type {
+  Publication,
+  PublicationProfileBookmarkRequest
+} from '@lenster/lens';
+import {
+  useAddPublicationProfileBookmarkMutation,
+  useRemovePublicationProfileBookmarkMutation
+} from '@lenster/lens';
+import type { ApolloCache } from '@lenster/lens/apollo';
+import { publicationKeyFields } from '@lenster/lens/apollo/lib';
+import stopEventPropagation from '@lenster/lib/stopEventPropagation';
+import errorToast from '@lib/errorToast';
+import clsx from 'clsx';
+import type { FC } from 'react';
+import { useAppStore } from 'src/store/app';
+
+interface BookmarkProps {
+  publication: Publication;
+}
+
+const Bookmark: FC<BookmarkProps> = ({ publication }) => {
+  const isMirror = publication.__typename === 'Mirror';
+  const bookmarked = isMirror
+    ? publication.mirrorOf.bookmarked
+    : publication.bookmarked;
+  const currentProfile = useAppStore((state) => state.currentProfile);
+  const request: PublicationProfileBookmarkRequest = {
+    profileId: currentProfile?.id,
+    publicationId: publication.id
+  };
+
+  const updateCache = (cache: ApolloCache<any>, bookmarked: boolean) => {
+    cache.modify({
+      id: publicationKeyFields(isMirror ? publication?.mirrorOf : publication),
+      fields: { bookmarked: () => bookmarked }
+    });
+  };
+
+  const onError = (error: any) => {
+    errorToast(error);
+  };
+
+  const [addPublicationProfileBookmark] =
+    useAddPublicationProfileBookmarkMutation({
+      variables: { request },
+      onError,
+      update: (cache) => updateCache(cache, true)
+    });
+
+  const [removePublicationProfileBookmark] =
+    useRemovePublicationProfileBookmarkMutation({
+      variables: { request },
+      onError,
+      update: (cache) => updateCache(cache, false)
+    });
+
+  const togglePublicationProfileBookmark = async () => {
+    if (bookmarked) {
+      return await removePublicationProfileBookmark();
+    }
+
+    return await addPublicationProfileBookmark();
+  };
+
+  return (
+    <Menu.Item
+      as="div"
+      className={({ active }) =>
+        clsx(
+          { 'dropdown-active': active },
+          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm'
+        )
+      }
+      onClick={(event) => {
+        stopEventPropagation(event);
+        togglePublicationProfileBookmark();
+      }}
+    >
+      <div className="flex items-center space-x-2">
+        {bookmarked ? (
+          <>
+            <BookmarkIconSolid className="h-4 w-4" />
+            <div>Remove Bookmark</div>
+          </>
+        ) : (
+          <>
+            <BookmarkIconOutline className="h-4 w-4" />
+            <div>Bookmark</div>
+          </>
+        )}
+      </div>
+    </Menu.Item>
+  );
+};
+
+export default Bookmark;

--- a/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
@@ -13,9 +13,11 @@ import type { ApolloCache } from '@lenster/lens/apollo';
 import { publicationKeyFields } from '@lenster/lens/apollo/lib';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import errorToast from '@lib/errorToast';
+import { t } from '@lingui/macro';
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
 import type { FC } from 'react';
+import { toast } from 'react-hot-toast';
 import { useAppStore } from 'src/store/app';
 
 interface BookmarkProps {
@@ -66,6 +68,9 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
     useAddPublicationProfileBookmarkMutation({
       variables: { request },
       onError,
+      onCompleted: () => {
+        toast.success(t`Publication bookmarked`);
+      },
       update: (cache) => updateCache(cache, true)
     });
 
@@ -73,6 +78,9 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
     useRemovePublicationProfileBookmarkMutation({
       variables: { request },
       onError,
+      onCompleted: () => {
+        toast.success(t`Removed publication bookmark`);
+      },
       update: (cache) => updateCache(cache, false)
     });
 

--- a/apps/web/src/components/Publication/Actions/Menu/index.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/index.tsx
@@ -8,6 +8,7 @@ import type { FC } from 'react';
 import { Fragment } from 'react';
 import { useAppStore } from 'src/store/app';
 
+import Bookmark from './Bookmark';
 import CopyPostText from './CopyPostText';
 import Delete from './Delete';
 import Report from './Report';
@@ -47,6 +48,7 @@ const PublicationMenu: FC<PublicationMenuProps> = ({ publication }) => {
           ) : (
             <Report publication={publication} />
           )}
+          {currentProfile ? <Bookmark publication={publication} /> : null}
           <Share publication={publication} />
           <Translate publication={publication} />
           <CopyPostText publication={publication} />

--- a/apps/web/src/components/Publication/PublicationStats.tsx
+++ b/apps/web/src/components/Publication/PublicationStats.tsx
@@ -37,6 +37,9 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
   const collectCount = isMirror
     ? publication?.mirrorOf?.stats?.totalAmountOfCollects
     : publication?.stats?.totalAmountOfCollects;
+  const bookmarkCount = isMirror
+    ? publication?.mirrorOf?.stats?.totalBookmarks
+    : publication?.stats?.totalBookmarks;
   const publicationId = isMirror ? publication?.mirrorOf?.id : publication?.id;
 
   return (
@@ -147,6 +150,19 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
             <Collectors publicationId={publicationId} />
           </Modal>
         </>
+      )}
+      {bookmarkCount > 0 && (
+        <span data-testid="bookmark-stats">
+          <b className="text-black dark:text-white">
+            {nFormatter(bookmarkCount)}
+          </b>{' '}
+          <Plural
+            value={bookmarkCount}
+            zero="Bookmark"
+            one="Bookmark"
+            other="Bookmarks"
+          />
+        </span>
       )}
     </div>
   );

--- a/apps/web/src/components/Shared/FeedFocusType.tsx
+++ b/apps/web/src/components/Shared/FeedFocusType.tsx
@@ -10,12 +10,12 @@ interface FeedLinkProps {
   type?: PublicationMainFocus;
 }
 
-interface FeedTypeProps {
+interface FeedFocusTypeProps {
   setFocus: Dispatch<PublicationMainFocus>;
   focus?: PublicationMainFocus;
 }
 
-const FeedType: FC<FeedTypeProps> = ({ setFocus, focus }) => {
+const FeedFocusType: FC<FeedFocusTypeProps> = ({ setFocus, focus }) => {
   const FeedLink: FC<FeedLinkProps> = ({ name, type }) => (
     <button
       type="button"
@@ -50,4 +50,4 @@ const FeedType: FC<FeedTypeProps> = ({ setFocus, focus }) => {
   );
 };
 
-export default FeedType;
+export default FeedFocusType;

--- a/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
+++ b/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
@@ -13,6 +13,7 @@ import { useGlobalModalStateStore } from 'src/store/modals';
 
 import Slug from '../Slug';
 import AppVersion from './NavItems/AppVersion';
+import Bookmarks from './NavItems/Bookmarks';
 import Contact from './NavItems/Contact';
 import Logout from './NavItems/Logout';
 import Mod from './NavItems/Mod';
@@ -86,6 +87,10 @@ const MobileDrawerMenu: FC = () => {
             <Link href={'/settings'} onClick={closeDrawer}>
               <Settings className="px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-800" />
             </Link>
+            <Bookmarks
+              className="py-3 hover:bg-gray-100 dark:hover:bg-gray-800"
+              onClick={closeDrawer}
+            />
             {isGardener(currentProfile?.id) && (
               <Link href="/mod" onClick={closeDrawer}>
                 <Mod className="px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-800" />

--- a/apps/web/src/components/Shared/Navbar/MoreNavItems.tsx
+++ b/apps/web/src/components/Shared/Navbar/MoreNavItems.tsx
@@ -2,12 +2,16 @@ import { Menu } from '@headlessui/react';
 import { Trans } from '@lingui/macro';
 import clsx from 'clsx';
 import type { FC } from 'react';
+import { useAppStore } from 'src/store/app';
 
 import MenuTransition from '../MenuTransition';
+import Bookmarks from './NavItems/Bookmarks';
 import Contact from './NavItems/Contact';
 import ReportBug from './NavItems/ReportBug';
 
 const MoreNavItems: FC = () => {
+  const currentProfile = useAppStore((state) => state.currentProfile);
+
   return (
     <Menu as="div" data-testid="nav-item-more">
       {({ open }) => (
@@ -30,6 +34,19 @@ const MoreNavItems: FC = () => {
               className="absolute mt-2 rounded-xl border bg-white py-1 shadow-sm focus:outline-none dark:border-gray-700 dark:bg-gray-900"
               data-testid="nav-item-more-dropdown"
             >
+              {currentProfile ? (
+                <>
+                  <Menu.Item
+                    as="div"
+                    className={({ active }: { active: boolean }) =>
+                      clsx({ 'dropdown-active': active }, 'm-2 rounded-lg')
+                    }
+                  >
+                    <Bookmarks />
+                  </Menu.Item>
+                  <div className="divider" />
+                </>
+              ) : null}
               <Menu.Item
                 as="div"
                 className={({ active }: { active: boolean }) =>

--- a/apps/web/src/components/Shared/Navbar/NavItems/Bookmarks.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Bookmarks.tsx
@@ -1,0 +1,30 @@
+import { BookmarkIcon } from '@heroicons/react/outline';
+import { Trans } from '@lingui/macro';
+import clsx from 'clsx';
+import Link from 'next/link';
+import type { FC } from 'react';
+
+interface BookmarksProps {
+  onClick?: () => void;
+  className?: string;
+}
+
+const Bookmarks: FC<BookmarksProps> = ({ onClick, className = '' }) => {
+  return (
+    <Link
+      href="/bookmarks"
+      className={clsx(
+        'flex w-full items-center space-x-1.5 px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        className
+      )}
+      onClick={onClick}
+    >
+      <BookmarkIcon className="h-4 w-4" />
+      <div>
+        <Trans>Bookmarks</Trans>
+      </div>
+    </Link>
+  );
+};
+
+export default Bookmarks;

--- a/apps/web/src/pages/bookmarks.tsx
+++ b/apps/web/src/pages/bookmarks.tsx
@@ -1,0 +1,3 @@
+import Bookmarks from '@components/Bookmarks';
+
+export default Bookmarks;

--- a/packages/lens/codegen.ts
+++ b/packages/lens/codegen.ts
@@ -2,7 +2,7 @@ import type { CodegenConfig } from '@graphql-codegen/cli';
 
 const config: CodegenConfig = {
   overwrite: true,
-  schema: 'https://api-mumbai.lens.dev',
+  schema: 'https://staging-api-social-mumbai.lens.crtlkey.com',
   documents: './documents/**/*.graphql',
   generates: {
     'generated.ts': {

--- a/packages/lens/documents/fragments/CommentFields.graphql
+++ b/packages/lens/documents/fragments/CommentFields.graphql
@@ -5,6 +5,7 @@ fragment CommentFields on Comment {
   }
   reaction(request: $reactionRequest)
   mirrors(by: $profileId)
+  bookmarked(by: $profileId)
   hasCollectedByMe
   onChainContentURI
   isGated
@@ -43,6 +44,7 @@ fragment CommentFields on Comment {
       }
       reaction(request: $reactionRequest)
       mirrors(by: $profileId)
+      bookmarked(by: $profileId)
       hasCollectedByMe
       onChainContentURI
       isGated

--- a/packages/lens/documents/fragments/MirrorFields.graphql
+++ b/packages/lens/documents/fragments/MirrorFields.graphql
@@ -40,6 +40,7 @@ fragment MirrorFields on Mirror {
       collectNftAddress
       reaction(request: $reactionRequest)
       mirrors(by: $profileId)
+      bookmarked(by: $profileId)
       onChainContentURI
       isGated
       isDataAvailability

--- a/packages/lens/documents/fragments/PostFields.graphql
+++ b/packages/lens/documents/fragments/PostFields.graphql
@@ -5,6 +5,7 @@ fragment PostFields on Post {
   }
   reaction(request: $reactionRequest)
   mirrors(by: $profileId)
+  bookmarked(by: $profileId)
   hasCollectedByMe
   onChainContentURI
   isGated

--- a/packages/lens/documents/fragments/StatsFields.graphql
+++ b/packages/lens/documents/fragments/StatsFields.graphql
@@ -2,5 +2,6 @@ fragment StatsFields on PublicationStats {
   totalUpvotes
   totalAmountOfMirrors
   totalAmountOfCollects
+  totalBookmarks
   commentsTotal(customFilters: GARDENERS)
 }

--- a/packages/lens/documents/mutations/AddPublicationProfileBookmark.graphql
+++ b/packages/lens/documents/mutations/AddPublicationProfileBookmark.graphql
@@ -1,0 +1,5 @@
+mutation AddPublicationProfileBookmark(
+  $request: PublicationProfileBookmarkRequest!
+) {
+  addPublicationProfileBookmark(request: $request)
+}

--- a/packages/lens/documents/mutations/RemovePublicationProfileBookmark.graphql
+++ b/packages/lens/documents/mutations/RemovePublicationProfileBookmark.graphql
@@ -1,0 +1,5 @@
+mutation RemovePublicationProfileBookmark(
+  $request: PublicationProfileBookmarkRequest!
+) {
+  removePublicationProfileBookmark(request: $request)
+}

--- a/packages/lens/documents/queries/PublicationsProfileBookmarks.graphql
+++ b/packages/lens/documents/queries/PublicationsProfileBookmarks.graphql
@@ -1,0 +1,22 @@
+query PublicationsProfileBookmarks(
+  $request: PublicationsProfileBookmarkedQueryRequest!
+  $reactionRequest: ReactionFieldResolverRequest
+  $profileId: ProfileId
+) {
+  publicationsProfileBookmarks(request: $request) {
+    items {
+      ... on Post {
+        ...PostFields
+      }
+      ... on Comment {
+        ...CommentFields
+      }
+      ... on Mirror {
+        ...MirrorFields
+      }
+    }
+    pageInfo {
+      next
+    }
+  }
+}

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -3870,6 +3870,8 @@ export type PublicationStats = {
   totalAmountOfComments: Scalars['Int']['output'];
   /** The total amount of mirrors */
   totalAmountOfMirrors: Scalars['Int']['output'];
+  /** The total amount of bookmarks */
+  totalBookmarks: Scalars['Int']['output'];
   /** The total amount of upvotes */
   totalDownvotes: Scalars['Int']['output'];
   /** The total amount of downvotes */
@@ -5334,6 +5336,7 @@ export type CommentFieldsFragment = {
     totalUpvotes: number;
     totalAmountOfMirrors: number;
     totalAmountOfCollects: number;
+    totalBookmarks: number;
     commentsTotal: number;
   };
   metadata: {
@@ -5794,6 +5797,7 @@ export type CommentFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
         mainPost:
@@ -6002,6 +6006,7 @@ export type CommentFieldsFragment = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -6216,6 +6221,7 @@ export type CommentFieldsFragment = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                   }
@@ -6430,6 +6436,7 @@ export type CommentFieldsFragment = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -6774,6 +6781,7 @@ export type CommentFieldsFragment = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -7112,6 +7120,7 @@ export type CommentFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
         metadata: {
@@ -7319,6 +7328,7 @@ export type CommentFieldsFragment = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
             }
@@ -7530,6 +7540,7 @@ export type CommentFieldsFragment = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -7871,6 +7882,7 @@ export type CommentFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
         metadata: {
@@ -8327,6 +8339,7 @@ export type MirrorFieldsFragment = {
     totalUpvotes: number;
     totalAmountOfMirrors: number;
     totalAmountOfCollects: number;
+    totalBookmarks: number;
     commentsTotal: number;
   };
   metadata: {
@@ -8528,6 +8541,7 @@ export type MirrorFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
       }
@@ -8736,6 +8750,7 @@ export type MirrorFieldsFragment = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
         metadata: {
@@ -9085,6 +9100,7 @@ export type PostFieldsFragment = {
     totalUpvotes: number;
     totalAmountOfMirrors: number;
     totalAmountOfCollects: number;
+    totalBookmarks: number;
     commentsTotal: number;
   };
   metadata: {
@@ -9304,6 +9320,7 @@ export type StatsFieldsFragment = {
   totalUpvotes: number;
   totalAmountOfMirrors: number;
   totalAmountOfCollects: number;
+  totalBookmarks: number;
   commentsTotal: number;
 };
 
@@ -10914,6 +10931,7 @@ export type CommentFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -11391,6 +11409,7 @@ export type CommentFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 mainPost:
@@ -11602,6 +11621,7 @@ export type CommentFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -11822,6 +11842,7 @@ export type CommentFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                           }
@@ -12044,6 +12065,7 @@ export type CommentFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                             metadata: {
@@ -12391,6 +12413,7 @@ export type CommentFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -12735,6 +12758,7 @@ export type CommentFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -12949,6 +12973,7 @@ export type CommentFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                     }
@@ -13163,6 +13188,7 @@ export type CommentFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -13510,6 +13536,7 @@ export type CommentFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -13891,6 +13918,7 @@ export type ExploreFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -14368,6 +14396,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 mainPost:
@@ -14579,6 +14608,7 @@ export type ExploreFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -14799,6 +14829,7 @@ export type ExploreFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                           }
@@ -15021,6 +15052,7 @@ export type ExploreFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                             metadata: {
@@ -15368,6 +15400,7 @@ export type ExploreFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -15712,6 +15745,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -15926,6 +15960,7 @@ export type ExploreFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                     }
@@ -16140,6 +16175,7 @@ export type ExploreFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -16487,6 +16523,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -16826,6 +16863,7 @@ export type ExploreFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -17040,6 +17078,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
               }
@@ -17254,6 +17293,7 @@ export type ExploreFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -17595,6 +17635,7 @@ export type ExploreFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -17951,6 +17992,7 @@ export type FeedHighlightsQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -18428,6 +18470,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 mainPost:
@@ -18639,6 +18682,7 @@ export type FeedHighlightsQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -18859,6 +18903,7 @@ export type FeedHighlightsQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                           }
@@ -19081,6 +19126,7 @@ export type FeedHighlightsQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                             metadata: {
@@ -19428,6 +19474,7 @@ export type FeedHighlightsQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -19772,6 +19819,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -19986,6 +20034,7 @@ export type FeedHighlightsQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                     }
@@ -20200,6 +20249,7 @@ export type FeedHighlightsQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -20547,6 +20597,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -20886,6 +20937,7 @@ export type FeedHighlightsQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -21100,6 +21152,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
               }
@@ -21314,6 +21367,7 @@ export type FeedHighlightsQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -21655,6 +21709,7 @@ export type FeedHighlightsQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -22145,6 +22200,7 @@ export type ForYouQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -22622,6 +22678,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 mainPost:
@@ -22833,6 +22890,7 @@ export type ForYouQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -23053,6 +23111,7 @@ export type ForYouQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                           }
@@ -23275,6 +23334,7 @@ export type ForYouQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                             metadata: {
@@ -23622,6 +23682,7 @@ export type ForYouQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -23966,6 +24027,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -24180,6 +24242,7 @@ export type ForYouQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                     }
@@ -24394,6 +24457,7 @@ export type ForYouQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -24741,6 +24805,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -25080,6 +25145,7 @@ export type ForYouQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -25294,6 +25360,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
               }
@@ -25508,6 +25575,7 @@ export type ForYouQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -25849,6 +25917,7 @@ export type ForYouQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -27293,6 +27362,7 @@ export type ProfileFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -27770,6 +27840,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 mainPost:
@@ -27981,6 +28052,7 @@ export type ProfileFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -28201,6 +28273,7 @@ export type ProfileFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                           }
@@ -28423,6 +28496,7 @@ export type ProfileFeedQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                             metadata: {
@@ -28770,6 +28844,7 @@ export type ProfileFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -29114,6 +29189,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -29328,6 +29404,7 @@ export type ProfileFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                     }
@@ -29542,6 +29619,7 @@ export type ProfileFeedQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -29889,6 +29967,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -30228,6 +30307,7 @@ export type ProfileFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -30442,6 +30522,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
               }
@@ -30656,6 +30737,7 @@ export type ProfileFeedQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -30997,6 +31079,7 @@ export type ProfileFeedQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -31483,6 +31566,7 @@ export type PublicationQuery = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
         metadata: {
@@ -31953,6 +32037,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               mainPost:
@@ -32164,6 +32249,7 @@ export type PublicationQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -32378,6 +32464,7 @@ export type PublicationQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
+                            totalBookmarks: number;
                             commentsTotal: number;
                           };
                         }
@@ -32592,6 +32679,7 @@ export type PublicationQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
+                            totalBookmarks: number;
                             commentsTotal: number;
                           };
                           metadata: {
@@ -32939,6 +33027,7 @@ export type PublicationQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -33280,6 +33369,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -33494,6 +33584,7 @@ export type PublicationQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                   }
@@ -33708,6 +33799,7 @@ export type PublicationQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -34052,6 +34144,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -34397,6 +34490,7 @@ export type PublicationQuery = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
         metadata: {
@@ -34604,6 +34698,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
             }
@@ -34815,6 +34910,7 @@ export type PublicationQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -35162,6 +35258,7 @@ export type PublicationQuery = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
         metadata: {
@@ -35527,6 +35624,7 @@ export type PublicationsProfileBookmarksQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -36004,6 +36102,7 @@ export type PublicationsProfileBookmarksQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 mainPost:
@@ -36215,6 +36314,7 @@ export type PublicationsProfileBookmarksQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -36435,6 +36535,7 @@ export type PublicationsProfileBookmarksQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                           }
@@ -36657,6 +36758,7 @@ export type PublicationsProfileBookmarksQuery = {
                               totalUpvotes: number;
                               totalAmountOfMirrors: number;
                               totalAmountOfCollects: number;
+                              totalBookmarks: number;
                               commentsTotal: number;
                             };
                             metadata: {
@@ -37004,6 +37106,7 @@ export type PublicationsProfileBookmarksQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -37348,6 +37451,7 @@ export type PublicationsProfileBookmarksQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -37562,6 +37666,7 @@ export type PublicationsProfileBookmarksQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                     }
@@ -37776,6 +37881,7 @@ export type PublicationsProfileBookmarksQuery = {
                         totalUpvotes: number;
                         totalAmountOfMirrors: number;
                         totalAmountOfCollects: number;
+                        totalBookmarks: number;
                         commentsTotal: number;
                       };
                       metadata: {
@@ -38123,6 +38229,7 @@ export type PublicationsProfileBookmarksQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -38462,6 +38569,7 @@ export type PublicationsProfileBookmarksQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -38676,6 +38784,7 @@ export type PublicationsProfileBookmarksQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
               }
@@ -38890,6 +38999,7 @@ export type PublicationsProfileBookmarksQuery = {
                   totalUpvotes: number;
                   totalAmountOfMirrors: number;
                   totalAmountOfCollects: number;
+                  totalBookmarks: number;
                   commentsTotal: number;
                 };
                 metadata: {
@@ -39231,6 +39341,7 @@ export type PublicationsProfileBookmarksQuery = {
             totalUpvotes: number;
             totalAmountOfMirrors: number;
             totalAmountOfCollects: number;
+            totalBookmarks: number;
             commentsTotal: number;
           };
           metadata: {
@@ -39724,6 +39835,7 @@ export type SearchPublicationsQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -40201,6 +40313,7 @@ export type SearchPublicationsQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     mainPost:
@@ -40412,6 +40525,7 @@ export type SearchPublicationsQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
+                            totalBookmarks: number;
                             commentsTotal: number;
                           };
                           metadata: {
@@ -40638,6 +40752,7 @@ export type SearchPublicationsQuery = {
                                   totalUpvotes: number;
                                   totalAmountOfMirrors: number;
                                   totalAmountOfCollects: number;
+                                  totalBookmarks: number;
                                   commentsTotal: number;
                                 };
                               }
@@ -40872,6 +40987,7 @@ export type SearchPublicationsQuery = {
                                   totalUpvotes: number;
                                   totalAmountOfMirrors: number;
                                   totalAmountOfCollects: number;
+                                  totalBookmarks: number;
                                   commentsTotal: number;
                                 };
                                 metadata: {
@@ -41226,6 +41342,7 @@ export type SearchPublicationsQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
+                            totalBookmarks: number;
                             commentsTotal: number;
                           };
                           metadata: {
@@ -41570,6 +41687,7 @@ export type SearchPublicationsQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -41784,6 +41902,7 @@ export type SearchPublicationsQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
+                            totalBookmarks: number;
                             commentsTotal: number;
                           };
                         }
@@ -41998,6 +42117,7 @@ export type SearchPublicationsQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
+                            totalBookmarks: number;
                             commentsTotal: number;
                           };
                           metadata: {
@@ -42345,6 +42465,7 @@ export type SearchPublicationsQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -42690,6 +42811,7 @@ export type SearchPublicationsQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -43459,6 +43581,7 @@ export type TimelineQuery = {
               totalUpvotes: number;
               totalAmountOfMirrors: number;
               totalAmountOfCollects: number;
+              totalBookmarks: number;
               commentsTotal: number;
             };
             metadata: {
@@ -43936,6 +44059,7 @@ export type TimelineQuery = {
                     totalUpvotes: number;
                     totalAmountOfMirrors: number;
                     totalAmountOfCollects: number;
+                    totalBookmarks: number;
                     commentsTotal: number;
                   };
                   mainPost:
@@ -44147,6 +44271,7 @@ export type TimelineQuery = {
                           totalUpvotes: number;
                           totalAmountOfMirrors: number;
                           totalAmountOfCollects: number;
+                          totalBookmarks: number;
                           commentsTotal: number;
                         };
                         metadata: {
@@ -44371,6 +44496,7 @@ export type TimelineQuery = {
                                 totalUpvotes: number;
                                 totalAmountOfMirrors: number;
                                 totalAmountOfCollects: number;
+                                totalBookmarks: number;
                                 commentsTotal: number;
                               };
                             }
@@ -44601,6 +44727,7 @@ export type TimelineQuery = {
                                 totalUpvotes: number;
                                 totalAmountOfMirrors: number;
                                 totalAmountOfCollects: number;
+                                totalBookmarks: number;
                                 commentsTotal: number;
                               };
                               metadata: {
@@ -44948,6 +45075,7 @@ export type TimelineQuery = {
                           totalUpvotes: number;
                           totalAmountOfMirrors: number;
                           totalAmountOfCollects: number;
+                          totalBookmarks: number;
                           commentsTotal: number;
                         };
                         metadata: {
@@ -45292,6 +45420,7 @@ export type TimelineQuery = {
                     totalUpvotes: number;
                     totalAmountOfMirrors: number;
                     totalAmountOfCollects: number;
+                    totalBookmarks: number;
                     commentsTotal: number;
                   };
                   metadata: {
@@ -45506,6 +45635,7 @@ export type TimelineQuery = {
                           totalUpvotes: number;
                           totalAmountOfMirrors: number;
                           totalAmountOfCollects: number;
+                          totalBookmarks: number;
                           commentsTotal: number;
                         };
                       }
@@ -45720,6 +45850,7 @@ export type TimelineQuery = {
                           totalUpvotes: number;
                           totalAmountOfMirrors: number;
                           totalAmountOfCollects: number;
+                          totalBookmarks: number;
                           commentsTotal: number;
                         };
                         metadata: {
@@ -46067,6 +46198,7 @@ export type TimelineQuery = {
                     totalUpvotes: number;
                     totalAmountOfMirrors: number;
                     totalAmountOfCollects: number;
+                    totalBookmarks: number;
                     commentsTotal: number;
                   };
                   metadata: {
@@ -46409,6 +46541,7 @@ export type TimelineQuery = {
               totalUpvotes: number;
               totalAmountOfMirrors: number;
               totalAmountOfCollects: number;
+              totalBookmarks: number;
               commentsTotal: number;
             };
             metadata: {
@@ -46963,6 +47096,7 @@ export type TimelineQuery = {
           totalUpvotes: number;
           totalAmountOfMirrors: number;
           totalAmountOfCollects: number;
+          totalBookmarks: number;
           commentsTotal: number;
         };
         metadata: {
@@ -47433,6 +47567,7 @@ export type TimelineQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               mainPost:
@@ -47644,6 +47779,7 @@ export type TimelineQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -47858,6 +47994,7 @@ export type TimelineQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
+                            totalBookmarks: number;
                             commentsTotal: number;
                           };
                         }
@@ -48072,6 +48209,7 @@ export type TimelineQuery = {
                             totalUpvotes: number;
                             totalAmountOfMirrors: number;
                             totalAmountOfCollects: number;
+                            totalBookmarks: number;
                             commentsTotal: number;
                           };
                           metadata: {
@@ -48419,6 +48557,7 @@ export type TimelineQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -48760,6 +48899,7 @@ export type TimelineQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -48974,6 +49114,7 @@ export type TimelineQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                   }
@@ -49188,6 +49329,7 @@ export type TimelineQuery = {
                       totalUpvotes: number;
                       totalAmountOfMirrors: number;
                       totalAmountOfCollects: number;
+                      totalBookmarks: number;
                       commentsTotal: number;
                     };
                     metadata: {
@@ -49532,6 +49674,7 @@ export type TimelineQuery = {
                 totalUpvotes: number;
                 totalAmountOfMirrors: number;
                 totalAmountOfCollects: number;
+                totalBookmarks: number;
                 commentsTotal: number;
               };
               metadata: {
@@ -49909,6 +50052,7 @@ export const StatsFieldsFragmentDoc = gql`
     totalUpvotes
     totalAmountOfMirrors
     totalAmountOfCollects
+    totalBookmarks
     commentsTotal(customFilters: GARDENERS)
   }
 `;

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -75,6 +75,10 @@ export type Scalars = {
   UnixTimestamp: { input: any; output: any };
   Url: { input: any; output: any };
   Void: { input: any; output: any };
+  ZkCommunityId: { input: any; output: any };
+  ZkIdentityCommitment: { input: any; output: any };
+  ZkPollId: { input: any; output: any };
+  ZkProof: { input: any; output: any };
 };
 
 export type AaveFeeCollectModuleParams = {
@@ -167,6 +171,15 @@ export type AddProfileInterestsRequest = {
   interests: Array<Scalars['ProfileInterest']['input']>;
   /** The profileId to add interests to */
   profileId: Scalars['ProfileId']['input'];
+};
+
+export type AddVoterRequest = {
+  /** The ZkCommunity id */
+  communityId: Scalars['ZkCommunityId']['input'];
+  /** The profile id */
+  profileId: Scalars['ProfileId']['input'];
+  /** The voter identity commitment */
+  voter: Scalars['ZkIdentityCommitment']['input'];
 };
 
 export type AllPublicationsTagsRequest = {
@@ -270,6 +283,21 @@ export type CanMirrorResponse = {
   result: Scalars['Boolean']['output'];
 };
 
+export type CastZkVoteRequest = {
+  /** The ZkCommunity id */
+  communityId: Scalars['ZkCommunityId']['input'];
+  /** The voter identity commitment */
+  identityCommitment: Scalars['ZkIdentityCommitment']['input'];
+  /** The nullifier hash of the vote */
+  nullifierHash: Scalars['String']['input'];
+  /** The ZkPoll id */
+  pollId: Scalars['ZkPollId']['input'];
+  /** The zkProof of the vote */
+  proof: Scalars['ZkProof']['input'];
+  /** The Vote , 1 = yes, 0 = no */
+  vote: Scalars['String']['input'];
+};
+
 /** The challenge request */
 export type ChallengeRequest = {
   /** The ethereum address you want to login with */
@@ -289,6 +317,15 @@ export enum ClaimStatus {
   ClaimFailed = 'CLAIM_FAILED',
   NotClaimed = 'NOT_CLAIMED'
 }
+
+export type ClaimZkBadgeRequest = {
+  /** The ZkCommunity id */
+  communityId: Scalars['ZkCommunityId']['input'];
+  /** The ZkPoll id */
+  pollId: Scalars['ZkPollId']['input'];
+  /** The profile id */
+  profileId: Scalars['ProfileId']['input'];
+};
 
 export type ClaimableHandles = {
   __typename?: 'ClaimableHandles';
@@ -381,6 +418,7 @@ export type Comment = {
   __typename?: 'Comment';
   /** ID of the source */
   appId?: Maybe<Scalars['Sources']['output']>;
+  bookmarked: Scalars['Boolean']['output'];
   canComment: CanCommentResponse;
   canDecrypt: CanDecryptResponse;
   canMirror: CanMirrorResponse;
@@ -412,6 +450,7 @@ export type Comment = {
   /** The metadata for the post */
   metadata: MetadataOutput;
   mirrors: Array<Scalars['InternalPublicationId']['output']>;
+  notInterested: Scalars['Boolean']['output'];
   /** The on chain content uri could be `ipfs://` or `https` */
   onChainContentURI: Scalars['String']['output'];
   /** The profile ref */
@@ -423,6 +462,11 @@ export type Comment = {
   referenceModule?: Maybe<ReferenceModule>;
   /** The publication stats */
   stats: PublicationStats;
+};
+
+/** The social comment */
+export type CommentBookmarkedArgs = {
+  by?: InputMaybe<Scalars['ProfileId']['input']>;
 };
 
 /** The social comment */
@@ -448,6 +492,11 @@ export type CommentHasCollectedByMeArgs = {
 
 /** The social comment */
 export type CommentMirrorsArgs = {
+  by?: InputMaybe<Scalars['ProfileId']['input']>;
+};
+
+/** The social comment */
+export type CommentNotInterestedArgs = {
   by?: InputMaybe<Scalars['ProfileId']['input']>;
 };
 
@@ -1059,6 +1108,26 @@ export type CreateUnfollowBroadcastItemResult = {
   id: Scalars['BroadcastId']['output'];
   /** The typed data */
   typedData: CreateBurnEip712TypedData;
+};
+
+export type CreateZkCommunityRequest = {
+  /** The ZkCommunity id */
+  communityId: Scalars['ZkCommunityId']['input'];
+  /** The description of the community */
+  description: Scalars['String']['input'];
+  /** The name of the community */
+  name: Scalars['String']['input'];
+  /** Community creator profile Id */
+  profileId: Scalars['ProfileId']['input'];
+};
+
+export type CreateZkPollRequest = {
+  /** The ZkCommunity id */
+  communityId: Scalars['ZkCommunityId']['input'];
+  /** The profile id */
+  profileId: Scalars['ProfileId']['input'];
+  /** The signature */
+  signature: Scalars['Signature']['input'];
 };
 
 export type CurRequest = {
@@ -1865,17 +1934,17 @@ export type IllegalReasonInputParams = {
   subreason: PublicationReportingIllegalSubreason;
 };
 
-export type InternalPublicationsFilterRequest = {
-  cursor?: InputMaybe<Scalars['Cursor']['input']>;
-  /** must be DD/MM/YYYY */
-  fromDate: Scalars['String']['input'];
-  limit?: InputMaybe<Scalars['LimitScalar']['input']>;
+export type InternalPinRequest = {
+  /** The shared secret */
+  items: Array<Scalars['Url']['input']>;
   /** The shared secret */
   secret: Scalars['String']['input'];
-  /** The App Id */
-  source: Scalars['Sources']['input'];
-  /** must be DD/MM/YYYY */
-  toDate: Scalars['String']['input'];
+};
+
+export type InternalPinResult = {
+  __typename?: 'InternalPinResult';
+  ipfs: Scalars['String']['output'];
+  referenceItem: Scalars['Url']['output'];
 };
 
 export type LimitedFeeCollectModuleParams = {
@@ -2082,6 +2151,7 @@ export type Mirror = {
   __typename?: 'Mirror';
   /** ID of the source */
   appId?: Maybe<Scalars['Sources']['output']>;
+  bookmarked: Scalars['Boolean']['output'];
   canComment: CanCommentResponse;
   canDecrypt: CanDecryptResponse;
   canMirror: CanMirrorResponse;
@@ -2106,6 +2176,7 @@ export type Mirror = {
   metadata: MetadataOutput;
   /** The mirror publication */
   mirrorOf: MirrorablePublication;
+  notInterested: Scalars['Boolean']['output'];
   /** The on chain content uri could be `ipfs://` or `https` */
   onChainContentURI: Scalars['String']['output'];
   /** The profile ref */
@@ -2115,6 +2186,11 @@ export type Mirror = {
   referenceModule?: Maybe<ReferenceModule>;
   /** The publication stats */
   stats: PublicationStats;
+};
+
+/** The social mirror */
+export type MirrorBookmarkedArgs = {
+  by?: InputMaybe<Scalars['ProfileId']['input']>;
 };
 
 /** The social mirror */
@@ -2136,6 +2212,11 @@ export type MirrorCanMirrorArgs = {
 /** The social mirror */
 export type MirrorHasCollectedByMeArgs = {
   isFinalisedOnChain?: InputMaybe<Scalars['Boolean']['input']>;
+};
+
+/** The social mirror */
+export type MirrorNotInterestedArgs = {
+  by?: InputMaybe<Scalars['ProfileId']['input']>;
 };
 
 /** The social mirror */
@@ -2262,11 +2343,17 @@ export type Mutation = {
   ach?: Maybe<Scalars['Void']['output']>;
   /** Adds profile interests to the given profile */
   addProfileInterests?: Maybe<Scalars['Void']['output']>;
+  addPublicationProfileBookmark?: Maybe<Scalars['Void']['output']>;
+  addPublicationProfileNotInterested?: Maybe<Scalars['Void']['output']>;
   addReaction?: Maybe<Scalars['Void']['output']>;
+  /** Add a voter to a zk community */
+  addVoterToCommunity: ZkRelayerResult;
   authenticate: AuthenticationResult;
   broadcast: RelayResult;
   broadcastDataAvailability: BroadcastDataAvailabilityUnion;
+  castZkVote: ZkRelayerResult;
   claim: RelayResult;
+  claimZkBadge: ZkRelayerResult;
   createAttachMediaData: PublicMediaResults;
   createBurnProfileTypedData: CreateBurnProfileBroadcastItemResult;
   createCollectTypedData: CreateCollectBroadcastItemResult;
@@ -2297,6 +2384,9 @@ export type Mutation = {
   createSetProfileMetadataViaDispatcher: RelayResult;
   createToggleFollowTypedData: CreateToggleFollowBroadcastItemResult;
   createUnfollowTypedData: CreateUnfollowBroadcastItemResult;
+  /** Create a zk community */
+  createZkCommunity: ZkRelayerResult;
+  createZkPoll: ZkRelayerResult;
   /** Delete an NFT Gallery */
   deleteNftGallery?: Maybe<Scalars['Void']['output']>;
   dismissRecommendedProfiles?: Maybe<Scalars['Void']['output']>;
@@ -2307,10 +2397,14 @@ export type Mutation = {
   hel?: Maybe<Scalars['Void']['output']>;
   hidePublication?: Maybe<Scalars['Void']['output']>;
   idKitPhoneVerifyWebhook: IdKitPhoneVerifyWebhookResultStatusType;
+  nni?: Maybe<Scalars['Void']['output']>;
+  nnv?: Maybe<Scalars['Void']['output']>;
   proxyAction: Scalars['ProxyActionId']['output'];
   refresh: AuthenticationResult;
   /** Removes profile interests from the given profile */
   removeProfileInterests?: Maybe<Scalars['Void']['output']>;
+  removePublicationProfileBookmark?: Maybe<Scalars['Void']['output']>;
+  removePublicationProfileNotInterested?: Maybe<Scalars['Void']['output']>;
   removeReaction?: Maybe<Scalars['Void']['output']>;
   reportPublication?: Maybe<Scalars['Void']['output']>;
   /** Update the name of an NFT gallery */
@@ -2329,8 +2423,20 @@ export type MutationAddProfileInterestsArgs = {
   request: AddProfileInterestsRequest;
 };
 
+export type MutationAddPublicationProfileBookmarkArgs = {
+  request: PublicationProfileBookmarkRequest;
+};
+
+export type MutationAddPublicationProfileNotInterestedArgs = {
+  request: PublicationProfileNotInterestedRequest;
+};
+
 export type MutationAddReactionArgs = {
   request: ReactionRequest;
+};
+
+export type MutationAddVoterToCommunityArgs = {
+  request: AddVoterRequest;
 };
 
 export type MutationAuthenticateArgs = {
@@ -2345,8 +2451,16 @@ export type MutationBroadcastDataAvailabilityArgs = {
   request: BroadcastRequest;
 };
 
+export type MutationCastZkVoteArgs = {
+  request: CastZkVoteRequest;
+};
+
 export type MutationClaimArgs = {
   request: ClaimHandleRequest;
+};
+
+export type MutationClaimZkBadgeArgs = {
+  request: ClaimZkBadgeRequest;
 };
 
 export type MutationCreateAttachMediaDataArgs = {
@@ -2479,6 +2593,14 @@ export type MutationCreateUnfollowTypedDataArgs = {
   request: UnfollowRequest;
 };
 
+export type MutationCreateZkCommunityArgs = {
+  request: CreateZkCommunityRequest;
+};
+
+export type MutationCreateZkPollArgs = {
+  request: CreateZkPollRequest;
+};
+
 export type MutationDeleteNftGalleryArgs = {
   request: NftGalleryDeleteRequest;
 };
@@ -2515,6 +2637,14 @@ export type MutationIdKitPhoneVerifyWebhookArgs = {
   request: IdKitPhoneVerifyWebhookRequest;
 };
 
+export type MutationNniArgs = {
+  request: NniRequest;
+};
+
+export type MutationNnvArgs = {
+  request: NnvRequest;
+};
+
 export type MutationProxyActionArgs = {
   request: ProxyActionRequest;
 };
@@ -2525,6 +2655,14 @@ export type MutationRefreshArgs = {
 
 export type MutationRemoveProfileInterestsArgs = {
   request: RemoveProfileInterestsRequest;
+};
+
+export type MutationRemovePublicationProfileBookmarkArgs = {
+  request: PublicationProfileBookmarkRequest;
+};
+
+export type MutationRemovePublicationProfileNotInterestedArgs = {
+  request: PublicationProfileNotInterestedRequest;
 };
 
 export type MutationRemoveReactionArgs = {
@@ -2603,12 +2741,34 @@ export type NftData = {
   signature: Scalars['Signature']['input'];
 };
 
+/** NFT search query */
+export type NftSearchRequest = {
+  /** Chain IDs to search. Supports Ethereum and Polygon. If omitted, it will search in both chains */
+  chainIds?: InputMaybe<Array<Scalars['ChainId']['input']>>;
+  cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  /** Exclude follower NFTs from the search */
+  excludeFollowers?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['LimitScalar']['input']>;
+  /** Ethereum address of the owner. If unknown you can also search by profile ID */
+  ownerAddress?: InputMaybe<Scalars['EthereumAddress']['input']>;
+  /** Profile ID of the owner */
+  profileId?: InputMaybe<Scalars['ProfileId']['input']>;
+  /** Search query. Has to be part of a collection name */
+  query: Scalars['String']['input'];
+};
+
 export type NfTsRequest = {
   /** Chain Ids */
-  chainIds: Array<Scalars['ChainId']['input']>;
+  chainIds?: InputMaybe<Array<Scalars['ChainId']['input']>>;
   /** Filter by contract address */
   contractAddress?: InputMaybe<Scalars['ContractAddress']['input']>;
   cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  /** Exclude filtered collection addresses from the search. Cannot be used together ith `includeCollections` */
+  excludeCollections?: InputMaybe<Array<NftCollectionInput>>;
+  /** Exclude follower NFTs from the search. */
+  excludeFollowers?: InputMaybe<Scalars['Boolean']['input']>;
+  /** Include only filtered collection addresses in the search. Overrides `contractAddress` */
+  includeCollections?: InputMaybe<Array<NftCollectionInput>>;
   limit?: InputMaybe<Scalars['LimitScalar']['input']>;
   /** Filter by owner address */
   ownerAddress: Scalars['EthereumAddress']['input'];
@@ -2670,6 +2830,54 @@ export type NewReactionNotification = {
   profile: Profile;
   publication: Publication;
   reaction: ReactionTypes;
+};
+
+export type Nfi = {
+  c: Scalars['ContractAddress']['input'];
+  i: Scalars['ChainId']['input'];
+};
+
+/** Nft Collection type */
+export type NftCollection = {
+  __typename?: 'NftCollection';
+  /** Collection chain ID */
+  chainId: Scalars['ChainId']['output'];
+  /** The contract address  "0x00001..." */
+  contractAddress: Scalars['ContractAddress']['output'];
+  /** Collection ERC type */
+  contractType: Scalars['String']['output'];
+  /** Collection name */
+  name: Scalars['String']['output'];
+  /** Collection symbol */
+  symbol: Scalars['String']['output'];
+};
+
+/** NFT collection filtering input */
+export type NftCollectionInput = {
+  /** The chain id that the collection exists in */
+  chainId: Scalars['ChainId']['input'];
+  /** Filter by NFT collection contract address */
+  contractAddress: Scalars['ContractAddress']['input'];
+};
+
+/** NFT collections result */
+export type NftCollectionResult = {
+  __typename?: 'NftCollectionResult';
+  items: Array<NftCollection>;
+  pageInfo: PaginatedResultInfo;
+};
+
+/** NFT collections request */
+export type NftCollectionsRequest = {
+  /** The chain ids to look for NFTs on. Ethereum and Polygon are supported. If omitted, it will look on both chains by default. */
+  chainIds?: InputMaybe<Array<Scalars['ChainId']['input']>>;
+  cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  /** Exclude Lens Follower NFTs */
+  excludeFollowers?: InputMaybe<Scalars['Boolean']['input']>;
+  limit?: InputMaybe<Scalars['Float']['input']>;
+  /** Filter by owner address */
+  ownerAddress?: InputMaybe<Scalars['EthereumAddress']['input']>;
+  profileId?: InputMaybe<Scalars['ProfileId']['input']>;
 };
 
 /** The NFT gallery input */
@@ -2828,6 +3036,16 @@ export type NftUpdateItemOrder = {
   newOrder: Scalars['Int']['input'];
   /** The token ID of the NFT */
   tokenId: Scalars['String']['input'];
+};
+
+export type NniRequest = {
+  n: Array<Nfi>;
+  secret: Scalars['String']['input'];
+};
+
+export type NnvRequest = {
+  n: Array<Nfi>;
+  secret: Scalars['String']['input'];
 };
 
 export type Notification =
@@ -3011,6 +3229,7 @@ export type Post = {
   __typename?: 'Post';
   /** ID of the source */
   appId?: Maybe<Scalars['Sources']['output']>;
+  bookmarked: Scalars['Boolean']['output'];
   canComment: CanCommentResponse;
   canDecrypt: CanDecryptResponse;
   canMirror: CanMirrorResponse;
@@ -3039,6 +3258,7 @@ export type Post = {
   /** The metadata for the post */
   metadata: MetadataOutput;
   mirrors: Array<Scalars['InternalPublicationId']['output']>;
+  notInterested: Scalars['Boolean']['output'];
   /** The on chain content uri could be `ipfs://` or `https` */
   onChainContentURI: Scalars['String']['output'];
   /** The profile ref */
@@ -3048,6 +3268,11 @@ export type Post = {
   referenceModule?: Maybe<ReferenceModule>;
   /** The publication stats */
   stats: PublicationStats;
+};
+
+/** The social post */
+export type PostBookmarkedArgs = {
+  by?: InputMaybe<Scalars['ProfileId']['input']>;
 };
 
 /** The social post */
@@ -3073,6 +3298,11 @@ export type PostHasCollectedByMeArgs = {
 
 /** The social post */
 export type PostMirrorsArgs = {
+  by?: InputMaybe<Scalars['ProfileId']['input']>;
+};
+
+/** The social post */
+export type PostNotInterestedArgs = {
   by?: InputMaybe<Scalars['ProfileId']['input']>;
 };
 
@@ -3531,6 +3761,20 @@ export type PublicationMetadataV2Input = {
   version: Scalars['String']['input'];
 };
 
+export type PublicationProfileBookmarkRequest = {
+  /** Profile id to perform the action */
+  profileId: Scalars['ProfileId']['input'];
+  /** The internal publication id */
+  publicationId: Scalars['InternalPublicationId']['input'];
+};
+
+export type PublicationProfileNotInterestedRequest = {
+  /** Profile id to perform the action */
+  profileId: Scalars['ProfileId']['input'];
+  /** The internal publication id */
+  publicationId: Scalars['InternalPublicationId']['input'];
+};
+
 export type PublicationQueryRequest = {
   /** The publication id */
   publicationId?: InputMaybe<Scalars['InternalPublicationId']['input']>;
@@ -3652,6 +3896,16 @@ export type PublicationValidateMetadataResult = {
   valid: Scalars['Boolean']['output'];
 };
 
+export type PublicationsProfileBookmarkedQueryRequest = {
+  cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  limit?: InputMaybe<Scalars['LimitScalar']['input']>;
+  metadata?: InputMaybe<PublicationMetadataFilters>;
+  /** Profile id */
+  profileId: Scalars['ProfileId']['input'];
+  /** The App Id */
+  sources?: InputMaybe<Array<Scalars['Sources']['input']>>;
+};
+
 export type PublicationsQueryRequest = {
   /** The ethereum address */
   collectedBy?: InputMaybe<Scalars['EthereumAddress']['input']>;
@@ -3707,13 +3961,18 @@ export type Query = {
   generateModuleCurrencyApprovalData: GenerateModuleCurrencyApproval;
   globalProtocolStats: GlobalProtocolStats;
   hasTxHashBeenIndexed: TransactionResult;
-  internalPublicationFilter: PaginatedPublicationResult;
+  internalPin: Array<InternalPinResult>;
   isIDKitPhoneVerified: Scalars['Boolean']['output'];
   iss: PrfResponse;
   mutualFollowersProfiles: PaginatedProfileResult;
+  /** Returns the latest poll for a given user */
+  myActivePoll: ZkPoll;
+  /** Get the NFT collections that the given wallet or profileId owns at least one NFT of. Only supports Ethereum and Polygon NFTs. Note excludeFollowers is set to true by default, so the result will not include Lens Follower NFTsunless explicitly requested. */
+  nftCollections: NftCollectionResult;
   /** Get all NFT galleries for a profile */
   nftGalleries: Array<NftGallery>;
   nftOwnershipChallenge: NftOwnershipChallengeResult;
+  /** Get the NFTs that the given wallet or profileId owns. Only supports Ethereum and Polygon NFTs. Note excludeFollowers is set to true by default, so the result will not include Lens Follower NFTs unless explicitly requested. */
   nfts: NfTsResult;
   notifications: PaginatedNotificationResult;
   pendingApprovalFollows: PendingApproveFollowsResult;
@@ -3732,10 +3991,13 @@ export type Query = {
   publicationMetadataStatus: PublicationMetadataStatus;
   publicationRevenue?: Maybe<PublicationRevenue>;
   publications: PaginatedPublicationResult;
+  publicationsProfileBookmarks: PaginatedPublicationResult;
   recommendedProfiles: Array<Profile>;
   rel?: Maybe<Scalars['Void']['output']>;
   relayQueues: Array<RelayQueueResult>;
   search: SearchResult;
+  /** Search for NFTs in a wallet by collection name. Supports Polygon and Ethereum and searches in both by default. */
+  searchNfts: NfTsResult;
   txIdToTxHash: Scalars['TxHash']['output'];
   unknownEnabledModules: EnabledModules;
   userSigNonces: UserSigNonces;
@@ -3743,6 +4005,24 @@ export type Query = {
   verify: Scalars['Boolean']['output'];
   whoCollectedPublication: PaginatedWhoCollectedResult;
   whoReactedPublication: PaginatedWhoReactedResult;
+  /** Get all zk communities */
+  zkCommunities: Array<ZkCommunity>;
+  /** Get a zk community by its id */
+  zkCommunity?: Maybe<ZkCommunity>;
+  /** Get a zk community members by communityId */
+  zkCommunityMembers?: Maybe<ZkCommunity>;
+  /** Returns the latest poll for a given community */
+  zkPoll: ZkPoll;
+  /** Returns the latest poll for a given profile and community */
+  zkPollByProfileAndCommunity?: Maybe<ZkPoll>;
+  /** Returns the status of a given poll */
+  zkPollStatus?: Maybe<ZkPollStatus>;
+  /** Returns the latest polls */
+  zkPolls: Array<ZkPoll>;
+  /** Returns the latest polls for a given community */
+  zkPollsByCommunity: Array<ZkPoll>;
+  /** Returns the latest polls for a given profile */
+  zkPollsByProfile: Array<ZkPoll>;
 };
 
 export type QueryAllPublicationsTagsArgs = {
@@ -3829,8 +4109,8 @@ export type QueryHasTxHashBeenIndexedArgs = {
   request: HasTxHashBeenIndexedRequest;
 };
 
-export type QueryInternalPublicationFilterArgs = {
-  request: InternalPublicationsFilterRequest;
+export type QueryInternalPinArgs = {
+  request: InternalPinRequest;
 };
 
 export type QueryIssArgs = {
@@ -3839,6 +4119,14 @@ export type QueryIssArgs = {
 
 export type QueryMutualFollowersProfilesArgs = {
   request: MutualFollowersProfilesQueryRequest;
+};
+
+export type QueryMyActivePollArgs = {
+  request: ZkPollByProfileAndCommunityRequest;
+};
+
+export type QueryNftCollectionsArgs = {
+  request: NftCollectionsRequest;
 };
 
 export type QueryNftGalleriesArgs = {
@@ -3909,6 +4197,10 @@ export type QueryPublicationsArgs = {
   request: PublicationsQueryRequest;
 };
 
+export type QueryPublicationsProfileBookmarksArgs = {
+  request: PublicationsProfileBookmarkedQueryRequest;
+};
+
 export type QueryRecommendedProfilesArgs = {
   options?: InputMaybe<RecommendedProfileOptions>;
 };
@@ -3919,6 +4211,10 @@ export type QueryRelArgs = {
 
 export type QuerySearchArgs = {
   request: SearchQueryRequest;
+};
+
+export type QuerySearchNftsArgs = {
+  request: NftSearchRequest;
 };
 
 export type QueryTxIdToTxHashArgs = {
@@ -3939,6 +4235,42 @@ export type QueryWhoCollectedPublicationArgs = {
 
 export type QueryWhoReactedPublicationArgs = {
   request: WhoReactedPublicationRequest;
+};
+
+export type QueryZkCommunitiesArgs = {
+  request: ZkCommunitiesRequest;
+};
+
+export type QueryZkCommunityArgs = {
+  request: ZkCommunityRequest;
+};
+
+export type QueryZkCommunityMembersArgs = {
+  request: ZkCommunityMembersRequest;
+};
+
+export type QueryZkPollArgs = {
+  request: ZkPollRequest;
+};
+
+export type QueryZkPollByProfileAndCommunityArgs = {
+  request: ZkPollByProfileAndCommunityRequest;
+};
+
+export type QueryZkPollStatusArgs = {
+  request: ZkPollStateRequest;
+};
+
+export type QueryZkPollsArgs = {
+  request: ZkPollsRequest;
+};
+
+export type QueryZkPollsByCommunityArgs = {
+  request: ZkCommunityRequest;
+};
+
+export type QueryZkPollsByProfileArgs = {
+  request: ZkPollByProfileRequest;
 };
 
 export type ReactionEvent = {
@@ -4086,7 +4418,8 @@ export enum RelayRoleKey {
   ProxyActionFollow_10 = 'PROXY_ACTION_FOLLOW_10',
   WithSig_1 = 'WITH_SIG_1',
   WithSig_2 = 'WITH_SIG_2',
-  WithSig_3 = 'WITH_SIG_3'
+  WithSig_3 = 'WITH_SIG_3',
+  ZkRelayer_1 = 'ZK_RELAYER_1'
 }
 
 /** The relayer result */
@@ -4514,6 +4847,126 @@ export type WorldcoinPhoneVerifyWebhookRequest = {
   signal: Scalars['EthereumAddress']['input'];
   signalType: WorldcoinPhoneVerifyType;
 };
+
+export type ZkCommunitiesRequest = {
+  cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  limit?: InputMaybe<Scalars['LimitScalar']['input']>;
+};
+
+/** The Zk Voting Community */
+export type ZkCommunity = {
+  __typename?: 'ZkCommunity';
+  /** The Community id */
+  communityId: Scalars['ZkCommunityId']['output'];
+  /** Metadata url */
+  contentURI: Scalars['Url']['output'];
+  /** community coordinator address */
+  coordinator: Scalars['EthereumAddress']['output'];
+  /** description of the community */
+  description?: Maybe<Scalars['String']['output']>;
+  /** Members of the community */
+  members?: Maybe<Array<Scalars['ZkIdentityCommitment']['output']>>;
+  /** Name of the community */
+  name?: Maybe<Scalars['String']['output']>;
+};
+
+export type ZkCommunityMembersRequest = {
+  /** The ZkCommunity id */
+  communityId: Scalars['ZkCommunityId']['input'];
+  cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  limit?: InputMaybe<Scalars['LimitScalar']['input']>;
+  /** The ZkCommunity id */
+  members?: InputMaybe<Scalars['ZkIdentityCommitment']['input']>;
+};
+
+export type ZkCommunityRequest = {
+  /** The ZkCommunity id */
+  communityId: Scalars['ZkCommunityId']['input'];
+  cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  limit?: InputMaybe<Scalars['LimitScalar']['input']>;
+};
+
+/** The Zk Voting Community */
+export type ZkPoll = {
+  __typename?: 'ZkPoll';
+  /** The Community id */
+  communityId: Scalars['ZkCommunityId']['output'];
+  /** Poll coordinator address */
+  coordinator: Scalars['EthereumAddress']['output'];
+  /** Poll end time */
+  endedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Poll is active */
+  isActive?: Maybe<Scalars['Boolean']['output']>;
+  /** The Poll id */
+  pollId: Scalars['ZkPollId']['output'];
+  /** Poll title */
+  profileData: Profile;
+  /** The profile id */
+  profileId: Scalars['ProfileId']['output'];
+  /** Poll start time */
+  startedAt?: Maybe<Scalars['DateTime']['output']>;
+  /** Poll absolute threshold */
+  thresholdAbs?: Maybe<Scalars['Float']['output']>;
+  /** Poll threshold Precent */
+  thresholdPct?: Maybe<Scalars['Float']['output']>;
+  /** Yes votes */
+  yesVotes?: Maybe<Scalars['Float']['output']>;
+};
+
+export type ZkPollByProfileAndCommunityRequest = {
+  /** The ZkCommunity id */
+  communityId: Scalars['ZkCommunityId']['input'];
+  /** The profile id */
+  profileId: Scalars['ProfileId']['input'];
+};
+
+export type ZkPollByProfileRequest = {
+  cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  limit?: InputMaybe<Scalars['LimitScalar']['input']>;
+  /** The profile id */
+  profileId: Scalars['ProfileId']['input'];
+};
+
+export type ZkPollRequest = {
+  /** The ZkPoll id */
+  pollId: Scalars['ZkPollId']['input'];
+};
+
+export type ZkPollStateRequest = {
+  /** The ZkPoll id */
+  pollId: Scalars['ZkPollId']['input'];
+};
+
+/** The Zk Voting Community */
+export type ZkPollStatus = {
+  __typename?: 'ZkPollStatus';
+  /** The Community id */
+  communityId: Scalars['ZkCommunityId']['output'];
+  /** Poll is active */
+  isActive?: Maybe<Scalars['Boolean']['output']>;
+  /** The Poll id */
+  pollId: Scalars['ZkPollId']['output'];
+  /** status of the poll, null if not created yet. */
+  status?: Maybe<Scalars['Float']['output']>;
+  /** Poll absolute threshold */
+  thresholdAbs?: Maybe<Scalars['Int']['output']>;
+  /** Poll threshold Percent */
+  thresholdPct?: Maybe<Scalars['Int']['output']>;
+  /** Yes votes */
+  yesVotes?: Maybe<Scalars['Int']['output']>;
+};
+
+export type ZkPollsRequest = {
+  cursor?: InputMaybe<Scalars['Cursor']['input']>;
+  limit?: InputMaybe<Scalars['LimitScalar']['input']>;
+};
+
+export type ZkRelayError = {
+  __typename?: 'ZkRelayError';
+  reason: Scalars['String']['output'];
+};
+
+export type ZkRelayerResult = RelayerResult | ZkRelayError;
 
 type CollectModuleFields_AaveFeeCollectModuleSettings_Fragment = {
   __typename?: 'AaveFeeCollectModuleSettings';
@@ -8852,6 +9305,15 @@ export type AddProfileInterestMutation = {
   addProfileInterests?: any | null;
 };
 
+export type AddPublicationProfileBookmarkMutationVariables = Exact<{
+  request: PublicationProfileBookmarkRequest;
+}>;
+
+export type AddPublicationProfileBookmarkMutation = {
+  __typename?: 'Mutation';
+  addPublicationProfileBookmark?: any | null;
+};
+
 export type AddReactionMutationVariables = Exact<{
   request: ReactionRequest;
 }>;
@@ -9630,6 +10092,15 @@ export type RemoveProfileInterestMutationVariables = Exact<{
 export type RemoveProfileInterestMutation = {
   __typename?: 'Mutation';
   removeProfileInterests?: any | null;
+};
+
+export type RemovePublicationProfileBookmarkMutationVariables = Exact<{
+  request: PublicationProfileBookmarkRequest;
+}>;
+
+export type RemovePublicationProfileBookmarkMutation = {
+  __typename?: 'Mutation';
+  removePublicationProfileBookmark?: any | null;
 };
 
 export type RemoveReactionMutationVariables = Exact<{
@@ -34766,6 +35237,4055 @@ export type PublicationRevenueQuery = {
   } | null;
 };
 
+export type PublicationsProfileBookmarksQueryVariables = Exact<{
+  request: PublicationsProfileBookmarkedQueryRequest;
+  reactionRequest?: InputMaybe<ReactionFieldResolverRequest>;
+  profileId?: InputMaybe<Scalars['ProfileId']['input']>;
+}>;
+
+export type PublicationsProfileBookmarksQuery = {
+  __typename?: 'Query';
+  publicationsProfileBookmarks: {
+    __typename?: 'PaginatedPublicationResult';
+    items: Array<
+      | {
+          __typename?: 'Comment';
+          id: any;
+          reaction?: ReactionTypes | null;
+          mirrors: Array<any>;
+          hasCollectedByMe: boolean;
+          onChainContentURI: string;
+          isGated: boolean;
+          isDataAvailability: boolean;
+          dataAvailabilityProofs?: string | null;
+          hidden: boolean;
+          createdAt: any;
+          appId?: any | null;
+          profile: {
+            __typename?: 'Profile';
+            id: any;
+            name?: string | null;
+            handle: any;
+            bio?: string | null;
+            ownedBy: any;
+            isFollowedByMe: boolean;
+            stats: {
+              __typename?: 'ProfileStats';
+              totalFollowers: number;
+              totalFollowing: number;
+              totalPosts: number;
+              totalComments: number;
+              totalMirrors: number;
+            };
+            attributes?: Array<{
+              __typename?: 'Attribute';
+              traitType?: string | null;
+              key: string;
+              value: string;
+            }> | null;
+            picture?:
+              | {
+                  __typename?: 'MediaSet';
+                  original: { __typename?: 'Media'; url: any };
+                }
+              | {
+                  __typename?: 'NftImage';
+                  uri: any;
+                  tokenId: string;
+                  contractAddress: any;
+                  chainId: number;
+                }
+              | null;
+            coverPicture?:
+              | {
+                  __typename?: 'MediaSet';
+                  original: { __typename?: 'Media'; url: any };
+                }
+              | { __typename?: 'NftImage' }
+              | null;
+            followModule?:
+              | { __typename: 'FeeFollowModuleSettings' }
+              | { __typename: 'ProfileFollowModuleSettings' }
+              | { __typename: 'RevertFollowModuleSettings' }
+              | { __typename: 'UnknownFollowModuleSettings' }
+              | null;
+          };
+          canComment: { __typename?: 'CanCommentResponse'; result: boolean };
+          canMirror: { __typename?: 'CanMirrorResponse'; result: boolean };
+          canDecrypt: {
+            __typename?: 'CanDecryptResponse';
+            result: boolean;
+            reasons?: Array<DecryptFailReason> | null;
+          };
+          collectModule:
+            | { __typename?: 'AaveFeeCollectModuleSettings' }
+            | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+            | {
+                __typename?: 'FeeCollectModuleSettings';
+                type: CollectModules;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'FreeCollectModuleSettings';
+                type: CollectModules;
+                contractAddress: any;
+                followerOnly: boolean;
+              }
+            | {
+                __typename?: 'LimitedFeeCollectModuleSettings';
+                type: CollectModules;
+                collectLimit: string;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                type: CollectModules;
+                collectLimit: string;
+                endTimestamp: any;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'MultirecipientFeeCollectModuleSettings';
+                type: CollectModules;
+                referralFee: number;
+                followerOnly: boolean;
+                contractAddress: any;
+                optionalCollectLimit?: string | null;
+                optionalEndTimestamp?: any | null;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+                recipients: Array<{
+                  __typename?: 'RecipientDataOutput';
+                  recipient: any;
+                  split: number;
+                }>;
+              }
+            | { __typename?: 'RevertCollectModuleSettings' }
+            | {
+                __typename?: 'SimpleCollectModuleSettings';
+                type: CollectModules;
+                contractAddress: any;
+                followerOnly: boolean;
+                optionalCollectLimit?: string | null;
+                optionalEndTimestamp?: any | null;
+                fee?: {
+                  __typename?: 'ModuleFee';
+                  recipient: any;
+                  referralFee: number;
+                  amount: {
+                    __typename?: 'ModuleFeeAmount';
+                    value: string;
+                    asset: {
+                      __typename?: 'Erc20';
+                      symbol: string;
+                      decimals: number;
+                      address: any;
+                    };
+                  };
+                } | null;
+              }
+            | {
+                __typename?: 'TimedFeeCollectModuleSettings';
+                type: CollectModules;
+                endTimestamp: any;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | { __typename?: 'UnknownCollectModuleSettings' };
+          stats: {
+            __typename?: 'PublicationStats';
+            totalUpvotes: number;
+            totalAmountOfMirrors: number;
+            totalAmountOfCollects: number;
+            commentsTotal: number;
+          };
+          metadata: {
+            __typename?: 'MetadataOutput';
+            name?: string | null;
+            content?: any | null;
+            image?: any | null;
+            tags: Array<string>;
+            attributes: Array<{
+              __typename?: 'MetadataAttributeOutput';
+              traitType?: string | null;
+              value?: string | null;
+            }>;
+            cover?: {
+              __typename?: 'MediaSet';
+              original: { __typename?: 'Media'; url: any };
+            } | null;
+            media: Array<{
+              __typename?: 'MediaSet';
+              original: {
+                __typename?: 'Media';
+                url: any;
+                mimeType?: any | null;
+              };
+            }>;
+            encryptionParams?: {
+              __typename?: 'EncryptionParamsOutput';
+              accessCondition: {
+                __typename?: 'AccessConditionOutput';
+                or?: {
+                  __typename?: 'OrConditionOutput';
+                  criteria: Array<{
+                    __typename?: 'AccessConditionOutput';
+                    and?: {
+                      __typename?: 'AndConditionOutput';
+                      criteria: Array<{
+                        __typename?: 'AccessConditionOutput';
+                        nft?: {
+                          __typename?: 'NftOwnershipOutput';
+                          contractAddress: any;
+                          chainID: any;
+                          contractType: ContractType;
+                          tokenIds?: Array<any> | null;
+                        } | null;
+                        eoa?: {
+                          __typename?: 'EoaOwnershipOutput';
+                          address: any;
+                        } | null;
+                        token?: {
+                          __typename?: 'Erc20OwnershipOutput';
+                          contractAddress: any;
+                          amount: string;
+                          chainID: any;
+                          condition: ScalarOperator;
+                          decimals: number;
+                        } | null;
+                        follow?: {
+                          __typename?: 'FollowConditionOutput';
+                          profileId: any;
+                        } | null;
+                        collect?: {
+                          __typename?: 'CollectConditionOutput';
+                          publicationId?: any | null;
+                          thisPublication?: boolean | null;
+                        } | null;
+                      }>;
+                    } | null;
+                    or?: {
+                      __typename?: 'OrConditionOutput';
+                      criteria: Array<{
+                        __typename?: 'AccessConditionOutput';
+                        nft?: {
+                          __typename?: 'NftOwnershipOutput';
+                          contractAddress: any;
+                          chainID: any;
+                          contractType: ContractType;
+                          tokenIds?: Array<any> | null;
+                        } | null;
+                        eoa?: {
+                          __typename?: 'EoaOwnershipOutput';
+                          address: any;
+                        } | null;
+                        token?: {
+                          __typename?: 'Erc20OwnershipOutput';
+                          contractAddress: any;
+                          amount: string;
+                          chainID: any;
+                          condition: ScalarOperator;
+                          decimals: number;
+                        } | null;
+                        follow?: {
+                          __typename?: 'FollowConditionOutput';
+                          profileId: any;
+                        } | null;
+                        collect?: {
+                          __typename?: 'CollectConditionOutput';
+                          publicationId?: any | null;
+                          thisPublication?: boolean | null;
+                        } | null;
+                      }>;
+                    } | null;
+                    nft?: {
+                      __typename?: 'NftOwnershipOutput';
+                      contractAddress: any;
+                      chainID: any;
+                      contractType: ContractType;
+                      tokenIds?: Array<any> | null;
+                    } | null;
+                    eoa?: {
+                      __typename?: 'EoaOwnershipOutput';
+                      address: any;
+                    } | null;
+                    token?: {
+                      __typename?: 'Erc20OwnershipOutput';
+                      contractAddress: any;
+                      amount: string;
+                      chainID: any;
+                      condition: ScalarOperator;
+                      decimals: number;
+                    } | null;
+                    follow?: {
+                      __typename?: 'FollowConditionOutput';
+                      profileId: any;
+                    } | null;
+                    collect?: {
+                      __typename?: 'CollectConditionOutput';
+                      publicationId?: any | null;
+                      thisPublication?: boolean | null;
+                    } | null;
+                  }>;
+                } | null;
+              };
+            } | null;
+          };
+          commentOn?:
+            | {
+                __typename?: 'Comment';
+                id: any;
+                reaction?: ReactionTypes | null;
+                mirrors: Array<any>;
+                hasCollectedByMe: boolean;
+                onChainContentURI: string;
+                isGated: boolean;
+                isDataAvailability: boolean;
+                dataAvailabilityProofs?: string | null;
+                hidden: boolean;
+                createdAt: any;
+                profile: {
+                  __typename?: 'Profile';
+                  id: any;
+                  name?: string | null;
+                  handle: any;
+                  bio?: string | null;
+                  ownedBy: any;
+                  isFollowedByMe: boolean;
+                  stats: {
+                    __typename?: 'ProfileStats';
+                    totalFollowers: number;
+                    totalFollowing: number;
+                    totalPosts: number;
+                    totalComments: number;
+                    totalMirrors: number;
+                  };
+                  attributes?: Array<{
+                    __typename?: 'Attribute';
+                    traitType?: string | null;
+                    key: string;
+                    value: string;
+                  }> | null;
+                  picture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | {
+                        __typename?: 'NftImage';
+                        uri: any;
+                        tokenId: string;
+                        contractAddress: any;
+                        chainId: number;
+                      }
+                    | null;
+                  coverPicture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | { __typename?: 'NftImage' }
+                    | null;
+                  followModule?:
+                    | { __typename: 'FeeFollowModuleSettings' }
+                    | { __typename: 'ProfileFollowModuleSettings' }
+                    | { __typename: 'RevertFollowModuleSettings' }
+                    | { __typename: 'UnknownFollowModuleSettings' }
+                    | null;
+                };
+                canComment: {
+                  __typename?: 'CanCommentResponse';
+                  result: boolean;
+                };
+                canMirror: {
+                  __typename?: 'CanMirrorResponse';
+                  result: boolean;
+                };
+                canDecrypt: {
+                  __typename?: 'CanDecryptResponse';
+                  result: boolean;
+                  reasons?: Array<DecryptFailReason> | null;
+                };
+                collectModule:
+                  | { __typename?: 'AaveFeeCollectModuleSettings' }
+                  | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+                  | {
+                      __typename?: 'FeeCollectModuleSettings';
+                      type: CollectModules;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'FreeCollectModuleSettings';
+                      type: CollectModules;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                    }
+                  | {
+                      __typename?: 'LimitedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      collectLimit: string;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      collectLimit: string;
+                      endTimestamp: any;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'MultirecipientFeeCollectModuleSettings';
+                      type: CollectModules;
+                      referralFee: number;
+                      followerOnly: boolean;
+                      contractAddress: any;
+                      optionalCollectLimit?: string | null;
+                      optionalEndTimestamp?: any | null;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                      recipients: Array<{
+                        __typename?: 'RecipientDataOutput';
+                        recipient: any;
+                        split: number;
+                      }>;
+                    }
+                  | { __typename?: 'RevertCollectModuleSettings' }
+                  | {
+                      __typename?: 'SimpleCollectModuleSettings';
+                      type: CollectModules;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      optionalCollectLimit?: string | null;
+                      optionalEndTimestamp?: any | null;
+                      fee?: {
+                        __typename?: 'ModuleFee';
+                        recipient: any;
+                        referralFee: number;
+                        amount: {
+                          __typename?: 'ModuleFeeAmount';
+                          value: string;
+                          asset: {
+                            __typename?: 'Erc20';
+                            symbol: string;
+                            decimals: number;
+                            address: any;
+                          };
+                        };
+                      } | null;
+                    }
+                  | {
+                      __typename?: 'TimedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      endTimestamp: any;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | { __typename?: 'UnknownCollectModuleSettings' };
+                metadata: {
+                  __typename?: 'MetadataOutput';
+                  name?: string | null;
+                  content?: any | null;
+                  image?: any | null;
+                  tags: Array<string>;
+                  attributes: Array<{
+                    __typename?: 'MetadataAttributeOutput';
+                    traitType?: string | null;
+                    value?: string | null;
+                  }>;
+                  cover?: {
+                    __typename?: 'MediaSet';
+                    original: { __typename?: 'Media'; url: any };
+                  } | null;
+                  media: Array<{
+                    __typename?: 'MediaSet';
+                    original: {
+                      __typename?: 'Media';
+                      url: any;
+                      mimeType?: any | null;
+                    };
+                  }>;
+                  encryptionParams?: {
+                    __typename?: 'EncryptionParamsOutput';
+                    accessCondition: {
+                      __typename?: 'AccessConditionOutput';
+                      or?: {
+                        __typename?: 'OrConditionOutput';
+                        criteria: Array<{
+                          __typename?: 'AccessConditionOutput';
+                          and?: {
+                            __typename?: 'AndConditionOutput';
+                            criteria: Array<{
+                              __typename?: 'AccessConditionOutput';
+                              nft?: {
+                                __typename?: 'NftOwnershipOutput';
+                                contractAddress: any;
+                                chainID: any;
+                                contractType: ContractType;
+                                tokenIds?: Array<any> | null;
+                              } | null;
+                              eoa?: {
+                                __typename?: 'EoaOwnershipOutput';
+                                address: any;
+                              } | null;
+                              token?: {
+                                __typename?: 'Erc20OwnershipOutput';
+                                contractAddress: any;
+                                amount: string;
+                                chainID: any;
+                                condition: ScalarOperator;
+                                decimals: number;
+                              } | null;
+                              follow?: {
+                                __typename?: 'FollowConditionOutput';
+                                profileId: any;
+                              } | null;
+                              collect?: {
+                                __typename?: 'CollectConditionOutput';
+                                publicationId?: any | null;
+                                thisPublication?: boolean | null;
+                              } | null;
+                            }>;
+                          } | null;
+                          or?: {
+                            __typename?: 'OrConditionOutput';
+                            criteria: Array<{
+                              __typename?: 'AccessConditionOutput';
+                              nft?: {
+                                __typename?: 'NftOwnershipOutput';
+                                contractAddress: any;
+                                chainID: any;
+                                contractType: ContractType;
+                                tokenIds?: Array<any> | null;
+                              } | null;
+                              eoa?: {
+                                __typename?: 'EoaOwnershipOutput';
+                                address: any;
+                              } | null;
+                              token?: {
+                                __typename?: 'Erc20OwnershipOutput';
+                                contractAddress: any;
+                                amount: string;
+                                chainID: any;
+                                condition: ScalarOperator;
+                                decimals: number;
+                              } | null;
+                              follow?: {
+                                __typename?: 'FollowConditionOutput';
+                                profileId: any;
+                              } | null;
+                              collect?: {
+                                __typename?: 'CollectConditionOutput';
+                                publicationId?: any | null;
+                                thisPublication?: boolean | null;
+                              } | null;
+                            }>;
+                          } | null;
+                          nft?: {
+                            __typename?: 'NftOwnershipOutput';
+                            contractAddress: any;
+                            chainID: any;
+                            contractType: ContractType;
+                            tokenIds?: Array<any> | null;
+                          } | null;
+                          eoa?: {
+                            __typename?: 'EoaOwnershipOutput';
+                            address: any;
+                          } | null;
+                          token?: {
+                            __typename?: 'Erc20OwnershipOutput';
+                            contractAddress: any;
+                            amount: string;
+                            chainID: any;
+                            condition: ScalarOperator;
+                            decimals: number;
+                          } | null;
+                          follow?: {
+                            __typename?: 'FollowConditionOutput';
+                            profileId: any;
+                          } | null;
+                          collect?: {
+                            __typename?: 'CollectConditionOutput';
+                            publicationId?: any | null;
+                            thisPublication?: boolean | null;
+                          } | null;
+                        }>;
+                      } | null;
+                    };
+                  } | null;
+                };
+                stats: {
+                  __typename?: 'PublicationStats';
+                  totalUpvotes: number;
+                  totalAmountOfMirrors: number;
+                  totalAmountOfCollects: number;
+                  commentsTotal: number;
+                };
+                mainPost:
+                  | {
+                      __typename?: 'Mirror';
+                      id: any;
+                      reaction?: ReactionTypes | null;
+                      hasCollectedByMe: boolean;
+                      isGated: boolean;
+                      isDataAvailability: boolean;
+                      dataAvailabilityProofs?: string | null;
+                      hidden: boolean;
+                      createdAt: any;
+                      appId?: any | null;
+                      profile: {
+                        __typename?: 'Profile';
+                        id: any;
+                        name?: string | null;
+                        handle: any;
+                        bio?: string | null;
+                        ownedBy: any;
+                        isFollowedByMe: boolean;
+                        stats: {
+                          __typename?: 'ProfileStats';
+                          totalFollowers: number;
+                          totalFollowing: number;
+                          totalPosts: number;
+                          totalComments: number;
+                          totalMirrors: number;
+                        };
+                        attributes?: Array<{
+                          __typename?: 'Attribute';
+                          traitType?: string | null;
+                          key: string;
+                          value: string;
+                        }> | null;
+                        picture?:
+                          | {
+                              __typename?: 'MediaSet';
+                              original: { __typename?: 'Media'; url: any };
+                            }
+                          | {
+                              __typename?: 'NftImage';
+                              uri: any;
+                              tokenId: string;
+                              contractAddress: any;
+                              chainId: number;
+                            }
+                          | null;
+                        coverPicture?:
+                          | {
+                              __typename?: 'MediaSet';
+                              original: { __typename?: 'Media'; url: any };
+                            }
+                          | { __typename?: 'NftImage' }
+                          | null;
+                        followModule?:
+                          | { __typename: 'FeeFollowModuleSettings' }
+                          | { __typename: 'ProfileFollowModuleSettings' }
+                          | { __typename: 'RevertFollowModuleSettings' }
+                          | { __typename: 'UnknownFollowModuleSettings' }
+                          | null;
+                      };
+                      canComment: {
+                        __typename?: 'CanCommentResponse';
+                        result: boolean;
+                      };
+                      canMirror: {
+                        __typename?: 'CanMirrorResponse';
+                        result: boolean;
+                      };
+                      canDecrypt: {
+                        __typename?: 'CanDecryptResponse';
+                        result: boolean;
+                        reasons?: Array<DecryptFailReason> | null;
+                      };
+                      collectModule:
+                        | { __typename?: 'AaveFeeCollectModuleSettings' }
+                        | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+                        | {
+                            __typename?: 'FeeCollectModuleSettings';
+                            type: CollectModules;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'FreeCollectModuleSettings';
+                            type: CollectModules;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                          }
+                        | {
+                            __typename?: 'LimitedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            collectLimit: string;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            collectLimit: string;
+                            endTimestamp: any;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'MultirecipientFeeCollectModuleSettings';
+                            type: CollectModules;
+                            referralFee: number;
+                            followerOnly: boolean;
+                            contractAddress: any;
+                            optionalCollectLimit?: string | null;
+                            optionalEndTimestamp?: any | null;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                            recipients: Array<{
+                              __typename?: 'RecipientDataOutput';
+                              recipient: any;
+                              split: number;
+                            }>;
+                          }
+                        | { __typename?: 'RevertCollectModuleSettings' }
+                        | {
+                            __typename?: 'SimpleCollectModuleSettings';
+                            type: CollectModules;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            optionalCollectLimit?: string | null;
+                            optionalEndTimestamp?: any | null;
+                            fee?: {
+                              __typename?: 'ModuleFee';
+                              recipient: any;
+                              referralFee: number;
+                              amount: {
+                                __typename?: 'ModuleFeeAmount';
+                                value: string;
+                                asset: {
+                                  __typename?: 'Erc20';
+                                  symbol: string;
+                                  decimals: number;
+                                  address: any;
+                                };
+                              };
+                            } | null;
+                          }
+                        | {
+                            __typename?: 'TimedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            endTimestamp: any;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | { __typename?: 'UnknownCollectModuleSettings' };
+                      stats: {
+                        __typename?: 'PublicationStats';
+                        totalUpvotes: number;
+                        totalAmountOfMirrors: number;
+                        totalAmountOfCollects: number;
+                        commentsTotal: number;
+                      };
+                      metadata: {
+                        __typename?: 'MetadataOutput';
+                        name?: string | null;
+                        content?: any | null;
+                        image?: any | null;
+                        tags: Array<string>;
+                        attributes: Array<{
+                          __typename?: 'MetadataAttributeOutput';
+                          traitType?: string | null;
+                          value?: string | null;
+                        }>;
+                        cover?: {
+                          __typename?: 'MediaSet';
+                          original: { __typename?: 'Media'; url: any };
+                        } | null;
+                        media: Array<{
+                          __typename?: 'MediaSet';
+                          original: {
+                            __typename?: 'Media';
+                            url: any;
+                            mimeType?: any | null;
+                          };
+                        }>;
+                        encryptionParams?: {
+                          __typename?: 'EncryptionParamsOutput';
+                          accessCondition: {
+                            __typename?: 'AccessConditionOutput';
+                            or?: {
+                              __typename?: 'OrConditionOutput';
+                              criteria: Array<{
+                                __typename?: 'AccessConditionOutput';
+                                and?: {
+                                  __typename?: 'AndConditionOutput';
+                                  criteria: Array<{
+                                    __typename?: 'AccessConditionOutput';
+                                    nft?: {
+                                      __typename?: 'NftOwnershipOutput';
+                                      contractAddress: any;
+                                      chainID: any;
+                                      contractType: ContractType;
+                                      tokenIds?: Array<any> | null;
+                                    } | null;
+                                    eoa?: {
+                                      __typename?: 'EoaOwnershipOutput';
+                                      address: any;
+                                    } | null;
+                                    token?: {
+                                      __typename?: 'Erc20OwnershipOutput';
+                                      contractAddress: any;
+                                      amount: string;
+                                      chainID: any;
+                                      condition: ScalarOperator;
+                                      decimals: number;
+                                    } | null;
+                                    follow?: {
+                                      __typename?: 'FollowConditionOutput';
+                                      profileId: any;
+                                    } | null;
+                                    collect?: {
+                                      __typename?: 'CollectConditionOutput';
+                                      publicationId?: any | null;
+                                      thisPublication?: boolean | null;
+                                    } | null;
+                                  }>;
+                                } | null;
+                                or?: {
+                                  __typename?: 'OrConditionOutput';
+                                  criteria: Array<{
+                                    __typename?: 'AccessConditionOutput';
+                                    nft?: {
+                                      __typename?: 'NftOwnershipOutput';
+                                      contractAddress: any;
+                                      chainID: any;
+                                      contractType: ContractType;
+                                      tokenIds?: Array<any> | null;
+                                    } | null;
+                                    eoa?: {
+                                      __typename?: 'EoaOwnershipOutput';
+                                      address: any;
+                                    } | null;
+                                    token?: {
+                                      __typename?: 'Erc20OwnershipOutput';
+                                      contractAddress: any;
+                                      amount: string;
+                                      chainID: any;
+                                      condition: ScalarOperator;
+                                      decimals: number;
+                                    } | null;
+                                    follow?: {
+                                      __typename?: 'FollowConditionOutput';
+                                      profileId: any;
+                                    } | null;
+                                    collect?: {
+                                      __typename?: 'CollectConditionOutput';
+                                      publicationId?: any | null;
+                                      thisPublication?: boolean | null;
+                                    } | null;
+                                  }>;
+                                } | null;
+                                nft?: {
+                                  __typename?: 'NftOwnershipOutput';
+                                  contractAddress: any;
+                                  chainID: any;
+                                  contractType: ContractType;
+                                  tokenIds?: Array<any> | null;
+                                } | null;
+                                eoa?: {
+                                  __typename?: 'EoaOwnershipOutput';
+                                  address: any;
+                                } | null;
+                                token?: {
+                                  __typename?: 'Erc20OwnershipOutput';
+                                  contractAddress: any;
+                                  amount: string;
+                                  chainID: any;
+                                  condition: ScalarOperator;
+                                  decimals: number;
+                                } | null;
+                                follow?: {
+                                  __typename?: 'FollowConditionOutput';
+                                  profileId: any;
+                                } | null;
+                                collect?: {
+                                  __typename?: 'CollectConditionOutput';
+                                  publicationId?: any | null;
+                                  thisPublication?: boolean | null;
+                                } | null;
+                              }>;
+                            } | null;
+                          };
+                        } | null;
+                      };
+                      mirrorOf:
+                        | {
+                            __typename?: 'Comment';
+                            id: any;
+                            collectNftAddress?: any | null;
+                            reaction?: ReactionTypes | null;
+                            mirrors: Array<any>;
+                            onChainContentURI: string;
+                            isGated: boolean;
+                            isDataAvailability: boolean;
+                            dataAvailabilityProofs?: string | null;
+                            createdAt: any;
+                            profile: {
+                              __typename?: 'Profile';
+                              id: any;
+                              name?: string | null;
+                              handle: any;
+                              bio?: string | null;
+                              ownedBy: any;
+                              isFollowedByMe: boolean;
+                              stats: {
+                                __typename?: 'ProfileStats';
+                                totalFollowers: number;
+                                totalFollowing: number;
+                                totalPosts: number;
+                                totalComments: number;
+                                totalMirrors: number;
+                              };
+                              attributes?: Array<{
+                                __typename?: 'Attribute';
+                                traitType?: string | null;
+                                key: string;
+                                value: string;
+                              }> | null;
+                              picture?:
+                                | {
+                                    __typename?: 'MediaSet';
+                                    original: {
+                                      __typename?: 'Media';
+                                      url: any;
+                                    };
+                                  }
+                                | {
+                                    __typename?: 'NftImage';
+                                    uri: any;
+                                    tokenId: string;
+                                    contractAddress: any;
+                                    chainId: number;
+                                  }
+                                | null;
+                              coverPicture?:
+                                | {
+                                    __typename?: 'MediaSet';
+                                    original: {
+                                      __typename?: 'Media';
+                                      url: any;
+                                    };
+                                  }
+                                | { __typename?: 'NftImage' }
+                                | null;
+                              followModule?:
+                                | { __typename: 'FeeFollowModuleSettings' }
+                                | { __typename: 'ProfileFollowModuleSettings' }
+                                | { __typename: 'RevertFollowModuleSettings' }
+                                | { __typename: 'UnknownFollowModuleSettings' }
+                                | null;
+                            };
+                            canComment: {
+                              __typename?: 'CanCommentResponse';
+                              result: boolean;
+                            };
+                            canMirror: {
+                              __typename?: 'CanMirrorResponse';
+                              result: boolean;
+                            };
+                            canDecrypt: {
+                              __typename?: 'CanDecryptResponse';
+                              result: boolean;
+                              reasons?: Array<DecryptFailReason> | null;
+                            };
+                            stats: {
+                              __typename?: 'PublicationStats';
+                              totalUpvotes: number;
+                              totalAmountOfMirrors: number;
+                              totalAmountOfCollects: number;
+                              commentsTotal: number;
+                            };
+                          }
+                        | {
+                            __typename?: 'Post';
+                            id: any;
+                            reaction?: ReactionTypes | null;
+                            mirrors: Array<any>;
+                            hasCollectedByMe: boolean;
+                            onChainContentURI: string;
+                            isGated: boolean;
+                            isDataAvailability: boolean;
+                            dataAvailabilityProofs?: string | null;
+                            hidden: boolean;
+                            createdAt: any;
+                            appId?: any | null;
+                            profile: {
+                              __typename?: 'Profile';
+                              id: any;
+                              name?: string | null;
+                              handle: any;
+                              bio?: string | null;
+                              ownedBy: any;
+                              isFollowedByMe: boolean;
+                              stats: {
+                                __typename?: 'ProfileStats';
+                                totalFollowers: number;
+                                totalFollowing: number;
+                                totalPosts: number;
+                                totalComments: number;
+                                totalMirrors: number;
+                              };
+                              attributes?: Array<{
+                                __typename?: 'Attribute';
+                                traitType?: string | null;
+                                key: string;
+                                value: string;
+                              }> | null;
+                              picture?:
+                                | {
+                                    __typename?: 'MediaSet';
+                                    original: {
+                                      __typename?: 'Media';
+                                      url: any;
+                                    };
+                                  }
+                                | {
+                                    __typename?: 'NftImage';
+                                    uri: any;
+                                    tokenId: string;
+                                    contractAddress: any;
+                                    chainId: number;
+                                  }
+                                | null;
+                              coverPicture?:
+                                | {
+                                    __typename?: 'MediaSet';
+                                    original: {
+                                      __typename?: 'Media';
+                                      url: any;
+                                    };
+                                  }
+                                | { __typename?: 'NftImage' }
+                                | null;
+                              followModule?:
+                                | { __typename: 'FeeFollowModuleSettings' }
+                                | { __typename: 'ProfileFollowModuleSettings' }
+                                | { __typename: 'RevertFollowModuleSettings' }
+                                | { __typename: 'UnknownFollowModuleSettings' }
+                                | null;
+                            };
+                            canComment: {
+                              __typename?: 'CanCommentResponse';
+                              result: boolean;
+                            };
+                            canMirror: {
+                              __typename?: 'CanMirrorResponse';
+                              result: boolean;
+                            };
+                            canDecrypt: {
+                              __typename?: 'CanDecryptResponse';
+                              result: boolean;
+                              reasons?: Array<DecryptFailReason> | null;
+                            };
+                            collectModule:
+                              | { __typename?: 'AaveFeeCollectModuleSettings' }
+                              | {
+                                  __typename?: 'ERC4626FeeCollectModuleSettings';
+                                }
+                              | {
+                                  __typename?: 'FeeCollectModuleSettings';
+                                  type: CollectModules;
+                                  referralFee: number;
+                                  contractAddress: any;
+                                  followerOnly: boolean;
+                                  amount: {
+                                    __typename?: 'ModuleFeeAmount';
+                                    value: string;
+                                    asset: {
+                                      __typename?: 'Erc20';
+                                      symbol: string;
+                                      decimals: number;
+                                      address: any;
+                                    };
+                                  };
+                                }
+                              | {
+                                  __typename?: 'FreeCollectModuleSettings';
+                                  type: CollectModules;
+                                  contractAddress: any;
+                                  followerOnly: boolean;
+                                }
+                              | {
+                                  __typename?: 'LimitedFeeCollectModuleSettings';
+                                  type: CollectModules;
+                                  collectLimit: string;
+                                  referralFee: number;
+                                  contractAddress: any;
+                                  followerOnly: boolean;
+                                  amount: {
+                                    __typename?: 'ModuleFeeAmount';
+                                    value: string;
+                                    asset: {
+                                      __typename?: 'Erc20';
+                                      symbol: string;
+                                      decimals: number;
+                                      address: any;
+                                    };
+                                  };
+                                }
+                              | {
+                                  __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                                  type: CollectModules;
+                                  collectLimit: string;
+                                  endTimestamp: any;
+                                  referralFee: number;
+                                  contractAddress: any;
+                                  followerOnly: boolean;
+                                  amount: {
+                                    __typename?: 'ModuleFeeAmount';
+                                    value: string;
+                                    asset: {
+                                      __typename?: 'Erc20';
+                                      symbol: string;
+                                      decimals: number;
+                                      address: any;
+                                    };
+                                  };
+                                }
+                              | {
+                                  __typename?: 'MultirecipientFeeCollectModuleSettings';
+                                  type: CollectModules;
+                                  referralFee: number;
+                                  followerOnly: boolean;
+                                  contractAddress: any;
+                                  optionalCollectLimit?: string | null;
+                                  optionalEndTimestamp?: any | null;
+                                  amount: {
+                                    __typename?: 'ModuleFeeAmount';
+                                    value: string;
+                                    asset: {
+                                      __typename?: 'Erc20';
+                                      symbol: string;
+                                      decimals: number;
+                                      address: any;
+                                    };
+                                  };
+                                  recipients: Array<{
+                                    __typename?: 'RecipientDataOutput';
+                                    recipient: any;
+                                    split: number;
+                                  }>;
+                                }
+                              | { __typename?: 'RevertCollectModuleSettings' }
+                              | {
+                                  __typename?: 'SimpleCollectModuleSettings';
+                                  type: CollectModules;
+                                  contractAddress: any;
+                                  followerOnly: boolean;
+                                  optionalCollectLimit?: string | null;
+                                  optionalEndTimestamp?: any | null;
+                                  fee?: {
+                                    __typename?: 'ModuleFee';
+                                    recipient: any;
+                                    referralFee: number;
+                                    amount: {
+                                      __typename?: 'ModuleFeeAmount';
+                                      value: string;
+                                      asset: {
+                                        __typename?: 'Erc20';
+                                        symbol: string;
+                                        decimals: number;
+                                        address: any;
+                                      };
+                                    };
+                                  } | null;
+                                }
+                              | {
+                                  __typename?: 'TimedFeeCollectModuleSettings';
+                                  type: CollectModules;
+                                  endTimestamp: any;
+                                  referralFee: number;
+                                  contractAddress: any;
+                                  followerOnly: boolean;
+                                  amount: {
+                                    __typename?: 'ModuleFeeAmount';
+                                    value: string;
+                                    asset: {
+                                      __typename?: 'Erc20';
+                                      symbol: string;
+                                      decimals: number;
+                                      address: any;
+                                    };
+                                  };
+                                }
+                              | { __typename?: 'UnknownCollectModuleSettings' };
+                            stats: {
+                              __typename?: 'PublicationStats';
+                              totalUpvotes: number;
+                              totalAmountOfMirrors: number;
+                              totalAmountOfCollects: number;
+                              commentsTotal: number;
+                            };
+                            metadata: {
+                              __typename?: 'MetadataOutput';
+                              name?: string | null;
+                              content?: any | null;
+                              image?: any | null;
+                              tags: Array<string>;
+                              attributes: Array<{
+                                __typename?: 'MetadataAttributeOutput';
+                                traitType?: string | null;
+                                value?: string | null;
+                              }>;
+                              cover?: {
+                                __typename?: 'MediaSet';
+                                original: { __typename?: 'Media'; url: any };
+                              } | null;
+                              media: Array<{
+                                __typename?: 'MediaSet';
+                                original: {
+                                  __typename?: 'Media';
+                                  url: any;
+                                  mimeType?: any | null;
+                                };
+                              }>;
+                              encryptionParams?: {
+                                __typename?: 'EncryptionParamsOutput';
+                                accessCondition: {
+                                  __typename?: 'AccessConditionOutput';
+                                  or?: {
+                                    __typename?: 'OrConditionOutput';
+                                    criteria: Array<{
+                                      __typename?: 'AccessConditionOutput';
+                                      and?: {
+                                        __typename?: 'AndConditionOutput';
+                                        criteria: Array<{
+                                          __typename?: 'AccessConditionOutput';
+                                          nft?: {
+                                            __typename?: 'NftOwnershipOutput';
+                                            contractAddress: any;
+                                            chainID: any;
+                                            contractType: ContractType;
+                                            tokenIds?: Array<any> | null;
+                                          } | null;
+                                          eoa?: {
+                                            __typename?: 'EoaOwnershipOutput';
+                                            address: any;
+                                          } | null;
+                                          token?: {
+                                            __typename?: 'Erc20OwnershipOutput';
+                                            contractAddress: any;
+                                            amount: string;
+                                            chainID: any;
+                                            condition: ScalarOperator;
+                                            decimals: number;
+                                          } | null;
+                                          follow?: {
+                                            __typename?: 'FollowConditionOutput';
+                                            profileId: any;
+                                          } | null;
+                                          collect?: {
+                                            __typename?: 'CollectConditionOutput';
+                                            publicationId?: any | null;
+                                            thisPublication?: boolean | null;
+                                          } | null;
+                                        }>;
+                                      } | null;
+                                      or?: {
+                                        __typename?: 'OrConditionOutput';
+                                        criteria: Array<{
+                                          __typename?: 'AccessConditionOutput';
+                                          nft?: {
+                                            __typename?: 'NftOwnershipOutput';
+                                            contractAddress: any;
+                                            chainID: any;
+                                            contractType: ContractType;
+                                            tokenIds?: Array<any> | null;
+                                          } | null;
+                                          eoa?: {
+                                            __typename?: 'EoaOwnershipOutput';
+                                            address: any;
+                                          } | null;
+                                          token?: {
+                                            __typename?: 'Erc20OwnershipOutput';
+                                            contractAddress: any;
+                                            amount: string;
+                                            chainID: any;
+                                            condition: ScalarOperator;
+                                            decimals: number;
+                                          } | null;
+                                          follow?: {
+                                            __typename?: 'FollowConditionOutput';
+                                            profileId: any;
+                                          } | null;
+                                          collect?: {
+                                            __typename?: 'CollectConditionOutput';
+                                            publicationId?: any | null;
+                                            thisPublication?: boolean | null;
+                                          } | null;
+                                        }>;
+                                      } | null;
+                                      nft?: {
+                                        __typename?: 'NftOwnershipOutput';
+                                        contractAddress: any;
+                                        chainID: any;
+                                        contractType: ContractType;
+                                        tokenIds?: Array<any> | null;
+                                      } | null;
+                                      eoa?: {
+                                        __typename?: 'EoaOwnershipOutput';
+                                        address: any;
+                                      } | null;
+                                      token?: {
+                                        __typename?: 'Erc20OwnershipOutput';
+                                        contractAddress: any;
+                                        amount: string;
+                                        chainID: any;
+                                        condition: ScalarOperator;
+                                        decimals: number;
+                                      } | null;
+                                      follow?: {
+                                        __typename?: 'FollowConditionOutput';
+                                        profileId: any;
+                                      } | null;
+                                      collect?: {
+                                        __typename?: 'CollectConditionOutput';
+                                        publicationId?: any | null;
+                                        thisPublication?: boolean | null;
+                                      } | null;
+                                    }>;
+                                  } | null;
+                                };
+                              } | null;
+                            };
+                          };
+                    }
+                  | {
+                      __typename?: 'Post';
+                      id: any;
+                      reaction?: ReactionTypes | null;
+                      mirrors: Array<any>;
+                      hasCollectedByMe: boolean;
+                      onChainContentURI: string;
+                      isGated: boolean;
+                      isDataAvailability: boolean;
+                      dataAvailabilityProofs?: string | null;
+                      hidden: boolean;
+                      createdAt: any;
+                      appId?: any | null;
+                      profile: {
+                        __typename?: 'Profile';
+                        id: any;
+                        name?: string | null;
+                        handle: any;
+                        bio?: string | null;
+                        ownedBy: any;
+                        isFollowedByMe: boolean;
+                        stats: {
+                          __typename?: 'ProfileStats';
+                          totalFollowers: number;
+                          totalFollowing: number;
+                          totalPosts: number;
+                          totalComments: number;
+                          totalMirrors: number;
+                        };
+                        attributes?: Array<{
+                          __typename?: 'Attribute';
+                          traitType?: string | null;
+                          key: string;
+                          value: string;
+                        }> | null;
+                        picture?:
+                          | {
+                              __typename?: 'MediaSet';
+                              original: { __typename?: 'Media'; url: any };
+                            }
+                          | {
+                              __typename?: 'NftImage';
+                              uri: any;
+                              tokenId: string;
+                              contractAddress: any;
+                              chainId: number;
+                            }
+                          | null;
+                        coverPicture?:
+                          | {
+                              __typename?: 'MediaSet';
+                              original: { __typename?: 'Media'; url: any };
+                            }
+                          | { __typename?: 'NftImage' }
+                          | null;
+                        followModule?:
+                          | { __typename: 'FeeFollowModuleSettings' }
+                          | { __typename: 'ProfileFollowModuleSettings' }
+                          | { __typename: 'RevertFollowModuleSettings' }
+                          | { __typename: 'UnknownFollowModuleSettings' }
+                          | null;
+                      };
+                      canComment: {
+                        __typename?: 'CanCommentResponse';
+                        result: boolean;
+                      };
+                      canMirror: {
+                        __typename?: 'CanMirrorResponse';
+                        result: boolean;
+                      };
+                      canDecrypt: {
+                        __typename?: 'CanDecryptResponse';
+                        result: boolean;
+                        reasons?: Array<DecryptFailReason> | null;
+                      };
+                      collectModule:
+                        | { __typename?: 'AaveFeeCollectModuleSettings' }
+                        | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+                        | {
+                            __typename?: 'FeeCollectModuleSettings';
+                            type: CollectModules;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'FreeCollectModuleSettings';
+                            type: CollectModules;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                          }
+                        | {
+                            __typename?: 'LimitedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            collectLimit: string;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            collectLimit: string;
+                            endTimestamp: any;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'MultirecipientFeeCollectModuleSettings';
+                            type: CollectModules;
+                            referralFee: number;
+                            followerOnly: boolean;
+                            contractAddress: any;
+                            optionalCollectLimit?: string | null;
+                            optionalEndTimestamp?: any | null;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                            recipients: Array<{
+                              __typename?: 'RecipientDataOutput';
+                              recipient: any;
+                              split: number;
+                            }>;
+                          }
+                        | { __typename?: 'RevertCollectModuleSettings' }
+                        | {
+                            __typename?: 'SimpleCollectModuleSettings';
+                            type: CollectModules;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            optionalCollectLimit?: string | null;
+                            optionalEndTimestamp?: any | null;
+                            fee?: {
+                              __typename?: 'ModuleFee';
+                              recipient: any;
+                              referralFee: number;
+                              amount: {
+                                __typename?: 'ModuleFeeAmount';
+                                value: string;
+                                asset: {
+                                  __typename?: 'Erc20';
+                                  symbol: string;
+                                  decimals: number;
+                                  address: any;
+                                };
+                              };
+                            } | null;
+                          }
+                        | {
+                            __typename?: 'TimedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            endTimestamp: any;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | { __typename?: 'UnknownCollectModuleSettings' };
+                      stats: {
+                        __typename?: 'PublicationStats';
+                        totalUpvotes: number;
+                        totalAmountOfMirrors: number;
+                        totalAmountOfCollects: number;
+                        commentsTotal: number;
+                      };
+                      metadata: {
+                        __typename?: 'MetadataOutput';
+                        name?: string | null;
+                        content?: any | null;
+                        image?: any | null;
+                        tags: Array<string>;
+                        attributes: Array<{
+                          __typename?: 'MetadataAttributeOutput';
+                          traitType?: string | null;
+                          value?: string | null;
+                        }>;
+                        cover?: {
+                          __typename?: 'MediaSet';
+                          original: { __typename?: 'Media'; url: any };
+                        } | null;
+                        media: Array<{
+                          __typename?: 'MediaSet';
+                          original: {
+                            __typename?: 'Media';
+                            url: any;
+                            mimeType?: any | null;
+                          };
+                        }>;
+                        encryptionParams?: {
+                          __typename?: 'EncryptionParamsOutput';
+                          accessCondition: {
+                            __typename?: 'AccessConditionOutput';
+                            or?: {
+                              __typename?: 'OrConditionOutput';
+                              criteria: Array<{
+                                __typename?: 'AccessConditionOutput';
+                                and?: {
+                                  __typename?: 'AndConditionOutput';
+                                  criteria: Array<{
+                                    __typename?: 'AccessConditionOutput';
+                                    nft?: {
+                                      __typename?: 'NftOwnershipOutput';
+                                      contractAddress: any;
+                                      chainID: any;
+                                      contractType: ContractType;
+                                      tokenIds?: Array<any> | null;
+                                    } | null;
+                                    eoa?: {
+                                      __typename?: 'EoaOwnershipOutput';
+                                      address: any;
+                                    } | null;
+                                    token?: {
+                                      __typename?: 'Erc20OwnershipOutput';
+                                      contractAddress: any;
+                                      amount: string;
+                                      chainID: any;
+                                      condition: ScalarOperator;
+                                      decimals: number;
+                                    } | null;
+                                    follow?: {
+                                      __typename?: 'FollowConditionOutput';
+                                      profileId: any;
+                                    } | null;
+                                    collect?: {
+                                      __typename?: 'CollectConditionOutput';
+                                      publicationId?: any | null;
+                                      thisPublication?: boolean | null;
+                                    } | null;
+                                  }>;
+                                } | null;
+                                or?: {
+                                  __typename?: 'OrConditionOutput';
+                                  criteria: Array<{
+                                    __typename?: 'AccessConditionOutput';
+                                    nft?: {
+                                      __typename?: 'NftOwnershipOutput';
+                                      contractAddress: any;
+                                      chainID: any;
+                                      contractType: ContractType;
+                                      tokenIds?: Array<any> | null;
+                                    } | null;
+                                    eoa?: {
+                                      __typename?: 'EoaOwnershipOutput';
+                                      address: any;
+                                    } | null;
+                                    token?: {
+                                      __typename?: 'Erc20OwnershipOutput';
+                                      contractAddress: any;
+                                      amount: string;
+                                      chainID: any;
+                                      condition: ScalarOperator;
+                                      decimals: number;
+                                    } | null;
+                                    follow?: {
+                                      __typename?: 'FollowConditionOutput';
+                                      profileId: any;
+                                    } | null;
+                                    collect?: {
+                                      __typename?: 'CollectConditionOutput';
+                                      publicationId?: any | null;
+                                      thisPublication?: boolean | null;
+                                    } | null;
+                                  }>;
+                                } | null;
+                                nft?: {
+                                  __typename?: 'NftOwnershipOutput';
+                                  contractAddress: any;
+                                  chainID: any;
+                                  contractType: ContractType;
+                                  tokenIds?: Array<any> | null;
+                                } | null;
+                                eoa?: {
+                                  __typename?: 'EoaOwnershipOutput';
+                                  address: any;
+                                } | null;
+                                token?: {
+                                  __typename?: 'Erc20OwnershipOutput';
+                                  contractAddress: any;
+                                  amount: string;
+                                  chainID: any;
+                                  condition: ScalarOperator;
+                                  decimals: number;
+                                } | null;
+                                follow?: {
+                                  __typename?: 'FollowConditionOutput';
+                                  profileId: any;
+                                } | null;
+                                collect?: {
+                                  __typename?: 'CollectConditionOutput';
+                                  publicationId?: any | null;
+                                  thisPublication?: boolean | null;
+                                } | null;
+                              }>;
+                            } | null;
+                          };
+                        } | null;
+                      };
+                    };
+              }
+            | {
+                __typename?: 'Mirror';
+                id: any;
+                reaction?: ReactionTypes | null;
+                hasCollectedByMe: boolean;
+                isGated: boolean;
+                isDataAvailability: boolean;
+                dataAvailabilityProofs?: string | null;
+                hidden: boolean;
+                createdAt: any;
+                appId?: any | null;
+                profile: {
+                  __typename?: 'Profile';
+                  id: any;
+                  name?: string | null;
+                  handle: any;
+                  bio?: string | null;
+                  ownedBy: any;
+                  isFollowedByMe: boolean;
+                  stats: {
+                    __typename?: 'ProfileStats';
+                    totalFollowers: number;
+                    totalFollowing: number;
+                    totalPosts: number;
+                    totalComments: number;
+                    totalMirrors: number;
+                  };
+                  attributes?: Array<{
+                    __typename?: 'Attribute';
+                    traitType?: string | null;
+                    key: string;
+                    value: string;
+                  }> | null;
+                  picture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | {
+                        __typename?: 'NftImage';
+                        uri: any;
+                        tokenId: string;
+                        contractAddress: any;
+                        chainId: number;
+                      }
+                    | null;
+                  coverPicture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | { __typename?: 'NftImage' }
+                    | null;
+                  followModule?:
+                    | { __typename: 'FeeFollowModuleSettings' }
+                    | { __typename: 'ProfileFollowModuleSettings' }
+                    | { __typename: 'RevertFollowModuleSettings' }
+                    | { __typename: 'UnknownFollowModuleSettings' }
+                    | null;
+                };
+                canComment: {
+                  __typename?: 'CanCommentResponse';
+                  result: boolean;
+                };
+                canMirror: {
+                  __typename?: 'CanMirrorResponse';
+                  result: boolean;
+                };
+                canDecrypt: {
+                  __typename?: 'CanDecryptResponse';
+                  result: boolean;
+                  reasons?: Array<DecryptFailReason> | null;
+                };
+                collectModule:
+                  | { __typename?: 'AaveFeeCollectModuleSettings' }
+                  | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+                  | {
+                      __typename?: 'FeeCollectModuleSettings';
+                      type: CollectModules;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'FreeCollectModuleSettings';
+                      type: CollectModules;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                    }
+                  | {
+                      __typename?: 'LimitedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      collectLimit: string;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      collectLimit: string;
+                      endTimestamp: any;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'MultirecipientFeeCollectModuleSettings';
+                      type: CollectModules;
+                      referralFee: number;
+                      followerOnly: boolean;
+                      contractAddress: any;
+                      optionalCollectLimit?: string | null;
+                      optionalEndTimestamp?: any | null;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                      recipients: Array<{
+                        __typename?: 'RecipientDataOutput';
+                        recipient: any;
+                        split: number;
+                      }>;
+                    }
+                  | { __typename?: 'RevertCollectModuleSettings' }
+                  | {
+                      __typename?: 'SimpleCollectModuleSettings';
+                      type: CollectModules;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      optionalCollectLimit?: string | null;
+                      optionalEndTimestamp?: any | null;
+                      fee?: {
+                        __typename?: 'ModuleFee';
+                        recipient: any;
+                        referralFee: number;
+                        amount: {
+                          __typename?: 'ModuleFeeAmount';
+                          value: string;
+                          asset: {
+                            __typename?: 'Erc20';
+                            symbol: string;
+                            decimals: number;
+                            address: any;
+                          };
+                        };
+                      } | null;
+                    }
+                  | {
+                      __typename?: 'TimedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      endTimestamp: any;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | { __typename?: 'UnknownCollectModuleSettings' };
+                stats: {
+                  __typename?: 'PublicationStats';
+                  totalUpvotes: number;
+                  totalAmountOfMirrors: number;
+                  totalAmountOfCollects: number;
+                  commentsTotal: number;
+                };
+                metadata: {
+                  __typename?: 'MetadataOutput';
+                  name?: string | null;
+                  content?: any | null;
+                  image?: any | null;
+                  tags: Array<string>;
+                  attributes: Array<{
+                    __typename?: 'MetadataAttributeOutput';
+                    traitType?: string | null;
+                    value?: string | null;
+                  }>;
+                  cover?: {
+                    __typename?: 'MediaSet';
+                    original: { __typename?: 'Media'; url: any };
+                  } | null;
+                  media: Array<{
+                    __typename?: 'MediaSet';
+                    original: {
+                      __typename?: 'Media';
+                      url: any;
+                      mimeType?: any | null;
+                    };
+                  }>;
+                  encryptionParams?: {
+                    __typename?: 'EncryptionParamsOutput';
+                    accessCondition: {
+                      __typename?: 'AccessConditionOutput';
+                      or?: {
+                        __typename?: 'OrConditionOutput';
+                        criteria: Array<{
+                          __typename?: 'AccessConditionOutput';
+                          and?: {
+                            __typename?: 'AndConditionOutput';
+                            criteria: Array<{
+                              __typename?: 'AccessConditionOutput';
+                              nft?: {
+                                __typename?: 'NftOwnershipOutput';
+                                contractAddress: any;
+                                chainID: any;
+                                contractType: ContractType;
+                                tokenIds?: Array<any> | null;
+                              } | null;
+                              eoa?: {
+                                __typename?: 'EoaOwnershipOutput';
+                                address: any;
+                              } | null;
+                              token?: {
+                                __typename?: 'Erc20OwnershipOutput';
+                                contractAddress: any;
+                                amount: string;
+                                chainID: any;
+                                condition: ScalarOperator;
+                                decimals: number;
+                              } | null;
+                              follow?: {
+                                __typename?: 'FollowConditionOutput';
+                                profileId: any;
+                              } | null;
+                              collect?: {
+                                __typename?: 'CollectConditionOutput';
+                                publicationId?: any | null;
+                                thisPublication?: boolean | null;
+                              } | null;
+                            }>;
+                          } | null;
+                          or?: {
+                            __typename?: 'OrConditionOutput';
+                            criteria: Array<{
+                              __typename?: 'AccessConditionOutput';
+                              nft?: {
+                                __typename?: 'NftOwnershipOutput';
+                                contractAddress: any;
+                                chainID: any;
+                                contractType: ContractType;
+                                tokenIds?: Array<any> | null;
+                              } | null;
+                              eoa?: {
+                                __typename?: 'EoaOwnershipOutput';
+                                address: any;
+                              } | null;
+                              token?: {
+                                __typename?: 'Erc20OwnershipOutput';
+                                contractAddress: any;
+                                amount: string;
+                                chainID: any;
+                                condition: ScalarOperator;
+                                decimals: number;
+                              } | null;
+                              follow?: {
+                                __typename?: 'FollowConditionOutput';
+                                profileId: any;
+                              } | null;
+                              collect?: {
+                                __typename?: 'CollectConditionOutput';
+                                publicationId?: any | null;
+                                thisPublication?: boolean | null;
+                              } | null;
+                            }>;
+                          } | null;
+                          nft?: {
+                            __typename?: 'NftOwnershipOutput';
+                            contractAddress: any;
+                            chainID: any;
+                            contractType: ContractType;
+                            tokenIds?: Array<any> | null;
+                          } | null;
+                          eoa?: {
+                            __typename?: 'EoaOwnershipOutput';
+                            address: any;
+                          } | null;
+                          token?: {
+                            __typename?: 'Erc20OwnershipOutput';
+                            contractAddress: any;
+                            amount: string;
+                            chainID: any;
+                            condition: ScalarOperator;
+                            decimals: number;
+                          } | null;
+                          follow?: {
+                            __typename?: 'FollowConditionOutput';
+                            profileId: any;
+                          } | null;
+                          collect?: {
+                            __typename?: 'CollectConditionOutput';
+                            publicationId?: any | null;
+                            thisPublication?: boolean | null;
+                          } | null;
+                        }>;
+                      } | null;
+                    };
+                  } | null;
+                };
+                mirrorOf:
+                  | {
+                      __typename?: 'Comment';
+                      id: any;
+                      collectNftAddress?: any | null;
+                      reaction?: ReactionTypes | null;
+                      mirrors: Array<any>;
+                      onChainContentURI: string;
+                      isGated: boolean;
+                      isDataAvailability: boolean;
+                      dataAvailabilityProofs?: string | null;
+                      createdAt: any;
+                      profile: {
+                        __typename?: 'Profile';
+                        id: any;
+                        name?: string | null;
+                        handle: any;
+                        bio?: string | null;
+                        ownedBy: any;
+                        isFollowedByMe: boolean;
+                        stats: {
+                          __typename?: 'ProfileStats';
+                          totalFollowers: number;
+                          totalFollowing: number;
+                          totalPosts: number;
+                          totalComments: number;
+                          totalMirrors: number;
+                        };
+                        attributes?: Array<{
+                          __typename?: 'Attribute';
+                          traitType?: string | null;
+                          key: string;
+                          value: string;
+                        }> | null;
+                        picture?:
+                          | {
+                              __typename?: 'MediaSet';
+                              original: { __typename?: 'Media'; url: any };
+                            }
+                          | {
+                              __typename?: 'NftImage';
+                              uri: any;
+                              tokenId: string;
+                              contractAddress: any;
+                              chainId: number;
+                            }
+                          | null;
+                        coverPicture?:
+                          | {
+                              __typename?: 'MediaSet';
+                              original: { __typename?: 'Media'; url: any };
+                            }
+                          | { __typename?: 'NftImage' }
+                          | null;
+                        followModule?:
+                          | { __typename: 'FeeFollowModuleSettings' }
+                          | { __typename: 'ProfileFollowModuleSettings' }
+                          | { __typename: 'RevertFollowModuleSettings' }
+                          | { __typename: 'UnknownFollowModuleSettings' }
+                          | null;
+                      };
+                      canComment: {
+                        __typename?: 'CanCommentResponse';
+                        result: boolean;
+                      };
+                      canMirror: {
+                        __typename?: 'CanMirrorResponse';
+                        result: boolean;
+                      };
+                      canDecrypt: {
+                        __typename?: 'CanDecryptResponse';
+                        result: boolean;
+                        reasons?: Array<DecryptFailReason> | null;
+                      };
+                      stats: {
+                        __typename?: 'PublicationStats';
+                        totalUpvotes: number;
+                        totalAmountOfMirrors: number;
+                        totalAmountOfCollects: number;
+                        commentsTotal: number;
+                      };
+                    }
+                  | {
+                      __typename?: 'Post';
+                      id: any;
+                      reaction?: ReactionTypes | null;
+                      mirrors: Array<any>;
+                      hasCollectedByMe: boolean;
+                      onChainContentURI: string;
+                      isGated: boolean;
+                      isDataAvailability: boolean;
+                      dataAvailabilityProofs?: string | null;
+                      hidden: boolean;
+                      createdAt: any;
+                      appId?: any | null;
+                      profile: {
+                        __typename?: 'Profile';
+                        id: any;
+                        name?: string | null;
+                        handle: any;
+                        bio?: string | null;
+                        ownedBy: any;
+                        isFollowedByMe: boolean;
+                        stats: {
+                          __typename?: 'ProfileStats';
+                          totalFollowers: number;
+                          totalFollowing: number;
+                          totalPosts: number;
+                          totalComments: number;
+                          totalMirrors: number;
+                        };
+                        attributes?: Array<{
+                          __typename?: 'Attribute';
+                          traitType?: string | null;
+                          key: string;
+                          value: string;
+                        }> | null;
+                        picture?:
+                          | {
+                              __typename?: 'MediaSet';
+                              original: { __typename?: 'Media'; url: any };
+                            }
+                          | {
+                              __typename?: 'NftImage';
+                              uri: any;
+                              tokenId: string;
+                              contractAddress: any;
+                              chainId: number;
+                            }
+                          | null;
+                        coverPicture?:
+                          | {
+                              __typename?: 'MediaSet';
+                              original: { __typename?: 'Media'; url: any };
+                            }
+                          | { __typename?: 'NftImage' }
+                          | null;
+                        followModule?:
+                          | { __typename: 'FeeFollowModuleSettings' }
+                          | { __typename: 'ProfileFollowModuleSettings' }
+                          | { __typename: 'RevertFollowModuleSettings' }
+                          | { __typename: 'UnknownFollowModuleSettings' }
+                          | null;
+                      };
+                      canComment: {
+                        __typename?: 'CanCommentResponse';
+                        result: boolean;
+                      };
+                      canMirror: {
+                        __typename?: 'CanMirrorResponse';
+                        result: boolean;
+                      };
+                      canDecrypt: {
+                        __typename?: 'CanDecryptResponse';
+                        result: boolean;
+                        reasons?: Array<DecryptFailReason> | null;
+                      };
+                      collectModule:
+                        | { __typename?: 'AaveFeeCollectModuleSettings' }
+                        | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+                        | {
+                            __typename?: 'FeeCollectModuleSettings';
+                            type: CollectModules;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'FreeCollectModuleSettings';
+                            type: CollectModules;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                          }
+                        | {
+                            __typename?: 'LimitedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            collectLimit: string;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            collectLimit: string;
+                            endTimestamp: any;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | {
+                            __typename?: 'MultirecipientFeeCollectModuleSettings';
+                            type: CollectModules;
+                            referralFee: number;
+                            followerOnly: boolean;
+                            contractAddress: any;
+                            optionalCollectLimit?: string | null;
+                            optionalEndTimestamp?: any | null;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                            recipients: Array<{
+                              __typename?: 'RecipientDataOutput';
+                              recipient: any;
+                              split: number;
+                            }>;
+                          }
+                        | { __typename?: 'RevertCollectModuleSettings' }
+                        | {
+                            __typename?: 'SimpleCollectModuleSettings';
+                            type: CollectModules;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            optionalCollectLimit?: string | null;
+                            optionalEndTimestamp?: any | null;
+                            fee?: {
+                              __typename?: 'ModuleFee';
+                              recipient: any;
+                              referralFee: number;
+                              amount: {
+                                __typename?: 'ModuleFeeAmount';
+                                value: string;
+                                asset: {
+                                  __typename?: 'Erc20';
+                                  symbol: string;
+                                  decimals: number;
+                                  address: any;
+                                };
+                              };
+                            } | null;
+                          }
+                        | {
+                            __typename?: 'TimedFeeCollectModuleSettings';
+                            type: CollectModules;
+                            endTimestamp: any;
+                            referralFee: number;
+                            contractAddress: any;
+                            followerOnly: boolean;
+                            amount: {
+                              __typename?: 'ModuleFeeAmount';
+                              value: string;
+                              asset: {
+                                __typename?: 'Erc20';
+                                symbol: string;
+                                decimals: number;
+                                address: any;
+                              };
+                            };
+                          }
+                        | { __typename?: 'UnknownCollectModuleSettings' };
+                      stats: {
+                        __typename?: 'PublicationStats';
+                        totalUpvotes: number;
+                        totalAmountOfMirrors: number;
+                        totalAmountOfCollects: number;
+                        commentsTotal: number;
+                      };
+                      metadata: {
+                        __typename?: 'MetadataOutput';
+                        name?: string | null;
+                        content?: any | null;
+                        image?: any | null;
+                        tags: Array<string>;
+                        attributes: Array<{
+                          __typename?: 'MetadataAttributeOutput';
+                          traitType?: string | null;
+                          value?: string | null;
+                        }>;
+                        cover?: {
+                          __typename?: 'MediaSet';
+                          original: { __typename?: 'Media'; url: any };
+                        } | null;
+                        media: Array<{
+                          __typename?: 'MediaSet';
+                          original: {
+                            __typename?: 'Media';
+                            url: any;
+                            mimeType?: any | null;
+                          };
+                        }>;
+                        encryptionParams?: {
+                          __typename?: 'EncryptionParamsOutput';
+                          accessCondition: {
+                            __typename?: 'AccessConditionOutput';
+                            or?: {
+                              __typename?: 'OrConditionOutput';
+                              criteria: Array<{
+                                __typename?: 'AccessConditionOutput';
+                                and?: {
+                                  __typename?: 'AndConditionOutput';
+                                  criteria: Array<{
+                                    __typename?: 'AccessConditionOutput';
+                                    nft?: {
+                                      __typename?: 'NftOwnershipOutput';
+                                      contractAddress: any;
+                                      chainID: any;
+                                      contractType: ContractType;
+                                      tokenIds?: Array<any> | null;
+                                    } | null;
+                                    eoa?: {
+                                      __typename?: 'EoaOwnershipOutput';
+                                      address: any;
+                                    } | null;
+                                    token?: {
+                                      __typename?: 'Erc20OwnershipOutput';
+                                      contractAddress: any;
+                                      amount: string;
+                                      chainID: any;
+                                      condition: ScalarOperator;
+                                      decimals: number;
+                                    } | null;
+                                    follow?: {
+                                      __typename?: 'FollowConditionOutput';
+                                      profileId: any;
+                                    } | null;
+                                    collect?: {
+                                      __typename?: 'CollectConditionOutput';
+                                      publicationId?: any | null;
+                                      thisPublication?: boolean | null;
+                                    } | null;
+                                  }>;
+                                } | null;
+                                or?: {
+                                  __typename?: 'OrConditionOutput';
+                                  criteria: Array<{
+                                    __typename?: 'AccessConditionOutput';
+                                    nft?: {
+                                      __typename?: 'NftOwnershipOutput';
+                                      contractAddress: any;
+                                      chainID: any;
+                                      contractType: ContractType;
+                                      tokenIds?: Array<any> | null;
+                                    } | null;
+                                    eoa?: {
+                                      __typename?: 'EoaOwnershipOutput';
+                                      address: any;
+                                    } | null;
+                                    token?: {
+                                      __typename?: 'Erc20OwnershipOutput';
+                                      contractAddress: any;
+                                      amount: string;
+                                      chainID: any;
+                                      condition: ScalarOperator;
+                                      decimals: number;
+                                    } | null;
+                                    follow?: {
+                                      __typename?: 'FollowConditionOutput';
+                                      profileId: any;
+                                    } | null;
+                                    collect?: {
+                                      __typename?: 'CollectConditionOutput';
+                                      publicationId?: any | null;
+                                      thisPublication?: boolean | null;
+                                    } | null;
+                                  }>;
+                                } | null;
+                                nft?: {
+                                  __typename?: 'NftOwnershipOutput';
+                                  contractAddress: any;
+                                  chainID: any;
+                                  contractType: ContractType;
+                                  tokenIds?: Array<any> | null;
+                                } | null;
+                                eoa?: {
+                                  __typename?: 'EoaOwnershipOutput';
+                                  address: any;
+                                } | null;
+                                token?: {
+                                  __typename?: 'Erc20OwnershipOutput';
+                                  contractAddress: any;
+                                  amount: string;
+                                  chainID: any;
+                                  condition: ScalarOperator;
+                                  decimals: number;
+                                } | null;
+                                follow?: {
+                                  __typename?: 'FollowConditionOutput';
+                                  profileId: any;
+                                } | null;
+                                collect?: {
+                                  __typename?: 'CollectConditionOutput';
+                                  publicationId?: any | null;
+                                  thisPublication?: boolean | null;
+                                } | null;
+                              }>;
+                            } | null;
+                          };
+                        } | null;
+                      };
+                    };
+              }
+            | {
+                __typename?: 'Post';
+                id: any;
+                reaction?: ReactionTypes | null;
+                mirrors: Array<any>;
+                hasCollectedByMe: boolean;
+                onChainContentURI: string;
+                isGated: boolean;
+                isDataAvailability: boolean;
+                dataAvailabilityProofs?: string | null;
+                hidden: boolean;
+                createdAt: any;
+                appId?: any | null;
+                profile: {
+                  __typename?: 'Profile';
+                  id: any;
+                  name?: string | null;
+                  handle: any;
+                  bio?: string | null;
+                  ownedBy: any;
+                  isFollowedByMe: boolean;
+                  stats: {
+                    __typename?: 'ProfileStats';
+                    totalFollowers: number;
+                    totalFollowing: number;
+                    totalPosts: number;
+                    totalComments: number;
+                    totalMirrors: number;
+                  };
+                  attributes?: Array<{
+                    __typename?: 'Attribute';
+                    traitType?: string | null;
+                    key: string;
+                    value: string;
+                  }> | null;
+                  picture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | {
+                        __typename?: 'NftImage';
+                        uri: any;
+                        tokenId: string;
+                        contractAddress: any;
+                        chainId: number;
+                      }
+                    | null;
+                  coverPicture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | { __typename?: 'NftImage' }
+                    | null;
+                  followModule?:
+                    | { __typename: 'FeeFollowModuleSettings' }
+                    | { __typename: 'ProfileFollowModuleSettings' }
+                    | { __typename: 'RevertFollowModuleSettings' }
+                    | { __typename: 'UnknownFollowModuleSettings' }
+                    | null;
+                };
+                canComment: {
+                  __typename?: 'CanCommentResponse';
+                  result: boolean;
+                };
+                canMirror: {
+                  __typename?: 'CanMirrorResponse';
+                  result: boolean;
+                };
+                canDecrypt: {
+                  __typename?: 'CanDecryptResponse';
+                  result: boolean;
+                  reasons?: Array<DecryptFailReason> | null;
+                };
+                collectModule:
+                  | { __typename?: 'AaveFeeCollectModuleSettings' }
+                  | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+                  | {
+                      __typename?: 'FeeCollectModuleSettings';
+                      type: CollectModules;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'FreeCollectModuleSettings';
+                      type: CollectModules;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                    }
+                  | {
+                      __typename?: 'LimitedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      collectLimit: string;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      collectLimit: string;
+                      endTimestamp: any;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'MultirecipientFeeCollectModuleSettings';
+                      type: CollectModules;
+                      referralFee: number;
+                      followerOnly: boolean;
+                      contractAddress: any;
+                      optionalCollectLimit?: string | null;
+                      optionalEndTimestamp?: any | null;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                      recipients: Array<{
+                        __typename?: 'RecipientDataOutput';
+                        recipient: any;
+                        split: number;
+                      }>;
+                    }
+                  | { __typename?: 'RevertCollectModuleSettings' }
+                  | {
+                      __typename?: 'SimpleCollectModuleSettings';
+                      type: CollectModules;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      optionalCollectLimit?: string | null;
+                      optionalEndTimestamp?: any | null;
+                      fee?: {
+                        __typename?: 'ModuleFee';
+                        recipient: any;
+                        referralFee: number;
+                        amount: {
+                          __typename?: 'ModuleFeeAmount';
+                          value: string;
+                          asset: {
+                            __typename?: 'Erc20';
+                            symbol: string;
+                            decimals: number;
+                            address: any;
+                          };
+                        };
+                      } | null;
+                    }
+                  | {
+                      __typename?: 'TimedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      endTimestamp: any;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | { __typename?: 'UnknownCollectModuleSettings' };
+                stats: {
+                  __typename?: 'PublicationStats';
+                  totalUpvotes: number;
+                  totalAmountOfMirrors: number;
+                  totalAmountOfCollects: number;
+                  commentsTotal: number;
+                };
+                metadata: {
+                  __typename?: 'MetadataOutput';
+                  name?: string | null;
+                  content?: any | null;
+                  image?: any | null;
+                  tags: Array<string>;
+                  attributes: Array<{
+                    __typename?: 'MetadataAttributeOutput';
+                    traitType?: string | null;
+                    value?: string | null;
+                  }>;
+                  cover?: {
+                    __typename?: 'MediaSet';
+                    original: { __typename?: 'Media'; url: any };
+                  } | null;
+                  media: Array<{
+                    __typename?: 'MediaSet';
+                    original: {
+                      __typename?: 'Media';
+                      url: any;
+                      mimeType?: any | null;
+                    };
+                  }>;
+                  encryptionParams?: {
+                    __typename?: 'EncryptionParamsOutput';
+                    accessCondition: {
+                      __typename?: 'AccessConditionOutput';
+                      or?: {
+                        __typename?: 'OrConditionOutput';
+                        criteria: Array<{
+                          __typename?: 'AccessConditionOutput';
+                          and?: {
+                            __typename?: 'AndConditionOutput';
+                            criteria: Array<{
+                              __typename?: 'AccessConditionOutput';
+                              nft?: {
+                                __typename?: 'NftOwnershipOutput';
+                                contractAddress: any;
+                                chainID: any;
+                                contractType: ContractType;
+                                tokenIds?: Array<any> | null;
+                              } | null;
+                              eoa?: {
+                                __typename?: 'EoaOwnershipOutput';
+                                address: any;
+                              } | null;
+                              token?: {
+                                __typename?: 'Erc20OwnershipOutput';
+                                contractAddress: any;
+                                amount: string;
+                                chainID: any;
+                                condition: ScalarOperator;
+                                decimals: number;
+                              } | null;
+                              follow?: {
+                                __typename?: 'FollowConditionOutput';
+                                profileId: any;
+                              } | null;
+                              collect?: {
+                                __typename?: 'CollectConditionOutput';
+                                publicationId?: any | null;
+                                thisPublication?: boolean | null;
+                              } | null;
+                            }>;
+                          } | null;
+                          or?: {
+                            __typename?: 'OrConditionOutput';
+                            criteria: Array<{
+                              __typename?: 'AccessConditionOutput';
+                              nft?: {
+                                __typename?: 'NftOwnershipOutput';
+                                contractAddress: any;
+                                chainID: any;
+                                contractType: ContractType;
+                                tokenIds?: Array<any> | null;
+                              } | null;
+                              eoa?: {
+                                __typename?: 'EoaOwnershipOutput';
+                                address: any;
+                              } | null;
+                              token?: {
+                                __typename?: 'Erc20OwnershipOutput';
+                                contractAddress: any;
+                                amount: string;
+                                chainID: any;
+                                condition: ScalarOperator;
+                                decimals: number;
+                              } | null;
+                              follow?: {
+                                __typename?: 'FollowConditionOutput';
+                                profileId: any;
+                              } | null;
+                              collect?: {
+                                __typename?: 'CollectConditionOutput';
+                                publicationId?: any | null;
+                                thisPublication?: boolean | null;
+                              } | null;
+                            }>;
+                          } | null;
+                          nft?: {
+                            __typename?: 'NftOwnershipOutput';
+                            contractAddress: any;
+                            chainID: any;
+                            contractType: ContractType;
+                            tokenIds?: Array<any> | null;
+                          } | null;
+                          eoa?: {
+                            __typename?: 'EoaOwnershipOutput';
+                            address: any;
+                          } | null;
+                          token?: {
+                            __typename?: 'Erc20OwnershipOutput';
+                            contractAddress: any;
+                            amount: string;
+                            chainID: any;
+                            condition: ScalarOperator;
+                            decimals: number;
+                          } | null;
+                          follow?: {
+                            __typename?: 'FollowConditionOutput';
+                            profileId: any;
+                          } | null;
+                          collect?: {
+                            __typename?: 'CollectConditionOutput';
+                            publicationId?: any | null;
+                            thisPublication?: boolean | null;
+                          } | null;
+                        }>;
+                      } | null;
+                    };
+                  } | null;
+                };
+              }
+            | null;
+        }
+      | {
+          __typename?: 'Mirror';
+          id: any;
+          reaction?: ReactionTypes | null;
+          hasCollectedByMe: boolean;
+          isGated: boolean;
+          isDataAvailability: boolean;
+          dataAvailabilityProofs?: string | null;
+          hidden: boolean;
+          createdAt: any;
+          appId?: any | null;
+          profile: {
+            __typename?: 'Profile';
+            id: any;
+            name?: string | null;
+            handle: any;
+            bio?: string | null;
+            ownedBy: any;
+            isFollowedByMe: boolean;
+            stats: {
+              __typename?: 'ProfileStats';
+              totalFollowers: number;
+              totalFollowing: number;
+              totalPosts: number;
+              totalComments: number;
+              totalMirrors: number;
+            };
+            attributes?: Array<{
+              __typename?: 'Attribute';
+              traitType?: string | null;
+              key: string;
+              value: string;
+            }> | null;
+            picture?:
+              | {
+                  __typename?: 'MediaSet';
+                  original: { __typename?: 'Media'; url: any };
+                }
+              | {
+                  __typename?: 'NftImage';
+                  uri: any;
+                  tokenId: string;
+                  contractAddress: any;
+                  chainId: number;
+                }
+              | null;
+            coverPicture?:
+              | {
+                  __typename?: 'MediaSet';
+                  original: { __typename?: 'Media'; url: any };
+                }
+              | { __typename?: 'NftImage' }
+              | null;
+            followModule?:
+              | { __typename: 'FeeFollowModuleSettings' }
+              | { __typename: 'ProfileFollowModuleSettings' }
+              | { __typename: 'RevertFollowModuleSettings' }
+              | { __typename: 'UnknownFollowModuleSettings' }
+              | null;
+          };
+          canComment: { __typename?: 'CanCommentResponse'; result: boolean };
+          canMirror: { __typename?: 'CanMirrorResponse'; result: boolean };
+          canDecrypt: {
+            __typename?: 'CanDecryptResponse';
+            result: boolean;
+            reasons?: Array<DecryptFailReason> | null;
+          };
+          collectModule:
+            | { __typename?: 'AaveFeeCollectModuleSettings' }
+            | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+            | {
+                __typename?: 'FeeCollectModuleSettings';
+                type: CollectModules;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'FreeCollectModuleSettings';
+                type: CollectModules;
+                contractAddress: any;
+                followerOnly: boolean;
+              }
+            | {
+                __typename?: 'LimitedFeeCollectModuleSettings';
+                type: CollectModules;
+                collectLimit: string;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                type: CollectModules;
+                collectLimit: string;
+                endTimestamp: any;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'MultirecipientFeeCollectModuleSettings';
+                type: CollectModules;
+                referralFee: number;
+                followerOnly: boolean;
+                contractAddress: any;
+                optionalCollectLimit?: string | null;
+                optionalEndTimestamp?: any | null;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+                recipients: Array<{
+                  __typename?: 'RecipientDataOutput';
+                  recipient: any;
+                  split: number;
+                }>;
+              }
+            | { __typename?: 'RevertCollectModuleSettings' }
+            | {
+                __typename?: 'SimpleCollectModuleSettings';
+                type: CollectModules;
+                contractAddress: any;
+                followerOnly: boolean;
+                optionalCollectLimit?: string | null;
+                optionalEndTimestamp?: any | null;
+                fee?: {
+                  __typename?: 'ModuleFee';
+                  recipient: any;
+                  referralFee: number;
+                  amount: {
+                    __typename?: 'ModuleFeeAmount';
+                    value: string;
+                    asset: {
+                      __typename?: 'Erc20';
+                      symbol: string;
+                      decimals: number;
+                      address: any;
+                    };
+                  };
+                } | null;
+              }
+            | {
+                __typename?: 'TimedFeeCollectModuleSettings';
+                type: CollectModules;
+                endTimestamp: any;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | { __typename?: 'UnknownCollectModuleSettings' };
+          stats: {
+            __typename?: 'PublicationStats';
+            totalUpvotes: number;
+            totalAmountOfMirrors: number;
+            totalAmountOfCollects: number;
+            commentsTotal: number;
+          };
+          metadata: {
+            __typename?: 'MetadataOutput';
+            name?: string | null;
+            content?: any | null;
+            image?: any | null;
+            tags: Array<string>;
+            attributes: Array<{
+              __typename?: 'MetadataAttributeOutput';
+              traitType?: string | null;
+              value?: string | null;
+            }>;
+            cover?: {
+              __typename?: 'MediaSet';
+              original: { __typename?: 'Media'; url: any };
+            } | null;
+            media: Array<{
+              __typename?: 'MediaSet';
+              original: {
+                __typename?: 'Media';
+                url: any;
+                mimeType?: any | null;
+              };
+            }>;
+            encryptionParams?: {
+              __typename?: 'EncryptionParamsOutput';
+              accessCondition: {
+                __typename?: 'AccessConditionOutput';
+                or?: {
+                  __typename?: 'OrConditionOutput';
+                  criteria: Array<{
+                    __typename?: 'AccessConditionOutput';
+                    and?: {
+                      __typename?: 'AndConditionOutput';
+                      criteria: Array<{
+                        __typename?: 'AccessConditionOutput';
+                        nft?: {
+                          __typename?: 'NftOwnershipOutput';
+                          contractAddress: any;
+                          chainID: any;
+                          contractType: ContractType;
+                          tokenIds?: Array<any> | null;
+                        } | null;
+                        eoa?: {
+                          __typename?: 'EoaOwnershipOutput';
+                          address: any;
+                        } | null;
+                        token?: {
+                          __typename?: 'Erc20OwnershipOutput';
+                          contractAddress: any;
+                          amount: string;
+                          chainID: any;
+                          condition: ScalarOperator;
+                          decimals: number;
+                        } | null;
+                        follow?: {
+                          __typename?: 'FollowConditionOutput';
+                          profileId: any;
+                        } | null;
+                        collect?: {
+                          __typename?: 'CollectConditionOutput';
+                          publicationId?: any | null;
+                          thisPublication?: boolean | null;
+                        } | null;
+                      }>;
+                    } | null;
+                    or?: {
+                      __typename?: 'OrConditionOutput';
+                      criteria: Array<{
+                        __typename?: 'AccessConditionOutput';
+                        nft?: {
+                          __typename?: 'NftOwnershipOutput';
+                          contractAddress: any;
+                          chainID: any;
+                          contractType: ContractType;
+                          tokenIds?: Array<any> | null;
+                        } | null;
+                        eoa?: {
+                          __typename?: 'EoaOwnershipOutput';
+                          address: any;
+                        } | null;
+                        token?: {
+                          __typename?: 'Erc20OwnershipOutput';
+                          contractAddress: any;
+                          amount: string;
+                          chainID: any;
+                          condition: ScalarOperator;
+                          decimals: number;
+                        } | null;
+                        follow?: {
+                          __typename?: 'FollowConditionOutput';
+                          profileId: any;
+                        } | null;
+                        collect?: {
+                          __typename?: 'CollectConditionOutput';
+                          publicationId?: any | null;
+                          thisPublication?: boolean | null;
+                        } | null;
+                      }>;
+                    } | null;
+                    nft?: {
+                      __typename?: 'NftOwnershipOutput';
+                      contractAddress: any;
+                      chainID: any;
+                      contractType: ContractType;
+                      tokenIds?: Array<any> | null;
+                    } | null;
+                    eoa?: {
+                      __typename?: 'EoaOwnershipOutput';
+                      address: any;
+                    } | null;
+                    token?: {
+                      __typename?: 'Erc20OwnershipOutput';
+                      contractAddress: any;
+                      amount: string;
+                      chainID: any;
+                      condition: ScalarOperator;
+                      decimals: number;
+                    } | null;
+                    follow?: {
+                      __typename?: 'FollowConditionOutput';
+                      profileId: any;
+                    } | null;
+                    collect?: {
+                      __typename?: 'CollectConditionOutput';
+                      publicationId?: any | null;
+                      thisPublication?: boolean | null;
+                    } | null;
+                  }>;
+                } | null;
+              };
+            } | null;
+          };
+          mirrorOf:
+            | {
+                __typename?: 'Comment';
+                id: any;
+                collectNftAddress?: any | null;
+                reaction?: ReactionTypes | null;
+                mirrors: Array<any>;
+                onChainContentURI: string;
+                isGated: boolean;
+                isDataAvailability: boolean;
+                dataAvailabilityProofs?: string | null;
+                createdAt: any;
+                profile: {
+                  __typename?: 'Profile';
+                  id: any;
+                  name?: string | null;
+                  handle: any;
+                  bio?: string | null;
+                  ownedBy: any;
+                  isFollowedByMe: boolean;
+                  stats: {
+                    __typename?: 'ProfileStats';
+                    totalFollowers: number;
+                    totalFollowing: number;
+                    totalPosts: number;
+                    totalComments: number;
+                    totalMirrors: number;
+                  };
+                  attributes?: Array<{
+                    __typename?: 'Attribute';
+                    traitType?: string | null;
+                    key: string;
+                    value: string;
+                  }> | null;
+                  picture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | {
+                        __typename?: 'NftImage';
+                        uri: any;
+                        tokenId: string;
+                        contractAddress: any;
+                        chainId: number;
+                      }
+                    | null;
+                  coverPicture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | { __typename?: 'NftImage' }
+                    | null;
+                  followModule?:
+                    | { __typename: 'FeeFollowModuleSettings' }
+                    | { __typename: 'ProfileFollowModuleSettings' }
+                    | { __typename: 'RevertFollowModuleSettings' }
+                    | { __typename: 'UnknownFollowModuleSettings' }
+                    | null;
+                };
+                canComment: {
+                  __typename?: 'CanCommentResponse';
+                  result: boolean;
+                };
+                canMirror: {
+                  __typename?: 'CanMirrorResponse';
+                  result: boolean;
+                };
+                canDecrypt: {
+                  __typename?: 'CanDecryptResponse';
+                  result: boolean;
+                  reasons?: Array<DecryptFailReason> | null;
+                };
+                stats: {
+                  __typename?: 'PublicationStats';
+                  totalUpvotes: number;
+                  totalAmountOfMirrors: number;
+                  totalAmountOfCollects: number;
+                  commentsTotal: number;
+                };
+              }
+            | {
+                __typename?: 'Post';
+                id: any;
+                reaction?: ReactionTypes | null;
+                mirrors: Array<any>;
+                hasCollectedByMe: boolean;
+                onChainContentURI: string;
+                isGated: boolean;
+                isDataAvailability: boolean;
+                dataAvailabilityProofs?: string | null;
+                hidden: boolean;
+                createdAt: any;
+                appId?: any | null;
+                profile: {
+                  __typename?: 'Profile';
+                  id: any;
+                  name?: string | null;
+                  handle: any;
+                  bio?: string | null;
+                  ownedBy: any;
+                  isFollowedByMe: boolean;
+                  stats: {
+                    __typename?: 'ProfileStats';
+                    totalFollowers: number;
+                    totalFollowing: number;
+                    totalPosts: number;
+                    totalComments: number;
+                    totalMirrors: number;
+                  };
+                  attributes?: Array<{
+                    __typename?: 'Attribute';
+                    traitType?: string | null;
+                    key: string;
+                    value: string;
+                  }> | null;
+                  picture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | {
+                        __typename?: 'NftImage';
+                        uri: any;
+                        tokenId: string;
+                        contractAddress: any;
+                        chainId: number;
+                      }
+                    | null;
+                  coverPicture?:
+                    | {
+                        __typename?: 'MediaSet';
+                        original: { __typename?: 'Media'; url: any };
+                      }
+                    | { __typename?: 'NftImage' }
+                    | null;
+                  followModule?:
+                    | { __typename: 'FeeFollowModuleSettings' }
+                    | { __typename: 'ProfileFollowModuleSettings' }
+                    | { __typename: 'RevertFollowModuleSettings' }
+                    | { __typename: 'UnknownFollowModuleSettings' }
+                    | null;
+                };
+                canComment: {
+                  __typename?: 'CanCommentResponse';
+                  result: boolean;
+                };
+                canMirror: {
+                  __typename?: 'CanMirrorResponse';
+                  result: boolean;
+                };
+                canDecrypt: {
+                  __typename?: 'CanDecryptResponse';
+                  result: boolean;
+                  reasons?: Array<DecryptFailReason> | null;
+                };
+                collectModule:
+                  | { __typename?: 'AaveFeeCollectModuleSettings' }
+                  | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+                  | {
+                      __typename?: 'FeeCollectModuleSettings';
+                      type: CollectModules;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'FreeCollectModuleSettings';
+                      type: CollectModules;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                    }
+                  | {
+                      __typename?: 'LimitedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      collectLimit: string;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      collectLimit: string;
+                      endTimestamp: any;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | {
+                      __typename?: 'MultirecipientFeeCollectModuleSettings';
+                      type: CollectModules;
+                      referralFee: number;
+                      followerOnly: boolean;
+                      contractAddress: any;
+                      optionalCollectLimit?: string | null;
+                      optionalEndTimestamp?: any | null;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                      recipients: Array<{
+                        __typename?: 'RecipientDataOutput';
+                        recipient: any;
+                        split: number;
+                      }>;
+                    }
+                  | { __typename?: 'RevertCollectModuleSettings' }
+                  | {
+                      __typename?: 'SimpleCollectModuleSettings';
+                      type: CollectModules;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      optionalCollectLimit?: string | null;
+                      optionalEndTimestamp?: any | null;
+                      fee?: {
+                        __typename?: 'ModuleFee';
+                        recipient: any;
+                        referralFee: number;
+                        amount: {
+                          __typename?: 'ModuleFeeAmount';
+                          value: string;
+                          asset: {
+                            __typename?: 'Erc20';
+                            symbol: string;
+                            decimals: number;
+                            address: any;
+                          };
+                        };
+                      } | null;
+                    }
+                  | {
+                      __typename?: 'TimedFeeCollectModuleSettings';
+                      type: CollectModules;
+                      endTimestamp: any;
+                      referralFee: number;
+                      contractAddress: any;
+                      followerOnly: boolean;
+                      amount: {
+                        __typename?: 'ModuleFeeAmount';
+                        value: string;
+                        asset: {
+                          __typename?: 'Erc20';
+                          symbol: string;
+                          decimals: number;
+                          address: any;
+                        };
+                      };
+                    }
+                  | { __typename?: 'UnknownCollectModuleSettings' };
+                stats: {
+                  __typename?: 'PublicationStats';
+                  totalUpvotes: number;
+                  totalAmountOfMirrors: number;
+                  totalAmountOfCollects: number;
+                  commentsTotal: number;
+                };
+                metadata: {
+                  __typename?: 'MetadataOutput';
+                  name?: string | null;
+                  content?: any | null;
+                  image?: any | null;
+                  tags: Array<string>;
+                  attributes: Array<{
+                    __typename?: 'MetadataAttributeOutput';
+                    traitType?: string | null;
+                    value?: string | null;
+                  }>;
+                  cover?: {
+                    __typename?: 'MediaSet';
+                    original: { __typename?: 'Media'; url: any };
+                  } | null;
+                  media: Array<{
+                    __typename?: 'MediaSet';
+                    original: {
+                      __typename?: 'Media';
+                      url: any;
+                      mimeType?: any | null;
+                    };
+                  }>;
+                  encryptionParams?: {
+                    __typename?: 'EncryptionParamsOutput';
+                    accessCondition: {
+                      __typename?: 'AccessConditionOutput';
+                      or?: {
+                        __typename?: 'OrConditionOutput';
+                        criteria: Array<{
+                          __typename?: 'AccessConditionOutput';
+                          and?: {
+                            __typename?: 'AndConditionOutput';
+                            criteria: Array<{
+                              __typename?: 'AccessConditionOutput';
+                              nft?: {
+                                __typename?: 'NftOwnershipOutput';
+                                contractAddress: any;
+                                chainID: any;
+                                contractType: ContractType;
+                                tokenIds?: Array<any> | null;
+                              } | null;
+                              eoa?: {
+                                __typename?: 'EoaOwnershipOutput';
+                                address: any;
+                              } | null;
+                              token?: {
+                                __typename?: 'Erc20OwnershipOutput';
+                                contractAddress: any;
+                                amount: string;
+                                chainID: any;
+                                condition: ScalarOperator;
+                                decimals: number;
+                              } | null;
+                              follow?: {
+                                __typename?: 'FollowConditionOutput';
+                                profileId: any;
+                              } | null;
+                              collect?: {
+                                __typename?: 'CollectConditionOutput';
+                                publicationId?: any | null;
+                                thisPublication?: boolean | null;
+                              } | null;
+                            }>;
+                          } | null;
+                          or?: {
+                            __typename?: 'OrConditionOutput';
+                            criteria: Array<{
+                              __typename?: 'AccessConditionOutput';
+                              nft?: {
+                                __typename?: 'NftOwnershipOutput';
+                                contractAddress: any;
+                                chainID: any;
+                                contractType: ContractType;
+                                tokenIds?: Array<any> | null;
+                              } | null;
+                              eoa?: {
+                                __typename?: 'EoaOwnershipOutput';
+                                address: any;
+                              } | null;
+                              token?: {
+                                __typename?: 'Erc20OwnershipOutput';
+                                contractAddress: any;
+                                amount: string;
+                                chainID: any;
+                                condition: ScalarOperator;
+                                decimals: number;
+                              } | null;
+                              follow?: {
+                                __typename?: 'FollowConditionOutput';
+                                profileId: any;
+                              } | null;
+                              collect?: {
+                                __typename?: 'CollectConditionOutput';
+                                publicationId?: any | null;
+                                thisPublication?: boolean | null;
+                              } | null;
+                            }>;
+                          } | null;
+                          nft?: {
+                            __typename?: 'NftOwnershipOutput';
+                            contractAddress: any;
+                            chainID: any;
+                            contractType: ContractType;
+                            tokenIds?: Array<any> | null;
+                          } | null;
+                          eoa?: {
+                            __typename?: 'EoaOwnershipOutput';
+                            address: any;
+                          } | null;
+                          token?: {
+                            __typename?: 'Erc20OwnershipOutput';
+                            contractAddress: any;
+                            amount: string;
+                            chainID: any;
+                            condition: ScalarOperator;
+                            decimals: number;
+                          } | null;
+                          follow?: {
+                            __typename?: 'FollowConditionOutput';
+                            profileId: any;
+                          } | null;
+                          collect?: {
+                            __typename?: 'CollectConditionOutput';
+                            publicationId?: any | null;
+                            thisPublication?: boolean | null;
+                          } | null;
+                        }>;
+                      } | null;
+                    };
+                  } | null;
+                };
+              };
+        }
+      | {
+          __typename?: 'Post';
+          id: any;
+          reaction?: ReactionTypes | null;
+          mirrors: Array<any>;
+          hasCollectedByMe: boolean;
+          onChainContentURI: string;
+          isGated: boolean;
+          isDataAvailability: boolean;
+          dataAvailabilityProofs?: string | null;
+          hidden: boolean;
+          createdAt: any;
+          appId?: any | null;
+          profile: {
+            __typename?: 'Profile';
+            id: any;
+            name?: string | null;
+            handle: any;
+            bio?: string | null;
+            ownedBy: any;
+            isFollowedByMe: boolean;
+            stats: {
+              __typename?: 'ProfileStats';
+              totalFollowers: number;
+              totalFollowing: number;
+              totalPosts: number;
+              totalComments: number;
+              totalMirrors: number;
+            };
+            attributes?: Array<{
+              __typename?: 'Attribute';
+              traitType?: string | null;
+              key: string;
+              value: string;
+            }> | null;
+            picture?:
+              | {
+                  __typename?: 'MediaSet';
+                  original: { __typename?: 'Media'; url: any };
+                }
+              | {
+                  __typename?: 'NftImage';
+                  uri: any;
+                  tokenId: string;
+                  contractAddress: any;
+                  chainId: number;
+                }
+              | null;
+            coverPicture?:
+              | {
+                  __typename?: 'MediaSet';
+                  original: { __typename?: 'Media'; url: any };
+                }
+              | { __typename?: 'NftImage' }
+              | null;
+            followModule?:
+              | { __typename: 'FeeFollowModuleSettings' }
+              | { __typename: 'ProfileFollowModuleSettings' }
+              | { __typename: 'RevertFollowModuleSettings' }
+              | { __typename: 'UnknownFollowModuleSettings' }
+              | null;
+          };
+          canComment: { __typename?: 'CanCommentResponse'; result: boolean };
+          canMirror: { __typename?: 'CanMirrorResponse'; result: boolean };
+          canDecrypt: {
+            __typename?: 'CanDecryptResponse';
+            result: boolean;
+            reasons?: Array<DecryptFailReason> | null;
+          };
+          collectModule:
+            | { __typename?: 'AaveFeeCollectModuleSettings' }
+            | { __typename?: 'ERC4626FeeCollectModuleSettings' }
+            | {
+                __typename?: 'FeeCollectModuleSettings';
+                type: CollectModules;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'FreeCollectModuleSettings';
+                type: CollectModules;
+                contractAddress: any;
+                followerOnly: boolean;
+              }
+            | {
+                __typename?: 'LimitedFeeCollectModuleSettings';
+                type: CollectModules;
+                collectLimit: string;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'LimitedTimedFeeCollectModuleSettings';
+                type: CollectModules;
+                collectLimit: string;
+                endTimestamp: any;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | {
+                __typename?: 'MultirecipientFeeCollectModuleSettings';
+                type: CollectModules;
+                referralFee: number;
+                followerOnly: boolean;
+                contractAddress: any;
+                optionalCollectLimit?: string | null;
+                optionalEndTimestamp?: any | null;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+                recipients: Array<{
+                  __typename?: 'RecipientDataOutput';
+                  recipient: any;
+                  split: number;
+                }>;
+              }
+            | { __typename?: 'RevertCollectModuleSettings' }
+            | {
+                __typename?: 'SimpleCollectModuleSettings';
+                type: CollectModules;
+                contractAddress: any;
+                followerOnly: boolean;
+                optionalCollectLimit?: string | null;
+                optionalEndTimestamp?: any | null;
+                fee?: {
+                  __typename?: 'ModuleFee';
+                  recipient: any;
+                  referralFee: number;
+                  amount: {
+                    __typename?: 'ModuleFeeAmount';
+                    value: string;
+                    asset: {
+                      __typename?: 'Erc20';
+                      symbol: string;
+                      decimals: number;
+                      address: any;
+                    };
+                  };
+                } | null;
+              }
+            | {
+                __typename?: 'TimedFeeCollectModuleSettings';
+                type: CollectModules;
+                endTimestamp: any;
+                referralFee: number;
+                contractAddress: any;
+                followerOnly: boolean;
+                amount: {
+                  __typename?: 'ModuleFeeAmount';
+                  value: string;
+                  asset: {
+                    __typename?: 'Erc20';
+                    symbol: string;
+                    decimals: number;
+                    address: any;
+                  };
+                };
+              }
+            | { __typename?: 'UnknownCollectModuleSettings' };
+          stats: {
+            __typename?: 'PublicationStats';
+            totalUpvotes: number;
+            totalAmountOfMirrors: number;
+            totalAmountOfCollects: number;
+            commentsTotal: number;
+          };
+          metadata: {
+            __typename?: 'MetadataOutput';
+            name?: string | null;
+            content?: any | null;
+            image?: any | null;
+            tags: Array<string>;
+            attributes: Array<{
+              __typename?: 'MetadataAttributeOutput';
+              traitType?: string | null;
+              value?: string | null;
+            }>;
+            cover?: {
+              __typename?: 'MediaSet';
+              original: { __typename?: 'Media'; url: any };
+            } | null;
+            media: Array<{
+              __typename?: 'MediaSet';
+              original: {
+                __typename?: 'Media';
+                url: any;
+                mimeType?: any | null;
+              };
+            }>;
+            encryptionParams?: {
+              __typename?: 'EncryptionParamsOutput';
+              accessCondition: {
+                __typename?: 'AccessConditionOutput';
+                or?: {
+                  __typename?: 'OrConditionOutput';
+                  criteria: Array<{
+                    __typename?: 'AccessConditionOutput';
+                    and?: {
+                      __typename?: 'AndConditionOutput';
+                      criteria: Array<{
+                        __typename?: 'AccessConditionOutput';
+                        nft?: {
+                          __typename?: 'NftOwnershipOutput';
+                          contractAddress: any;
+                          chainID: any;
+                          contractType: ContractType;
+                          tokenIds?: Array<any> | null;
+                        } | null;
+                        eoa?: {
+                          __typename?: 'EoaOwnershipOutput';
+                          address: any;
+                        } | null;
+                        token?: {
+                          __typename?: 'Erc20OwnershipOutput';
+                          contractAddress: any;
+                          amount: string;
+                          chainID: any;
+                          condition: ScalarOperator;
+                          decimals: number;
+                        } | null;
+                        follow?: {
+                          __typename?: 'FollowConditionOutput';
+                          profileId: any;
+                        } | null;
+                        collect?: {
+                          __typename?: 'CollectConditionOutput';
+                          publicationId?: any | null;
+                          thisPublication?: boolean | null;
+                        } | null;
+                      }>;
+                    } | null;
+                    or?: {
+                      __typename?: 'OrConditionOutput';
+                      criteria: Array<{
+                        __typename?: 'AccessConditionOutput';
+                        nft?: {
+                          __typename?: 'NftOwnershipOutput';
+                          contractAddress: any;
+                          chainID: any;
+                          contractType: ContractType;
+                          tokenIds?: Array<any> | null;
+                        } | null;
+                        eoa?: {
+                          __typename?: 'EoaOwnershipOutput';
+                          address: any;
+                        } | null;
+                        token?: {
+                          __typename?: 'Erc20OwnershipOutput';
+                          contractAddress: any;
+                          amount: string;
+                          chainID: any;
+                          condition: ScalarOperator;
+                          decimals: number;
+                        } | null;
+                        follow?: {
+                          __typename?: 'FollowConditionOutput';
+                          profileId: any;
+                        } | null;
+                        collect?: {
+                          __typename?: 'CollectConditionOutput';
+                          publicationId?: any | null;
+                          thisPublication?: boolean | null;
+                        } | null;
+                      }>;
+                    } | null;
+                    nft?: {
+                      __typename?: 'NftOwnershipOutput';
+                      contractAddress: any;
+                      chainID: any;
+                      contractType: ContractType;
+                      tokenIds?: Array<any> | null;
+                    } | null;
+                    eoa?: {
+                      __typename?: 'EoaOwnershipOutput';
+                      address: any;
+                    } | null;
+                    token?: {
+                      __typename?: 'Erc20OwnershipOutput';
+                      contractAddress: any;
+                      amount: string;
+                      chainID: any;
+                      condition: ScalarOperator;
+                      decimals: number;
+                    } | null;
+                    follow?: {
+                      __typename?: 'FollowConditionOutput';
+                      profileId: any;
+                    } | null;
+                    collect?: {
+                      __typename?: 'CollectConditionOutput';
+                      publicationId?: any | null;
+                      thisPublication?: boolean | null;
+                    } | null;
+                  }>;
+                } | null;
+              };
+            } | null;
+          };
+        }
+    >;
+    pageInfo: { __typename?: 'PaginatedResultInfo'; next?: any | null };
+  };
+};
+
 export type RecommendedProfilesQueryVariables = Exact<{
   options?: InputMaybe<RecommendedProfileOptions>;
 }>;
@@ -45616,6 +50136,57 @@ export type AddProfileInterestMutationOptions = Apollo.BaseMutationOptions<
   AddProfileInterestMutation,
   AddProfileInterestMutationVariables
 >;
+export const AddPublicationProfileBookmarkDocument = gql`
+  mutation AddPublicationProfileBookmark(
+    $request: PublicationProfileBookmarkRequest!
+  ) {
+    addPublicationProfileBookmark(request: $request)
+  }
+`;
+export type AddPublicationProfileBookmarkMutationFn = Apollo.MutationFunction<
+  AddPublicationProfileBookmarkMutation,
+  AddPublicationProfileBookmarkMutationVariables
+>;
+
+/**
+ * __useAddPublicationProfileBookmarkMutation__
+ *
+ * To run a mutation, you first call `useAddPublicationProfileBookmarkMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useAddPublicationProfileBookmarkMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [addPublicationProfileBookmarkMutation, { data, loading, error }] = useAddPublicationProfileBookmarkMutation({
+ *   variables: {
+ *      request: // value for 'request'
+ *   },
+ * });
+ */
+export function useAddPublicationProfileBookmarkMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    AddPublicationProfileBookmarkMutation,
+    AddPublicationProfileBookmarkMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    AddPublicationProfileBookmarkMutation,
+    AddPublicationProfileBookmarkMutationVariables
+  >(AddPublicationProfileBookmarkDocument, options);
+}
+export type AddPublicationProfileBookmarkMutationHookResult = ReturnType<
+  typeof useAddPublicationProfileBookmarkMutation
+>;
+export type AddPublicationProfileBookmarkMutationResult =
+  Apollo.MutationResult<AddPublicationProfileBookmarkMutation>;
+export type AddPublicationProfileBookmarkMutationOptions =
+  Apollo.BaseMutationOptions<
+    AddPublicationProfileBookmarkMutation,
+    AddPublicationProfileBookmarkMutationVariables
+  >;
 export const AddReactionDocument = gql`
   mutation AddReaction($request: ReactionRequest!) {
     addReaction(request: $request)
@@ -47689,6 +52260,58 @@ export type RemoveProfileInterestMutationOptions = Apollo.BaseMutationOptions<
   RemoveProfileInterestMutation,
   RemoveProfileInterestMutationVariables
 >;
+export const RemovePublicationProfileBookmarkDocument = gql`
+  mutation RemovePublicationProfileBookmark(
+    $request: PublicationProfileBookmarkRequest!
+  ) {
+    removePublicationProfileBookmark(request: $request)
+  }
+`;
+export type RemovePublicationProfileBookmarkMutationFn =
+  Apollo.MutationFunction<
+    RemovePublicationProfileBookmarkMutation,
+    RemovePublicationProfileBookmarkMutationVariables
+  >;
+
+/**
+ * __useRemovePublicationProfileBookmarkMutation__
+ *
+ * To run a mutation, you first call `useRemovePublicationProfileBookmarkMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemovePublicationProfileBookmarkMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removePublicationProfileBookmarkMutation, { data, loading, error }] = useRemovePublicationProfileBookmarkMutation({
+ *   variables: {
+ *      request: // value for 'request'
+ *   },
+ * });
+ */
+export function useRemovePublicationProfileBookmarkMutation(
+  baseOptions?: Apollo.MutationHookOptions<
+    RemovePublicationProfileBookmarkMutation,
+    RemovePublicationProfileBookmarkMutationVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useMutation<
+    RemovePublicationProfileBookmarkMutation,
+    RemovePublicationProfileBookmarkMutationVariables
+  >(RemovePublicationProfileBookmarkDocument, options);
+}
+export type RemovePublicationProfileBookmarkMutationHookResult = ReturnType<
+  typeof useRemovePublicationProfileBookmarkMutation
+>;
+export type RemovePublicationProfileBookmarkMutationResult =
+  Apollo.MutationResult<RemovePublicationProfileBookmarkMutation>;
+export type RemovePublicationProfileBookmarkMutationOptions =
+  Apollo.BaseMutationOptions<
+    RemovePublicationProfileBookmarkMutation,
+    RemovePublicationProfileBookmarkMutationVariables
+  >;
 export const RemoveReactionDocument = gql`
   mutation RemoveReaction($request: ReactionRequest!) {
     removeReaction(request: $request)
@@ -50015,6 +54638,86 @@ export type PublicationRevenueQueryResult = Apollo.QueryResult<
   PublicationRevenueQuery,
   PublicationRevenueQueryVariables
 >;
+export const PublicationsProfileBookmarksDocument = gql`
+  query PublicationsProfileBookmarks(
+    $request: PublicationsProfileBookmarkedQueryRequest!
+    $reactionRequest: ReactionFieldResolverRequest
+    $profileId: ProfileId
+  ) {
+    publicationsProfileBookmarks(request: $request) {
+      items {
+        ... on Post {
+          ...PostFields
+        }
+        ... on Comment {
+          ...CommentFields
+        }
+        ... on Mirror {
+          ...MirrorFields
+        }
+      }
+      pageInfo {
+        next
+      }
+    }
+  }
+  ${PostFieldsFragmentDoc}
+  ${CommentFieldsFragmentDoc}
+  ${MirrorFieldsFragmentDoc}
+`;
+
+/**
+ * __usePublicationsProfileBookmarksQuery__
+ *
+ * To run a query within a React component, call `usePublicationsProfileBookmarksQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePublicationsProfileBookmarksQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePublicationsProfileBookmarksQuery({
+ *   variables: {
+ *      request: // value for 'request'
+ *      reactionRequest: // value for 'reactionRequest'
+ *      profileId: // value for 'profileId'
+ *   },
+ * });
+ */
+export function usePublicationsProfileBookmarksQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    PublicationsProfileBookmarksQuery,
+    PublicationsProfileBookmarksQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<
+    PublicationsProfileBookmarksQuery,
+    PublicationsProfileBookmarksQueryVariables
+  >(PublicationsProfileBookmarksDocument, options);
+}
+export function usePublicationsProfileBookmarksLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    PublicationsProfileBookmarksQuery,
+    PublicationsProfileBookmarksQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<
+    PublicationsProfileBookmarksQuery,
+    PublicationsProfileBookmarksQueryVariables
+  >(PublicationsProfileBookmarksDocument, options);
+}
+export type PublicationsProfileBookmarksQueryHookResult = ReturnType<
+  typeof usePublicationsProfileBookmarksQuery
+>;
+export type PublicationsProfileBookmarksLazyQueryHookResult = ReturnType<
+  typeof usePublicationsProfileBookmarksLazyQuery
+>;
+export type PublicationsProfileBookmarksQueryResult = Apollo.QueryResult<
+  PublicationsProfileBookmarksQuery,
+  PublicationsProfileBookmarksQueryVariables
+>;
 export const RecommendedProfilesDocument = gql`
   query RecommendedProfiles($options: RecommendedProfileOptions) {
     recommendedProfiles(options: $options) {
@@ -50845,7 +55548,8 @@ const result: PossibleTypesResultData = {
     ],
     RelayResult: ['RelayError', 'RelayerResult'],
     SearchResult: ['ProfileSearchResult', 'PublicationSearchResult'],
-    TransactionResult: ['TransactionError', 'TransactionIndexedResult']
+    TransactionResult: ['TransactionError', 'TransactionIndexedResult'],
+    ZkRelayerResult: ['RelayerResult', 'ZkRelayError']
   }
 };
 export default result;

--- a/packages/lens/generated.ts
+++ b/packages/lens/generated.ts
@@ -5134,6 +5134,7 @@ export type CommentFieldsFragment = {
   id: any;
   reaction?: ReactionTypes | null;
   mirrors: Array<any>;
+  bookmarked: boolean;
   hasCollectedByMe: boolean;
   onChainContentURI: string;
   isGated: boolean;
@@ -5466,6 +5467,7 @@ export type CommentFieldsFragment = {
         id: any;
         reaction?: ReactionTypes | null;
         mirrors: Array<any>;
+        bookmarked: boolean;
         hasCollectedByMe: boolean;
         onChainContentURI: string;
         isGated: boolean;
@@ -6141,6 +6143,7 @@ export type CommentFieldsFragment = {
                     collectNftAddress?: any | null;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
                     isDataAvailability: boolean;
@@ -6221,6 +6224,7 @@ export type CommentFieldsFragment = {
                     id: any;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     hasCollectedByMe: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
@@ -6567,6 +6571,7 @@ export type CommentFieldsFragment = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -7244,6 +7249,7 @@ export type CommentFieldsFragment = {
               collectNftAddress?: any | null;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               onChainContentURI: string;
               isGated: boolean;
               isDataAvailability: boolean;
@@ -7321,6 +7327,7 @@ export type CommentFieldsFragment = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -7664,6 +7671,7 @@ export type CommentFieldsFragment = {
         id: any;
         reaction?: ReactionTypes | null;
         mirrors: Array<any>;
+        bookmarked: boolean;
         hasCollectedByMe: boolean;
         onChainContentURI: string;
         isGated: boolean;
@@ -8453,6 +8461,7 @@ export type MirrorFieldsFragment = {
         collectNftAddress?: any | null;
         reaction?: ReactionTypes | null;
         mirrors: Array<any>;
+        bookmarked: boolean;
         onChainContentURI: string;
         isGated: boolean;
         isDataAvailability: boolean;
@@ -8527,6 +8536,7 @@ export type MirrorFieldsFragment = {
         id: any;
         reaction?: ReactionTypes | null;
         mirrors: Array<any>;
+        bookmarked: boolean;
         hasCollectedByMe: boolean;
         onChainContentURI: string;
         isGated: boolean;
@@ -8875,6 +8885,7 @@ export type PostFieldsFragment = {
   id: any;
   reaction?: ReactionTypes | null;
   mirrors: Array<any>;
+  bookmarked: boolean;
   hasCollectedByMe: boolean;
   onChainContentURI: string;
   isGated: boolean;
@@ -10703,6 +10714,7 @@ export type CommentFeedQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -11042,6 +11054,7 @@ export type CommentFeedQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -11730,6 +11743,7 @@ export type CommentFeedQuery = {
                             collectNftAddress?: any | null;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
                             isDataAvailability: boolean;
@@ -11816,6 +11830,7 @@ export type CommentFeedQuery = {
                             id: any;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             hasCollectedByMe: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
@@ -12170,6 +12185,7 @@ export type CommentFeedQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -12860,6 +12876,7 @@ export type CommentFeedQuery = {
                       collectNftAddress?: any | null;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
                       isDataAvailability: boolean;
@@ -12940,6 +12957,7 @@ export type CommentFeedQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -13286,6 +13304,7 @@ export type CommentFeedQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -13672,6 +13691,7 @@ export type ExploreFeedQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -14011,6 +14031,7 @@ export type ExploreFeedQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -14699,6 +14720,7 @@ export type ExploreFeedQuery = {
                             collectNftAddress?: any | null;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
                             isDataAvailability: boolean;
@@ -14785,6 +14807,7 @@ export type ExploreFeedQuery = {
                             id: any;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             hasCollectedByMe: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
@@ -15139,6 +15162,7 @@ export type ExploreFeedQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -15829,6 +15853,7 @@ export type ExploreFeedQuery = {
                       collectNftAddress?: any | null;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
                       isDataAvailability: boolean;
@@ -15909,6 +15934,7 @@ export type ExploreFeedQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -16255,6 +16281,7 @@ export type ExploreFeedQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -16940,6 +16967,7 @@ export type ExploreFeedQuery = {
                 collectNftAddress?: any | null;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
                 isDataAvailability: boolean;
@@ -17020,6 +17048,7 @@ export type ExploreFeedQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -17366,6 +17395,7 @@ export type ExploreFeedQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -17721,6 +17751,7 @@ export type FeedHighlightsQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -18060,6 +18091,7 @@ export type FeedHighlightsQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -18748,6 +18780,7 @@ export type FeedHighlightsQuery = {
                             collectNftAddress?: any | null;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
                             isDataAvailability: boolean;
@@ -18834,6 +18867,7 @@ export type FeedHighlightsQuery = {
                             id: any;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             hasCollectedByMe: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
@@ -19188,6 +19222,7 @@ export type FeedHighlightsQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -19878,6 +19913,7 @@ export type FeedHighlightsQuery = {
                       collectNftAddress?: any | null;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
                       isDataAvailability: boolean;
@@ -19958,6 +19994,7 @@ export type FeedHighlightsQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -20304,6 +20341,7 @@ export type FeedHighlightsQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -20989,6 +21027,7 @@ export type FeedHighlightsQuery = {
                 collectNftAddress?: any | null;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
                 isDataAvailability: boolean;
@@ -21069,6 +21108,7 @@ export type FeedHighlightsQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -21415,6 +21455,7 @@ export type FeedHighlightsQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -21904,6 +21945,7 @@ export type ForYouQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -22243,6 +22285,7 @@ export type ForYouQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -22931,6 +22974,7 @@ export type ForYouQuery = {
                             collectNftAddress?: any | null;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
                             isDataAvailability: boolean;
@@ -23017,6 +23061,7 @@ export type ForYouQuery = {
                             id: any;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             hasCollectedByMe: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
@@ -23371,6 +23416,7 @@ export type ForYouQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -24061,6 +24107,7 @@ export type ForYouQuery = {
                       collectNftAddress?: any | null;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
                       isDataAvailability: boolean;
@@ -24141,6 +24188,7 @@ export type ForYouQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -24487,6 +24535,7 @@ export type ForYouQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -25172,6 +25221,7 @@ export type ForYouQuery = {
                 collectNftAddress?: any | null;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
                 isDataAvailability: boolean;
@@ -25252,6 +25302,7 @@ export type ForYouQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -25598,6 +25649,7 @@ export type ForYouQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -27041,6 +27093,7 @@ export type ProfileFeedQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -27380,6 +27433,7 @@ export type ProfileFeedQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -28068,6 +28122,7 @@ export type ProfileFeedQuery = {
                             collectNftAddress?: any | null;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
                             isDataAvailability: boolean;
@@ -28154,6 +28209,7 @@ export type ProfileFeedQuery = {
                             id: any;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             hasCollectedByMe: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
@@ -28508,6 +28564,7 @@ export type ProfileFeedQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -29198,6 +29255,7 @@ export type ProfileFeedQuery = {
                       collectNftAddress?: any | null;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
                       isDataAvailability: boolean;
@@ -29278,6 +29336,7 @@ export type ProfileFeedQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -29624,6 +29683,7 @@ export type ProfileFeedQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -30309,6 +30369,7 @@ export type ProfileFeedQuery = {
                 collectNftAddress?: any | null;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
                 isDataAvailability: boolean;
@@ -30389,6 +30450,7 @@ export type ProfileFeedQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -30735,6 +30797,7 @@ export type ProfileFeedQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -31215,6 +31278,7 @@ export type PublicationQuery = {
         id: any;
         reaction?: ReactionTypes | null;
         mirrors: Array<any>;
+        bookmarked: boolean;
         hasCollectedByMe: boolean;
         onChainContentURI: string;
         isGated: boolean;
@@ -31555,6 +31619,7 @@ export type PublicationQuery = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -32240,6 +32305,7 @@ export type PublicationQuery = {
                           collectNftAddress?: any | null;
                           reaction?: ReactionTypes | null;
                           mirrors: Array<any>;
+                          bookmarked: boolean;
                           onChainContentURI: string;
                           isGated: boolean;
                           isDataAvailability: boolean;
@@ -32320,6 +32386,7 @@ export type PublicationQuery = {
                           id: any;
                           reaction?: ReactionTypes | null;
                           mirrors: Array<any>;
+                          bookmarked: boolean;
                           hasCollectedByMe: boolean;
                           onChainContentURI: string;
                           isGated: boolean;
@@ -32666,6 +32733,7 @@ export type PublicationQuery = {
                     id: any;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     hasCollectedByMe: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
@@ -33353,6 +33421,7 @@ export type PublicationQuery = {
                     collectNftAddress?: any | null;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
                     isDataAvailability: boolean;
@@ -33433,6 +33502,7 @@ export type PublicationQuery = {
                     id: any;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     hasCollectedByMe: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
@@ -33779,6 +33849,7 @@ export type PublicationQuery = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -34463,6 +34534,7 @@ export type PublicationQuery = {
               collectNftAddress?: any | null;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               onChainContentURI: string;
               isGated: boolean;
               isDataAvailability: boolean;
@@ -34540,6 +34612,7 @@ export type PublicationQuery = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -34884,6 +34957,7 @@ export type PublicationQuery = {
         id: any;
         reaction?: ReactionTypes | null;
         mirrors: Array<any>;
+        bookmarked: boolean;
         hasCollectedByMe: boolean;
         onChainContentURI: string;
         isGated: boolean;
@@ -35253,6 +35327,7 @@ export type PublicationsProfileBookmarksQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -35592,6 +35667,7 @@ export type PublicationsProfileBookmarksQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -36280,6 +36356,7 @@ export type PublicationsProfileBookmarksQuery = {
                             collectNftAddress?: any | null;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
                             isDataAvailability: boolean;
@@ -36366,6 +36443,7 @@ export type PublicationsProfileBookmarksQuery = {
                             id: any;
                             reaction?: ReactionTypes | null;
                             mirrors: Array<any>;
+                            bookmarked: boolean;
                             hasCollectedByMe: boolean;
                             onChainContentURI: string;
                             isGated: boolean;
@@ -36720,6 +36798,7 @@ export type PublicationsProfileBookmarksQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -37410,6 +37489,7 @@ export type PublicationsProfileBookmarksQuery = {
                       collectNftAddress?: any | null;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
                       isDataAvailability: boolean;
@@ -37490,6 +37570,7 @@ export type PublicationsProfileBookmarksQuery = {
                       id: any;
                       reaction?: ReactionTypes | null;
                       mirrors: Array<any>;
+                      bookmarked: boolean;
                       hasCollectedByMe: boolean;
                       onChainContentURI: string;
                       isGated: boolean;
@@ -37836,6 +37917,7 @@ export type PublicationsProfileBookmarksQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -38521,6 +38603,7 @@ export type PublicationsProfileBookmarksQuery = {
                 collectNftAddress?: any | null;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
                 isDataAvailability: boolean;
@@ -38601,6 +38684,7 @@ export type PublicationsProfileBookmarksQuery = {
                 id: any;
                 reaction?: ReactionTypes | null;
                 mirrors: Array<any>;
+                bookmarked: boolean;
                 hasCollectedByMe: boolean;
                 onChainContentURI: string;
                 isGated: boolean;
@@ -38947,6 +39031,7 @@ export type PublicationsProfileBookmarksQuery = {
           id: any;
           reaction?: ReactionTypes | null;
           mirrors: Array<any>;
+          bookmarked: boolean;
           hasCollectedByMe: boolean;
           onChainContentURI: string;
           isGated: boolean;
@@ -39436,6 +39521,7 @@ export type SearchPublicationsQuery = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -39778,6 +39864,7 @@ export type SearchPublicationsQuery = {
                     id: any;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     hasCollectedByMe: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
@@ -40466,6 +40553,7 @@ export type SearchPublicationsQuery = {
                                 collectNftAddress?: any | null;
                                 reaction?: ReactionTypes | null;
                                 mirrors: Array<any>;
+                                bookmarked: boolean;
                                 onChainContentURI: string;
                                 isGated: boolean;
                                 isDataAvailability: boolean;
@@ -40558,6 +40646,7 @@ export type SearchPublicationsQuery = {
                                 id: any;
                                 reaction?: ReactionTypes | null;
                                 mirrors: Array<any>;
+                                bookmarked: boolean;
                                 hasCollectedByMe: boolean;
                                 onChainContentURI: string;
                                 isGated: boolean;
@@ -40931,6 +41020,7 @@ export type SearchPublicationsQuery = {
                           id: any;
                           reaction?: ReactionTypes | null;
                           mirrors: Array<any>;
+                          bookmarked: boolean;
                           hasCollectedByMe: boolean;
                           onChainContentURI: string;
                           isGated: boolean;
@@ -41621,6 +41711,7 @@ export type SearchPublicationsQuery = {
                           collectNftAddress?: any | null;
                           reaction?: ReactionTypes | null;
                           mirrors: Array<any>;
+                          bookmarked: boolean;
                           onChainContentURI: string;
                           isGated: boolean;
                           isDataAvailability: boolean;
@@ -41701,6 +41792,7 @@ export type SearchPublicationsQuery = {
                           id: any;
                           reaction?: ReactionTypes | null;
                           mirrors: Array<any>;
+                          bookmarked: boolean;
                           hasCollectedByMe: boolean;
                           onChainContentURI: string;
                           isGated: boolean;
@@ -42047,6 +42139,7 @@ export type SearchPublicationsQuery = {
                     id: any;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     hasCollectedByMe: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
@@ -42394,6 +42487,7 @@ export type SearchPublicationsQuery = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -43165,6 +43259,7 @@ export type TimelineQuery = {
             id: any;
             reaction?: ReactionTypes | null;
             mirrors: Array<any>;
+            bookmarked: boolean;
             hasCollectedByMe: boolean;
             onChainContentURI: string;
             isGated: boolean;
@@ -43504,6 +43599,7 @@ export type TimelineQuery = {
                   id: any;
                   reaction?: ReactionTypes | null;
                   mirrors: Array<any>;
+                  bookmarked: boolean;
                   hasCollectedByMe: boolean;
                   onChainContentURI: string;
                   isGated: boolean;
@@ -44192,6 +44288,7 @@ export type TimelineQuery = {
                               collectNftAddress?: any | null;
                               reaction?: ReactionTypes | null;
                               mirrors: Array<any>;
+                              bookmarked: boolean;
                               onChainContentURI: string;
                               isGated: boolean;
                               isDataAvailability: boolean;
@@ -44282,6 +44379,7 @@ export type TimelineQuery = {
                               id: any;
                               reaction?: ReactionTypes | null;
                               mirrors: Array<any>;
+                              bookmarked: boolean;
                               hasCollectedByMe: boolean;
                               onChainContentURI: string;
                               isGated: boolean;
@@ -44644,6 +44742,7 @@ export type TimelineQuery = {
                         id: any;
                         reaction?: ReactionTypes | null;
                         mirrors: Array<any>;
+                        bookmarked: boolean;
                         hasCollectedByMe: boolean;
                         onChainContentURI: string;
                         isGated: boolean;
@@ -45334,6 +45433,7 @@ export type TimelineQuery = {
                         collectNftAddress?: any | null;
                         reaction?: ReactionTypes | null;
                         mirrors: Array<any>;
+                        bookmarked: boolean;
                         onChainContentURI: string;
                         isGated: boolean;
                         isDataAvailability: boolean;
@@ -45414,6 +45514,7 @@ export type TimelineQuery = {
                         id: any;
                         reaction?: ReactionTypes | null;
                         mirrors: Array<any>;
+                        bookmarked: boolean;
                         hasCollectedByMe: boolean;
                         onChainContentURI: string;
                         isGated: boolean;
@@ -45760,6 +45861,7 @@ export type TimelineQuery = {
                   id: any;
                   reaction?: ReactionTypes | null;
                   mirrors: Array<any>;
+                  bookmarked: boolean;
                   hasCollectedByMe: boolean;
                   onChainContentURI: string;
                   isGated: boolean;
@@ -46107,6 +46209,7 @@ export type TimelineQuery = {
             id: any;
             reaction?: ReactionTypes | null;
             mirrors: Array<any>;
+            bookmarked: boolean;
             hasCollectedByMe: boolean;
             onChainContentURI: string;
             isGated: boolean;
@@ -46660,6 +46763,7 @@ export type TimelineQuery = {
         id: any;
         reaction?: ReactionTypes | null;
         mirrors: Array<any>;
+        bookmarked: boolean;
         hasCollectedByMe: boolean;
         onChainContentURI: string;
         isGated: boolean;
@@ -46995,6 +47099,7 @@ export type TimelineQuery = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -47680,6 +47785,7 @@ export type TimelineQuery = {
                           collectNftAddress?: any | null;
                           reaction?: ReactionTypes | null;
                           mirrors: Array<any>;
+                          bookmarked: boolean;
                           onChainContentURI: string;
                           isGated: boolean;
                           isDataAvailability: boolean;
@@ -47760,6 +47866,7 @@ export type TimelineQuery = {
                           id: any;
                           reaction?: ReactionTypes | null;
                           mirrors: Array<any>;
+                          bookmarked: boolean;
                           hasCollectedByMe: boolean;
                           onChainContentURI: string;
                           isGated: boolean;
@@ -48106,6 +48213,7 @@ export type TimelineQuery = {
                     id: any;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     hasCollectedByMe: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
@@ -48793,6 +48901,7 @@ export type TimelineQuery = {
                     collectNftAddress?: any | null;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
                     isDataAvailability: boolean;
@@ -48873,6 +48982,7 @@ export type TimelineQuery = {
                     id: any;
                     reaction?: ReactionTypes | null;
                     mirrors: Array<any>;
+                    bookmarked: boolean;
                     hasCollectedByMe: boolean;
                     onChainContentURI: string;
                     isGated: boolean;
@@ -49219,6 +49329,7 @@ export type TimelineQuery = {
               id: any;
               reaction?: ReactionTypes | null;
               mirrors: Array<any>;
+              bookmarked: boolean;
               hasCollectedByMe: boolean;
               onChainContentURI: string;
               isGated: boolean;
@@ -49879,6 +49990,7 @@ export const PostFieldsFragmentDoc = gql`
     }
     reaction(request: $reactionRequest)
     mirrors(by: $profileId)
+    bookmarked(by: $profileId)
     hasCollectedByMe
     onChainContentURI
     isGated
@@ -49955,6 +50067,7 @@ export const MirrorFieldsFragmentDoc = gql`
         collectNftAddress
         reaction(request: $reactionRequest)
         mirrors(by: $profileId)
+        bookmarked(by: $profileId)
         onChainContentURI
         isGated
         isDataAvailability
@@ -49992,6 +50105,7 @@ export const CommentFieldsFragmentDoc = gql`
     }
     reaction(request: $reactionRequest)
     mirrors(by: $profileId)
+    bookmarked(by: $profileId)
     hasCollectedByMe
     onChainContentURI
     isGated
@@ -50030,6 +50144,7 @@ export const CommentFieldsFragmentDoc = gql`
         }
         reaction(request: $reactionRequest)
         mirrors(by: $profileId)
+        bookmarked(by: $profileId)
         hasCollectedByMe
         onChainContentURI
         isGated


### PR DESCRIPTION
- chore: codegen for bookmarks
- feat: add bookmarks mutations

## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ec4443</samp>

This pull request adds a bookmark feature to the web app and the lens package, allowing users to save publications for later and see their bookmark status. It adds a `Bookmark` component to the publication menu, a `bookmarked` field to various publication fragments, and new mutations and queries for bookmarking logic. It also updates the `codegen.ts` file to use the staging API schema.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ec4443</samp>

*  Add a new component `Bookmark.tsx` to render a menu item for bookmarking or removing bookmark from a publication ([link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-092d5ebe6db060904cad2182f60783e0a48febafd2d8d24a907537c858b0c89cR1-R99))
* Import and render the `Bookmark` component in the `Menu` component, conditionally showing it only for logged-in users ([link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-98ae234a63fdd27eeadf44f0622c55a8ae8bc07e239cab14f538d0100b13259bR11), [link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-98ae234a63fdd27eeadf44f0622c55a8ae8bc07e239cab14f538d0100b13259bR51))
* Add a new field `bookmarked` to the GraphQL fragments for posts, comments, and mirrors, taking a `profileId` argument to indicate the bookmark status ([link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-4d5e131db167ad0d98bcfb0aacc2f2679baf99dd3555d6fd1e7a31717cb144aeR8), [link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-4d5e131db167ad0d98bcfb0aacc2f2679baf99dd3555d6fd1e7a31717cb144aeR47), [link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-1ab41ae3a982c2b5184a2d6efd41ba0a5574f112c53249159f84080eda0640a2R43), [link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-ede11b1b2d5a078d958ca58815cddfa284b7e3eba70ec4250b6de825ebeaf808R8))
* Add new mutation documents for adding and removing bookmarks from a profile to a publication, taking a `request` argument with the `profileId` and the `publicationId` ([link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-50106d3c62efbab92278e9628593676ecaa47393c73b9915f64513da4e89b7d2R1-R5), [link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-eeb2d97c1e4910a0cb791490cf85f4a51c1ac95f7cd3a10229ecf826b63581b7R1-R5))
* Add a new query document for fetching a list of publications bookmarked by a profile, taking a `request` argument with the `profileId` and pagination parameters, a `reactionRequest` argument for fetching reactions, and a `profileId` argument for fetching the `bookmarked` field ([link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-7978a2d85e8d8b3513d59499634fe14cd9fc4e42a4c9072ae2e074b16d487788R1-R22))
* Switch the schema URL in the `codegen.ts` file from the production API to the staging API for testing purposes ([link](https://github.com/lensterxyz/lenster/pull/3193/files?diff=unified&w=0#diff-94397669f7e81a7e02e5d32c9a13f9181907f00809ca6a4033982bf0853031c3L5-R5))

## Emoji

<!--
copilot:emoji
-->

📚🧪💬

<!--
1.  📚 - This emoji represents the bookmarking feature and the new `Bookmark` component.
2.  🧪 - This emoji represents the switch to the staging API schema for testing purposes.
3.  💬 - This emoji represents the comment system and the addition of the `bookmarked` field to the `CommentFields` fragment.
-->
