### PR TITLE
feat: add rules to get community

### DIFF
--- a/apps/web/src/components/Community/Details.tsx
+++ b/apps/web/src/components/Community/Details.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react';
 import { useAppStore } from 'src/store/app';
 
 import Members from './Members';
+import Rules from './Rules';
 
 interface DetailsProps {
   community: Community;
@@ -168,6 +169,7 @@ const Details: FC<DetailsProps> = ({ community }) => {
             </MetaDetails>
           )}
         </div>
+        <Rules rules={community.rules} />
       </div>
     </div>
   );

--- a/apps/web/src/components/Community/Rules.tsx
+++ b/apps/web/src/components/Community/Rules.tsx
@@ -1,0 +1,37 @@
+import type { Rule } from '@lenster/types/communities';
+import type { FC } from 'react';
+
+interface RulesProps {
+  rules?: Rule[];
+}
+
+const Rules: FC<RulesProps> = ({ rules }) => {
+  if (!rules) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="divider w-full" />
+      <div className="space-y-5">
+        <div>
+          <div className="text-lg font-bold">Rules</div>
+          <div>These are set and enforced by Community admins</div>
+        </div>
+        {rules.map((rule, index) => (
+          <div key={rule.id} className="flex items-start space-x-2">
+            <div className="bg-brand-500 flex h-8 w-8 items-center justify-center rounded-full p-3 text-sm font-bold text-white">
+              {index + 1}
+            </div>
+            <div className="space-y-1">
+              <div className="font-bold">{rule.title}</div>
+              <div className="lt-text-gray-500 text-sm">{rule.description}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default Rules;

--- a/packages/types/communities.d.ts
+++ b/packages/types/communities.d.ts
@@ -1,3 +1,10 @@
+export interface Rule {
+  id: string;
+  title: string;
+  description: string;
+  created_at: string;
+}
+
 export interface Community {
   id: string;
   name: string;
@@ -10,4 +17,5 @@ export interface Community {
   nsfw?: boolean;
   admin: string;
   created_at: string;
+  rules?: Rule[];
 }

--- a/packages/workers/communities/src/handlers/get/getCommunity.ts
+++ b/packages/workers/communities/src/handlers/get/getCommunity.ts
@@ -16,20 +16,21 @@ export default async (identifier: string, type: 'id' | 'slug', env: Env) => {
       text: `
         SELECT
           c.*,
-          COALESCE(m.members_count, 0)::integer AS members_count
-        FROM
-          communities AS c
+          COALESCE(m.members_count, 0)::integer AS members_count,
+          (
+            SELECT json_agg(json_build_object('id', r.id, 'title', r.title, 'description', r.description))
+            FROM rules AS r
+            WHERE r.community_id = c.id
+          ) AS rules
+        FROM communities AS c
         LEFT JOIN (
           SELECT
             community_id,
             COUNT(profile_id) AS members_count
-          FROM
-            memberships
-          GROUP BY
-            community_id
+          FROM memberships
+          GROUP BY community_id
         ) AS m ON c.id = m.community_id
-        WHERE
-          ${type === 'id' ? 'c.id' : 'c.slug'} = $1;
+        WHERE ${type === 'id' ? 'c.id' : 'c.slug'} = $1;
       `,
       values: [identifier]
     };


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b07bf91</samp>

Added rules subquery to `getCommunity` handler. This allows the frontend to show the rules of each community on the community page.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b07bf91</samp>

*  Add a subquery to the SQL query for getting a community by id or slug that returns a JSON array of the community's rules ([link](https://github.com/lensterxyz/lenster/pull/3343/files?diff=unified&w=0#diff-6a9adf610b3e3cc5f56518cc6c9be5f74bc8c5c60d710a50d1ac85eb3f318b6cL19-R33)). This allows the frontend to display the rules of each community on the community page. The file `packages/workers/communities/src/handlers/get/getCommunity.ts` contains this change.

## Emoji

<!--
copilot:emoji
-->

📜🗃️🧩

<!--
1.  📜 This emoji represents the rules feature, which is a set of guidelines or expectations for the community members. The emoji can also suggest a document or a contract, which are related to rules or agreements.
2.  🗃️ This emoji represents the subquery, which is a nested query that produces a set of data to be used by the main query. The emoji can also suggest a database or a file, which are related to data storage or retrieval.
3.  🧩 This emoji represents the JSON array, which is a data format that consists of a collection of values or objects. The emoji can also suggest a puzzle or a piece of a larger picture, which are related to arrays or structures.
-->
