### PR TITLE
feat: add mainnet and testnet support

### DIFF
--- a/apps/web/src/components/Community/New.tsx
+++ b/apps/web/src/components/Community/New.tsx
@@ -1,7 +1,11 @@
 import MetaTags from '@components/Common/MetaTags';
 import SettingsHelper from '@components/Shared/SettingsHelper';
 import { PlusIcon } from '@heroicons/react/outline';
-import { APP_NAME, COMMUNITIES_WORKER_URL } from '@lenster/data/constants';
+import {
+  APP_NAME,
+  COMMUNITIES_WORKER_URL,
+  IS_MAINNET
+} from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
 import { FeatureFlag } from '@lenster/data/feature-flags';
 import { Localstorage } from '@lenster/data/storage';
@@ -71,7 +75,8 @@ const NewCommunity: FC = () => {
           description,
           avatar: avatar || `https://avatar.tobi.sh/${slug}`,
           admin: currentProfile.id,
-          accessToken: localStorage.getItem(Localstorage.AccessToken)
+          accessToken: localStorage.getItem(Localstorage.AccessToken),
+          isMainnet: IS_MAINNET
         }
       });
 

--- a/apps/web/src/components/Shared/Community/JoinOrLeave.tsx
+++ b/apps/web/src/components/Shared/Community/JoinOrLeave.tsx
@@ -1,5 +1,5 @@
 import { UserAddIcon } from '@heroicons/react/outline';
-import { COMMUNITIES_WORKER_URL } from '@lenster/data/constants';
+import { COMMUNITIES_WORKER_URL, IS_MAINNET } from '@lenster/data/constants';
 import { Localstorage } from '@lenster/data/storage';
 import type { Community } from '@lenster/types/communities';
 import { Button, Spinner } from '@lenster/ui';
