### PR TITLE
fix: use getRpc in ens worker

### DIFF
--- a/packages/workers/ens/package.json
+++ b/packages/workers/ens/package.json
@@ -15,6 +15,7 @@
     "worker:deploy": "wrangler deploy"
   },
   "dependencies": {
+    "@lenster/lib": "*",
     "itty-router": "^4.0.14",
     "viem": "^1.4.1",
     "zod": "^3.21.4"

--- a/packages/workers/ens/src/handlers/resolveEns.ts
+++ b/packages/workers/ens/src/handlers/resolveEns.ts
@@ -1,3 +1,4 @@
+import getRpc from '@lenster/lib/getRpc';
 import type { IRequest } from 'itty-router';
 import { error } from 'itty-router';
 import { createPublicClient, http } from 'viem';
@@ -35,7 +36,7 @@ export default async (request: IRequest) => {
   try {
     const client = createPublicClient({
       chain: mainnet,
-      transport: http('https://ethereum.rpc.thirdweb.com')
+      transport: http(getRpc(1))
     });
 
     const data = await client.readContract({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,6 +654,9 @@ importers:
 
   packages/workers/ens:
     dependencies:
+      '@lenster/lib':
+        specifier: '*'
+        version: link:../../lib
       itty-router:
         specifier: ^4.0.14
         version: 4.0.14


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6343afd</samp>

Refactor ENS resolution handler to use dynamic RPC URL from `@lenster/lib` package. Add `@lenster/lib` as a local dependency and update `pnpm-lock.yaml` file.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6343afd</samp>

*  Add dependency on local `@lenster/lib` package for Ethereum RPC utilities ([link](https://github.com/lensterxyz/lenster/pull/3356/files?diff=unified&w=0#diff-94b7382dd579ab991570594f6a56fd18c85d3df29ed745bf1bb7080da8405e01R18), [link](https://github.com/lensterxyz/lenster/pull/3356/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR657-R659))
*  Use `getRpc` function from `@lenster/lib` to dynamically get RPC URL for ENS resolution ([link](https://github.com/lensterxyz/lenster/pull/3356/files?diff=unified&w=0#diff-fb75a865c6222903097d986e3d928fa7a8853000d38f6326cde177d2dfdd45c4R1), [link](https://github.com/lensterxyz/lenster/pull/3356/files?diff=unified&w=0#diff-fb75a865c6222903097d986e3d928fa7a8853000d38f6326cde177d2dfdd45c4L38-R39))

## Emoji

<!--
copilot:emoji
-->

📦🔗♻️

<!--
1.  📦 - This emoji represents adding a new dependency or package, which is what the `@lenster/lib` package is.
2.  🔗 - This emoji represents linking or connecting something, which is what the `pnpm-lock.yaml` file does to enable the use of the local package.
3.  ♻️ - This emoji represents refactoring or improving code, which is what the ENS resolution handler does by using a dynamic RPC URL.
-->
