### PR TITLE
feat: add hasOwnedLensProfiles and check in endpoints

### DIFF
--- a/apps/web/src/components/Community/Details.tsx
+++ b/apps/web/src/components/Community/Details.tsx
@@ -88,7 +88,7 @@ const Details: FC<DetailsProps> = ({ community }) => {
       <div className="space-y-5">
         <Members community={community} />
         <div className="flex items-center space-x-2">
-          {currentProfile?.id === community?.profile ? (
+          {currentProfile?.id === community.admin ? (
             <Link href="/settings">
               <Button
                 variant="secondary"

--- a/packages/lib/hasOwnedLensProfiles.spec.ts
+++ b/packages/lib/hasOwnedLensProfiles.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+
+import hasOwnedLensProfiles from './hasOwnedLensProfiles';
+
+describe('hasOwnedLensProfiles', () => {
+  test('should return true if the ID has a lens profile', async () => {
+    expect(
+      await hasOwnedLensProfiles(
+        '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3',
+        '0x0d',
+        true
+      )
+    ).toBeTruthy();
+  });
+
+  test('should return false if the ID is not has a lens profile', async () => {
+    expect(
+      await hasOwnedLensProfiles(
+        '0x3A5bd1E37b099aE3386D13947b6a90d97675e5e3',
+        '0x05',
+        true
+      )
+    ).toBeFalsy();
+  });
+});

--- a/packages/lib/hasOwnedLensProfiles.ts
+++ b/packages/lib/hasOwnedLensProfiles.ts
@@ -1,0 +1,46 @@
+/**
+ * Get is lens profile owned by wallet address
+ * @param address Wallet address
+ * @param id Lens profile id
+ * @param isMainnet Is mainnet
+ * @returns is lens profile owned by wallet address or not
+ */
+const hasOwnedLensProfile = async (
+  address: string,
+  id: string,
+  isMainnet: boolean
+) => {
+  const response = await fetch(
+    isMainnet ? 'https://api.lens.dev' : 'https://api-mumbai.lens.dev',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-agent': 'Lenster'
+      },
+      body: JSON.stringify({
+        query: `
+          query Profiles {
+            profiles(request: {
+              ownedBy: "${address}"
+            }) {
+              items {
+                id
+              }
+            }
+          }
+        `
+      })
+    }
+  );
+
+  const json: { data: { profiles: { items: { id: string }[] } } } =
+    await response.json();
+
+  const ids = json.data.profiles.items.map((item) => item.id);
+  const hasOwned = ids.includes(id);
+
+  return hasOwned;
+};
+
+export default hasOwnedLensProfile;

--- a/packages/lib/validateLensAccount.ts
+++ b/packages/lib/validateLensAccount.ts
@@ -11,7 +11,7 @@ const validateLensAccount = async (accessToken: string, isMainnet: boolean) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'User-agent': 'Lenster-Snapshot-Relay'
+        'User-agent': 'Lenster'
       },
       body: JSON.stringify({
         query: `

--- a/packages/types/communities.d.ts
+++ b/packages/types/communities.d.ts
@@ -8,6 +8,6 @@ export interface Community {
   twitter?: string;
   website?: string;
   nsfw?: boolean;
-  admin?: string;
+  admin: string;
   created_at: string;
 }

--- a/packages/workers/communities/src/handlers/createCommunity.ts
+++ b/packages/workers/communities/src/handlers/createCommunity.ts
@@ -1,5 +1,7 @@
+import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import type { Community } from '@lenster/types/communities';
+import jwt from '@tsndr/cloudflare-worker-jwt';
 import { error, type IRequest } from 'itty-router';
 import { Client } from 'pg';
 import { object, string } from 'zod';
@@ -41,6 +43,14 @@ export default async (request: IRequest, env: Env) => {
     if (!isAuthenticated) {
       return new Response(
         JSON.stringify({ success: false, error: 'Invalid access token!' })
+      );
+    }
+
+    const { payload } = jwt.decode(accessToken);
+    const hasOwned = await hasOwnedLensProfiles(payload.id, admin, true);
+    if (!hasOwned) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid profile ID' })
       );
     }
 

--- a/packages/workers/communities/src/handlers/joinOrLeaveCommunity.ts
+++ b/packages/workers/communities/src/handlers/joinOrLeaveCommunity.ts
@@ -1,4 +1,6 @@
+import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
+import jwt from '@tsndr/cloudflare-worker-jwt';
 import { error, type IRequest } from 'itty-router';
 import { Client } from 'pg';
 import { boolean, object, string } from 'zod';
@@ -41,6 +43,14 @@ export default async (request: IRequest, env: Env) => {
     if (!isAuthenticated) {
       return new Response(
         JSON.stringify({ success: false, error: 'Invalid access token!' })
+      );
+    }
+
+    const { payload } = jwt.decode(accessToken);
+    const hasOwned = await hasOwnedLensProfiles(payload.id, profileId, true);
+    if (!hasOwned) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Invalid profile ID' })
       );
     }
 


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 96fdad2</samp>

This pull request adds profile ownership verification and validation to the community handlers in `packages/workers/communities`. It also enables users to change the community admin when updating a community, and fixes a user agent header in `packages/lib/validateLensAccount.ts`. These changes improve the security and functionality of the community features in Lenster.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 96fdad2</samp>

*  Validate profile ID ownership for community actions using `hasOwnedLensProfiles` function ([link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-5c393b9cc9eb8083d838428ef70e4997b2ea5bf2700c6f9e90dc52ddb1e21341R1-R46), [link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-b64e0022c19d9e22ee3532a944a93717b49ae0ae3448d7b7fd5f61fde44124aeL1-R4), [link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-b64e0022c19d9e22ee3532a944a93717b49ae0ae3448d7b7fd5f61fde44124aeR49-R56), [link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-b85400823e5ead8e74dc64effc22e0963a748a52b82ed4f16344b69b9b6003f6L1-R3), [link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-b85400823e5ead8e74dc64effc22e0963a748a52b82ed4f16344b69b9b6003f6R49-R56), [link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-70c43f410fca20c20cabc80a5ed35b548a0c490c8e13967e28d5703b877523b7L1-R4), [link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-70c43f410fca20c20cabc80a5ed35b548a0c490c8e13967e28d5703b877523b7R50-R57))
* Allow changing community admin ID when updating community settings ([link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-70c43f410fca20c20cabc80a5ed35b548a0c490c8e13967e28d5703b877523b7R21), [link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-70c43f410fca20c20cabc80a5ed35b548a0c490c8e13967e28d5703b877523b7L36-R39))
* Fix user agent header for lens API request in `validateLensAccount` function ([link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-3a7969565e41c2a15fb4aa3a8a8e6dea27fe19e2c21c5b8279759357467e50f1L14-R14))
* Check current profile ID against community admin ID in `Details` component ([link](https://github.com/lensterxyz/lenster/pull/3331/files?diff=unified&w=0#diff-3e2e5e60840c9ba471c574238faabb53824199be86cbe06d51d4beacec8f8a9aL91-R91))

## Emoji

<!--
copilot:emoji
-->

🔐🔄🛠️

<!--
1.  🔐 - This emoji represents the security and verification aspects of the changes, such as checking the ownership of the profile IDs and the access tokens.
2.  🔄 - This emoji represents the ability to change the admin of a community, which is a new feature that allows more flexibility and control for the community creators and members.
3.  🛠️ - This emoji represents the bug fixes and improvements made to the existing code, such as using a more appropriate user agent header and checking the current profile ID instead of the community profile ID.
-->