@@ -58,7 +58,8 @@ const JoinOrLeave: FC<JoinOrLeaveProps> = ({ community }) => {
         communityId: community.id,
         profileId: currentProfile.id,
         join: !isMember,
-        accessToken: localStorage.getItem(Localstorage.AccessToken)
+        accessToken: localStorage.getItem(Localstorage.AccessToken),
+        isMainnet: IS_MAINNET
       });
       setIsMember(!isMember);
       toast.success(

--- a/packages/workers/communities/src/handlers/post/updateCommunity.ts
+++ b/packages/workers/communities/src/handlers/post/updateCommunity.ts
@@ -4,12 +4,13 @@ import type { Community } from '@lenster/types/communities';
 import jwt from '@tsndr/cloudflare-worker-jwt';
 import { error, type IRequest } from 'itty-router';
 import { Client } from 'pg';
-import { object, string } from 'zod';
+import { boolean, object, string } from 'zod';
 
 import type { Env } from '../../types';
 
 type ExtensionRequest = Community & {
   accessToken: string;
+  isMainnet: boolean;
 };
 
 const validationSchema = object({
@@ -19,7 +20,8 @@ const validationSchema = object({
   description: string().optional().nullable(),
   image: string().optional().nullable(),
   admin: string(),
-  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/)
+  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/),
+  isMainnet: boolean()
 });
 
 export default async (request: IRequest, env: Env) => {
@@ -36,11 +38,11 @@ export default async (request: IRequest, env: Env) => {
     );
   }
 
-  const { id, name, slug, description, avatar, admin, accessToken } =
+  const { id, name, slug, description, avatar, admin, accessToken, isMainnet } =
     body as ExtensionRequest;
 
   try {
-    const isAuthenticated = await validateLensAccount(accessToken, true);
+    const isAuthenticated = await validateLensAccount(accessToken, isMainnet);
     if (!isAuthenticated) {
       return new Response(
         JSON.stringify({ success: false, error: 'Invalid access token!' })
@@ -48,7 +50,7 @@ export default async (request: IRequest, env: Env) => {
     }
 
     const { payload } = jwt.decode(accessToken);
-    const hasOwned = await hasOwnedLensProfiles(payload.id, admin, true);
+    const hasOwned = await hasOwnedLensProfiles(payload.id, admin, isMainnet);
     if (!hasOwned) {
       return new Response(
         JSON.stringify({ success: false, error: 'Invalid profile ID' })


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 742fc7f</samp>

Added support for creating and managing communities on both mainnet and testnet networks. Added a `isMainnet` flag to the web app and the workers' API calls to indicate the network type. Updated the validation, authentication, and ownership logic in the workers' handlers to use the `isMainnet` value.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 742fc7f</samp>

*  Add `isMainnet` property to the request body of various API calls to indicate whether the community is on the mainnet or the testnet ([link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-9680998145d629c4ae8c9a02f1711533c8fd4af0f05913c81bb55241e7d5f817L74-R79), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-39da916d764123038d58bec3046b7487e07bf7a98eda5a421c07e428117da9e9L61-R62), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-eef8e3748a3be065fa34e4defce5e7f0b009b2865a41e35b0cfeb65233432935R13), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-eef8e3748a3be065fa34e4defce5e7f0b009b2865a41e35b0cfeb65233432935L21-R23), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-9c26e8890db0a8cda217775a958070ba0251f5b762b5365e960d2b611da051d7R15), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-9c26e8890db0a8cda217775a958070ba0251f5b762b5365e960d2b611da051d7L21-R23), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-99e2c7f212a04d986af4f07d37318d6b00ea2da99fd81f58b262d361df11ca0aR14), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-99e2c7f212a04d986af4f07d37318d6b00ea2da99fd81f58b262d361df11ca0aL19-R21), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-ca08fc6130d7749a7c77259e44f752ec23c7c14fe22c0ccc21e1ab0c9a5adbe8R13), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-ca08fc6130d7749a7c77259e44f752ec23c7c14fe22c0ccc21e1ab0c9a5adbe8L22-R24))
* Import `IS_MAINNET` constant from `@lenster/data/constants` in the frontend components `NewCommunity` and `JoinOrLeave` to use the value from the environment variables ([link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-9680998145d629c4ae8c9a02f1711533c8fd4af0f05913c81bb55241e7d5f817L4-R8), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-39da916d764123038d58bec3046b7487e07bf7a98eda5a421c07e428117da9e9L2-R2))
* Import `boolean` function from `zod` in the backend handlers `createCommunity`, `staffPickCommunity`, and `updateCommunity` to validate the `isMainnet` property of the request body ([link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-eef8e3748a3be065fa34e4defce5e7f0b009b2865a41e35b0cfeb65233432935L7-R7), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-99e2c7f212a04d986af4f07d37318d6b00ea2da99fd81f58b262d361df11ca0aL6-R6), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-ca08fc6130d7749a7c77259e44f752ec23c7c14fe22c0ccc21e1ab0c9a5adbe8L7-R7))
* Destructure `isMainnet` property from the request body and pass it to the `validateLensAccount` function in the backend handlers `createCommunity`, `joinOrLeaveCommunity`, `staffPickCommunity`, and `updateCommunity` to check the authentication of the user based on the network ([link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-eef8e3748a3be065fa34e4defce5e7f0b009b2865a41e35b0cfeb65233432935L38-R44), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-9c26e8890db0a8cda217775a958070ba0251f5b762b5365e960d2b611da051d7L38-R44), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-99e2c7f212a04d986af4f07d37318d6b00ea2da99fd81f58b262d361df11ca0aL36-R41), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-ca08fc6130d7749a7c77259e44f752ec23c7c14fe22c0ccc21e1ab0c9a5adbe8L39-R45))
* Pass `isMainnet` property to the `hasOwnedLensProfiles` function in the backend handlers `createCommunity` and `updateCommunity` to check the ownership of the lens profiles based on the network ([link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-eef8e3748a3be065fa34e4defce5e7f0b009b2865a41e35b0cfeb65233432935L50-R52), [link](https://github.com/lensterxyz/lenster/pull/3340/files?diff=unified&w=0#diff-ca08fc6130d7749a7c77259e44f752ec23c7c14fe22c0ccc21e1ab0c9a5adbe8L51-R53))

## Emoji

<!--
copilot:emoji
-->

🌐🚩🔑

<!--
1.  🌐 - This emoji represents the concept of network type, which is the main feature added by these changes. It also suggests the global and diverse nature of the communities that can be created on the web app.
2.  🚩 - This emoji represents the flag that is used to indicate the network type when creating a new community. It also suggests the idea of marking or distinguishing different communities based on their network.
3.  🔑 - This emoji represents the authentication and ownership logic that is updated to support both mainnet and testnet communities. It also suggests the idea of security and access control for the web app.
-->
