### PR TITLE
feat: add more comments component

### DIFF
--- a/apps/web/src/components/Profile/MutualFollowers/index.tsx
+++ b/apps/web/src/components/Profile/MutualFollowers/index.tsx
@@ -47,7 +47,7 @@ const MutualFollowers: FC<MutualFollowersProps> = ({
       onClick={() => setShowMutualFollowersModal?.(true)}
       aria-hidden="true"
     >
-      <div className="contents -space-x-2">
+      <div className="contents -space-x-1.5">
         {profiles?.map((profile) => (
           <Image
             key={profile.handle}

--- a/apps/web/src/components/Publication/MoreComments.tsx
+++ b/apps/web/src/components/Publication/MoreComments.tsx
@@ -1,24 +1,9 @@
-import ActionType from '@components/Home/Timeline/EventType';
-import PublicationWrapper from '@components/Shared/PublicationWrapper';
-import type {
-  Comment,
-  ElectedMirror,
-  FeedItem,
-  Publication
-} from '@lenster/lens';
-import clsx from 'clsx';
-import type { FC, ReactNode } from 'react';
-
-import PublicationActions from './Actions';
-import ModAction from './Actions/ModAction';
-import HiddenPublication from './HiddenPublication';
-import PublicationBody from './PublicationBody';
-import PublicationHeader from './PublicationHeader';
-import PublicationType from './Type';
-import { Image } from '@lenster/ui';
+import type { Comment } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
+import { Image } from '@lenster/ui';
 import Link from 'next/link';
+import type { FC, ReactNode } from 'react';
 
 interface MoreCommentsProps {
   rootPublicationId: string;

--- a/apps/web/src/components/Publication/MoreComments.tsx
+++ b/apps/web/src/components/Publication/MoreComments.tsx
@@ -1,0 +1,33 @@
+import ActionType from '@components/Home/Timeline/EventType';
+import PublicationWrapper from '@components/Shared/PublicationWrapper';
+import type {
+  Comment,
+  ElectedMirror,
+  FeedItem,
+  Publication
+} from '@lenster/lens';
+import clsx from 'clsx';
+import type { FC } from 'react';
+
+import PublicationActions from './Actions';
+import ModAction from './Actions/ModAction';
+import HiddenPublication from './HiddenPublication';
+import PublicationBody from './PublicationBody';
+import PublicationHeader from './PublicationHeader';
+import PublicationType from './Type';
+
+interface MoreCommentsProps {
+  comments: Comment[];
+}
+
+const MoreComments: FC<MoreCommentsProps> = ({ comments }) => {
+  const hasMoreComments = comments.length > 1;
+
+  if (!hasMoreComments) {
+    return null;
+  }
+
+  return <div>gm</div>;
+};
+
+export default MoreComments;

--- a/apps/web/src/components/Publication/MoreComments.tsx
+++ b/apps/web/src/components/Publication/MoreComments.tsx
@@ -7,7 +7,7 @@ import type {
   Publication
 } from '@lenster/lens';
 import clsx from 'clsx';
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
 
 import PublicationActions from './Actions';
 import ModAction from './Actions/ModAction';
@@ -15,19 +15,89 @@ import HiddenPublication from './HiddenPublication';
 import PublicationBody from './PublicationBody';
 import PublicationHeader from './PublicationHeader';
 import PublicationType from './Type';
+import { Image } from '@lenster/ui';
+import formatHandle from '@lenster/lib/formatHandle';
+import getAvatar from '@lenster/lib/getAvatar';
+import Link from 'next/link';
 
 interface MoreCommentsProps {
+  rootPublicationId: string;
   comments: Comment[];
 }
 
-const MoreComments: FC<MoreCommentsProps> = ({ comments }) => {
+const MoreComments: FC<MoreCommentsProps> = ({
+  rootPublicationId,
+  comments
+}) => {
   const hasMoreComments = comments.length > 1;
+  const hasMoreThanThreeComments = comments.length > 3;
+  const firstComment = comments[0];
+  // get the first three comments and remove duplicate profiles based on profile id also make sure profile not in first comment
+  const firstThreeComments = comments
+    .slice(1, 4)
+    .filter((comment) => comment.profile.id !== firstComment.profile.id)
+    .filter(
+      (comment, index, self) =>
+        index === self.findIndex((c) => c.profile.id === comment.profile.id)
+    );
 
   if (!hasMoreComments) {
     return null;
   }
 
-  return <div>gm</div>;
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <Link
+      className="lt-text-gray-500 mt-3 flex cursor-pointer items-center space-x-2.5 text-sm hover:underline"
+      href={`/posts/${rootPublicationId}`}
+      aria-hidden="true"
+    >
+      <div className="contents -space-x-1.5">
+        {firstThreeComments?.map((comment) => (
+          <Image
+            key={comment.profile.handle}
+            className="h-5 w-5 rounded-full border dark:border-gray-700"
+            src={getAvatar(comment.profile)}
+            alt={formatHandle(comment.profile?.handle)}
+          />
+        ))}
+      </div>
+      <div>{children} also commented</div>
+    </Link>
+  );
+
+  const profileOne = firstThreeComments[0]?.profile;
+  const profileTwo = firstThreeComments[1]?.profile;
+  const profileThree = firstThreeComments[2]?.profile;
+
+  if (firstThreeComments?.length === 1) {
+    return (
+      <Wrapper>
+        <span>{profileOne?.name ?? formatHandle(profileOne?.handle)}</span>
+      </Wrapper>
+    );
+  }
+
+  if (firstThreeComments?.length === 2) {
+    return (
+      <Wrapper>
+        <span>{profileOne?.name ?? formatHandle(profileOne?.handle)} and </span>
+        <span>{profileTwo?.name ?? formatHandle(profileTwo?.handle)}</span>
+      </Wrapper>
+    );
+  }
+
+  if (firstThreeComments?.length === 3) {
+    return (
+      <Wrapper>
+        <span>{profileOne?.name ?? formatHandle(profileOne?.handle)}, </span>
+        <span>{profileTwo?.name ?? formatHandle(profileTwo?.handle)} and </span>
+        <span>{profileThree?.name ?? formatHandle(profileThree?.handle)} </span>
+        {!hasMoreThanThreeComments && <span>and others</span>}
+      </Wrapper>
+    );
+  }
+
+  return null;
 };
 
 export default MoreComments;

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -84,8 +84,11 @@ const SinglePublication: FC<SinglePublicationProps> = ({
             )}
           </>
         )}
+        <MoreComments
+          rootPublicationId={rootPublication.id}
+          comments={feedItem?.comments ?? []}
+        />
       </div>
-      <MoreComments comments={feedItem?.comments ?? []} />
     </PublicationWrapper>
   );
 };

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -7,10 +7,10 @@ import type { FC } from 'react';
 import PublicationActions from './Actions';
 import ModAction from './Actions/ModAction';
 import HiddenPublication from './HiddenPublication';
+import MoreComments from './MoreComments';
 import PublicationBody from './PublicationBody';
 import PublicationHeader from './PublicationHeader';
 import PublicationType from './Type';
-import MoreComments from './MoreComments';
 
 interface SinglePublicationProps {
   publication: Publication;

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -10,6 +10,7 @@ import HiddenPublication from './HiddenPublication';
 import PublicationBody from './PublicationBody';
 import PublicationHeader from './PublicationHeader';
 import PublicationType from './Type';
+import MoreComments from './MoreComments';
 
 interface SinglePublicationProps {
   publication: Publication;
@@ -84,6 +85,7 @@ const SinglePublication: FC<SinglePublicationProps> = ({
           </>
         )}
       </div>
+      <MoreComments comments={feedItem?.comments ?? []} />
     </PublicationWrapper>
   );
 };


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a3e6f0b</samp>

Added a new component `MoreComments` to the web app to enable loading more comments for a publication. The component is used in `SinglePublication.tsx` and returns a placeholder div for now.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a3e6f0b</samp>

*  Add a new component `MoreComments` to display more comments for a publication ([link](https://github.com/lensterxyz/lenster/pull/3269/files?diff=unified&w=0#diff-10a5aff781d79ead4645bd70a139395ced644904b80d19cf344b54b98028f163R1-R33))
*  Import and use the `MoreComments` component in the `SinglePublication` component, passing the `comments` prop from the `feedItem` state ([link](https://github.com/lensterxyz/lenster/pull/3269/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9R13), [link](https://github.com/lensterxyz/lenster/pull/3269/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9R88))
*  Update the `SinglePublication` component to render the `MoreComments` component after the publication actions ([link](https://github.com/lensterxyz/lenster/pull/3269/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9R88))

## Emoji

<!--
copilot:emoji
-->

🆕📦🗣️

<!--
1.  🆕 for adding a new component
2.  📦 for importing modules
3.  🗣️ for enhancing the comment feature
-->
