### PR TITLE
chore: move polls to GA

### DIFF
--- a/apps/web/src/components/Composer/Actions/PollSettings/index.tsx
+++ b/apps/web/src/components/Composer/Actions/PollSettings/index.tsx
@@ -1,6 +1,4 @@
 import { MenuAlt2Icon } from '@heroicons/react/solid';
-import { FeatureFlag } from '@lenster/data';
-import isFeatureEnabled from '@lenster/lib/isFeatureEnabled';
 import { Tooltip } from '@lenster/ui';
 import { t } from '@lingui/macro';
 import { motion } from 'framer-motion';
@@ -13,11 +11,6 @@ const PollSettings: FC = () => {
     (state) => state.setShowPollEditor
   );
   const resetPollConfig = usePublicationStore((state) => state.resetPollConfig);
-  const isPollsEnabled = isFeatureEnabled(FeatureFlag.Polls);
-
-  if (!isPollsEnabled) {
-    return null;
-  }
 
   return (
     <Tooltip placement="top" content={t`Poll`}>

--- a/packages/data/feature-flags.ts
+++ b/packages/data/feature-flags.ts
@@ -6,7 +6,6 @@ export enum FeatureFlag {
   NftGallery = 'nft-gallery',
   NftDetail = 'nft-detail',
   GatedLocales = 'gated-locales',
-  Polls = 'polls',
   Spaces = 'spaces',
   ForYou = 'for-you',
   WTF2 = 'wtf2',
@@ -28,10 +27,6 @@ export const featureFlags = [
   },
   {
     key: FeatureFlag.GatedLocales,
-    enabledFor: [...mainnetStaffs]
-  },
-  {
-    key: FeatureFlag.Polls,
     enabledFor: [...mainnetStaffs]
   },
   {


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5661742</samp>

Removed the `Polls` feature flag from the codebase and enabled the polls feature for all users. Simplified the `PollSettings` component to always render the poll settings.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5661742</samp>

*  Remove feature flag check and configuration for polls feature
  - Delete `Polls` enum value and object from `FeatureFlag` type and `featureFlags` array ([link](https://github.com/lensterxyz/lenster/pull/3245/files?diff=unified&w=0#diff-e06e181e3ef331e886fe8bfb4b664826e1a3ae2d1f22097dd7273c0e917c566eL9), [link](https://github.com/lensterxyz/lenster/pull/3245/files?diff=unified&w=0#diff-e06e181e3ef331e886fe8bfb4b664826e1a3ae2d1f22097dd7273c0e917c566eL34-L37))
  - Delete imports of `FeatureFlag` and `isFeatureEnabled` from `PollSettings` component ([link](https://github.com/lensterxyz/lenster/pull/3245/files?diff=unified&w=0#diff-60e3f5b80c2b77b36d4b19d49d0b67eadc64f7c8727c3f1c770435830bc956d0L2-L3))
  - Delete `isPollsEnabled` variable and conditional rendering of `PollSettings` component ([link](https://github.com/lensterxyz/lenster/pull/3245/files?diff=unified&w=0#diff-60e3f5b80c2b77b36d4b19d49d0b67eadc64f7c8727c3f1c770435830bc956d0L16-R14))

## Emoji

<!--
copilot:emoji
-->

🗑️🎉🖼️

<!--
1.  🗑️ - This emoji represents the removal of the feature flag logic and the `Polls` feature flag from the codebase, as they are no longer needed.
2.  🎉 - This emoji represents the celebration of the polls feature being fully launched and available to all users, without any restrictions or conditions.
3.  🖼️ - This emoji represents the rendering of the poll settings component, which allows users to customize their polls with various options and images.
-->
