### PR TITLE
refactor: workers data

### DIFF
--- a/apps/web/src/components/Composer/Actions/Attachment.tsx
+++ b/apps/web/src/components/Composer/Actions/Attachment.tsx
@@ -72,8 +72,7 @@ const Attachment: FC = () => {
       } else {
         return toast.error(t`File format not allowed.`);
       }
-    } catch (error) {
-      console.error('Failed to upload attachments', error);
+    } catch {
       toast.error(t`Something went wrong while uploading!`);
     }
   };

--- a/apps/web/src/components/Composer/ChooseThumbnail.tsx
+++ b/apps/web/src/components/Composer/ChooseThumbnail.tsx
@@ -94,9 +94,7 @@ const ChooseThumbnail: FC = () => {
       }
       setThumbnails(thumbnailList);
       setSelectedThumbnailIndex(DEFAULT_THUMBNAIL_INDEX);
-    } catch (error) {
-      console.error('Failed to generate thumbnails', error);
-    }
+    } catch {}
   };
 
   useUpdateEffect(() => {
@@ -131,8 +129,7 @@ const ChooseThumbnail: FC = () => {
           ...thumbnails
         ]);
         setSelectedThumbnailIndex(0);
-      } catch (error) {
-        console.error('Failed to upload thumbnail', error);
+      } catch {
         toast.error(t`Failed to upload thumbnail`);
       } finally {
         setImageUploading(false);

--- a/apps/web/src/components/Shared/Lexical/withLexicalContext.tsx
+++ b/apps/web/src/components/Shared/Lexical/withLexicalContext.tsx
@@ -27,9 +27,7 @@ const initialConfig = {
     EmojiNode
   ],
   editorState: null,
-  onError: (error: Error) => {
-    console.error(error);
-  }
+  onError: () => {}
 };
 
 const withLexicalContext = (Component: FC<any>) => {

--- a/apps/web/src/components/Shared/Login/WalletSelector.tsx
+++ b/apps/web/src/components/Shared/Login/WalletSelector.tsx
@@ -75,9 +75,7 @@ const WalletSelector: FC<WalletSelectorProps> = ({
       Leafwatch.track(AUTH.CONNECT_WALLET, {
         wallet: connector.name.toLowerCase()
       });
-    } catch (error) {
-      console.error(error);
-    }
+    } catch {}
   };
 
   const handleSign = async () => {
@@ -132,8 +130,7 @@ const WalletSelector: FC<WalletSelectorProps> = ({
         setProfileId(currentProfile.id);
       }
       Leafwatch.track(AUTH.SIWL);
-    } catch (error) {
-      console.error(error);
+    } catch {
     } finally {
       setIsLoading(false);
       if (!keepModal) {

--- a/apps/web/src/components/Shared/Snapshot/Choices.tsx
+++ b/apps/web/src/components/Shared/Snapshot/Choices.tsx
@@ -125,8 +125,7 @@ const Choices: FC<ChoicesProps> = ({
         proposal_source: APP_NAME.toLowerCase()
       });
       toast.success(t`Your vote has been casted!`);
-    } catch (error) {
-      console.error('Failed to vote on snapshot', error);
+    } catch {
       toast.error(Errors.SomethingWentWrong);
     } finally {
       setVoteSubmitting(false);

--- a/apps/web/src/components/Shared/Snapshot/VoteProposal.tsx
+++ b/apps/web/src/components/Shared/Snapshot/VoteProposal.tsx
@@ -101,8 +101,7 @@ const VoteProposal: FC<VoteProposalProps> = ({
         proposal_id: id,
         proposal_source: 'snapshot'
       });
-    } catch (error) {
-      console.error('Failed to vote on snapshot proposal', error);
+    } catch {
       toast.error(Errors.SomethingWentWrong);
     } finally {
       setVoteSubmitting(false);

--- a/apps/web/src/components/utils/hooks/useSendOptimisticMessage.tsx
+++ b/apps/web/src/components/utils/hooks/useSendOptimisticMessage.tsx
@@ -202,9 +202,7 @@ const useSendOptimisticMessage = (
     try {
       // send prepared message
       await prepared.send();
-    } catch (error) {
-      console.error('Failed to send message', error);
-
+    } catch {
       // update message externally
       options?.onUpdate?.(id, {
         status: 'failed',

--- a/apps/web/src/components/utils/hooks/useUploadAttachments.tsx
+++ b/apps/web/src/components/utils/hooks/useUploadAttachments.tsx
@@ -84,8 +84,7 @@ const useUploadAttachments = () => {
           );
           updateAttachments(attachmentsIPFS);
         }
-      } catch (error) {
-        console.error('Failed to upload attachments', error);
+      } catch {
         removeAttachments(attachmentIds);
         toast.error(t`Something went wrong while uploading!`);
       }

--- a/apps/web/src/lib/getCoingeckoPrice.ts
+++ b/apps/web/src/lib/getCoingeckoPrice.ts
@@ -19,8 +19,7 @@ const getCoingeckoPrice = async (address: string) => {
     );
 
     return response.data[address].usd;
-  } catch (error) {
-    console.error('Failed to get price from Coingecko API', error);
+  } catch {
     return 0;
   }
 };

--- a/apps/web/src/lib/uploadToArweave.ts
+++ b/apps/web/src/lib/uploadToArweave.ts
@@ -23,8 +23,7 @@ const uploadToArweave = async (data: any): Promise<string> => {
     const { id }: { id: string } = upload?.data;
 
     return id;
-  } catch (error) {
-    console.error('Failed to upload to Arweave', error);
+  } catch {
     toast.error(Errors.SomethingWentWrong);
     throw new Error(Errors.SomethingWentWrong);
   }

--- a/apps/web/src/lib/uploadToIPFS.ts
+++ b/apps/web/src/lib/uploadToIPFS.ts
@@ -106,8 +106,7 @@ export const uploadFileToIPFS = async (
         mimeType: file.type || FALLBACK_TYPE
       }
     };
-  } catch (error) {
-    console.error('Failed to upload file to IPFS', error);
+  } catch {
     return { original: { url: '', mimeType: file.type || FALLBACK_TYPE } };
   }
 };

--- a/packages/data/errors.ts
+++ b/packages/data/errors.ts
@@ -1,4 +1,9 @@
 export enum Errors {
   SomethingWentWrong = 'Something went wrong!',
-  SignWallet = 'Please sign in your wallet.'
+  SignWallet = 'Please sign in your wallet.',
+  StatusCodeIsNot200 = 'Status code is not 200!',
+  InvalidAccesstoken = 'Invalid access token!',
+  InvalidProfileId = 'Invalid profile id!',
+  NotACommunityAdmin = 'Not a community admin!',
+  NotAStaff = 'Not a staff!'
 }

--- a/packages/data/regex.ts
+++ b/packages/data/regex.ts
@@ -10,5 +10,6 @@ export const Regex = {
   santiizeHandle: /[^\d .A-Za-z]/g,
   profileNameValidator: new RegExp('^[^' + RESTRICTED_SYMBOLS + ']+$'),
   profileNameFilter: new RegExp('[' + RESTRICTED_SYMBOLS + ']', 'gu'),
-  gm: /\bgm\b/i
+  gm: /\bgm\b/i,
+  accessToken: /^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/
 };

--- a/packages/lens/apollo/lib/parseJwt.ts
+++ b/packages/lens/apollo/lib/parseJwt.ts
@@ -23,8 +23,7 @@ const parseJwt = (
 } => {
   try {
     return JSON.parse(decoded(token.split('.')[1]));
-  } catch (error) {
-    console.error('Failed to parse JWT', error);
+  } catch {
     return {
       id: '',
       role: '',

--- a/packages/lib/getSnapshotProposalId.ts
+++ b/packages/lib/getSnapshotProposalId.ts
@@ -21,8 +21,7 @@ const getSnapshotProposalId = (url: string[]): string | null => {
     const proposalId = parsedUrl.hash.match(/\/proposal\/(0x[\dA-Fa-f]{64})/);
 
     return proposalId?.[1] || null;
-  } catch (error) {
-    console.error('Failed to parse Snapshot URL', error);
+  } catch {
     return null;
   }
 };

--- a/packages/workers/achievements/src/handlers/hasUsedLenster.ts
+++ b/packages/workers/achievements/src/handlers/hasUsedLenster.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import { error } from 'itty-router';
 
 import type { Env } from '../types';
@@ -20,7 +21,7 @@ export default async (id: string, env: Env) => {
 
     if (clickhouseResponse.status !== 200) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Status code is not 200!' })
+        JSON.stringify({ success: false, error: Errors.StatusCodeIsNot200 })
       );
     }
 
@@ -39,9 +40,7 @@ export default async (id: string, env: Env) => {
     response.headers.set('Cache-Control', 'max-age=600');
 
     return response;
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/achievements/src/handlers/hasUsedLenster.ts
+++ b/packages/workers/achievements/src/handlers/hasUsedLenster.ts
@@ -39,8 +39,7 @@ export default async (id: string, env: Env) => {
     response.headers.set('Cache-Control', 'max-age=600');
 
     return response;
-  } catch (error) {
-    console.error('Failed to get hasUsedLenster', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/achievements/src/handlers/streaksCalendar.ts
+++ b/packages/workers/achievements/src/handlers/streaksCalendar.ts
@@ -55,8 +55,7 @@ export default async (id: string, env: Env) => {
     response.headers.set('Cache-Control', 'max-age=600');
 
     return response;
-  } catch (error) {
-    console.error('Failed to get streaksCalendar', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/achievements/src/handlers/streaksCalendar.ts
+++ b/packages/workers/achievements/src/handlers/streaksCalendar.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import { error } from 'itty-router';
 
 import filteredEvents from '../helpers/filteredNames';
@@ -31,7 +32,7 @@ export default async (id: string, env: Env) => {
 
     if (clickhouseResponse.status !== 200) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Status code is not 200!' })
+        JSON.stringify({ success: false, error: Errors.StatusCodeIsNot200 })
       );
     }
 
@@ -55,9 +56,7 @@ export default async (id: string, env: Env) => {
     response.headers.set('Cache-Control', 'max-age=600');
 
     return response;
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/achievements/src/handlers/streaksList.ts
+++ b/packages/workers/achievements/src/handlers/streaksList.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import { error } from 'itty-router';
 
 import filteredEvents from '../helpers/filteredNames';
@@ -44,7 +45,7 @@ export default async (id: string, date: string, env: Env) => {
 
     if (clickhouseResponse.status !== 200) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Status code is not 200!' })
+        JSON.stringify({ success: false, error: Errors.StatusCodeIsNot200 })
       );
     }
 
@@ -69,9 +70,7 @@ export default async (id: string, date: string, env: Env) => {
     response.headers.set('Cache-Control', 'max-age=600');
 
     return response;
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/achievements/src/handlers/streaksList.ts
+++ b/packages/workers/achievements/src/handlers/streaksList.ts
@@ -69,8 +69,7 @@ export default async (id: string, date: string, env: Env) => {
     response.headers.set('Cache-Control', 'max-age=600');
 
     return response;
-  } catch (error) {
-    console.error('Failed to get streaksList', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/achievements/src/index.ts
+++ b/packages/workers/achievements/src/index.ts
@@ -34,8 +34,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/communities/src/handlers/post/community/createOrUpdate.ts
+++ b/packages/workers/communities/src/handlers/post/community/createOrUpdate.ts
@@ -1,4 +1,5 @@
 import { Errors } from '@lenster/data/errors';
+import { Regex } from '@lenster/data/regex';
 import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import type { Community } from '@lenster/types/communities';
@@ -25,7 +26,7 @@ const validationSchema = object({
   twitter: string().optional().nullable(),
   website: string().optional().nullable(),
   profileId: string(),
-  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/),
+  accessToken: string().regex(Regex.accessToken),
   isMainnet: boolean()
 });
 

--- a/packages/workers/communities/src/handlers/post/community/createOrUpdate.ts
+++ b/packages/workers/communities/src/handlers/post/community/createOrUpdate.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import type { Community } from '@lenster/types/communities';
@@ -60,7 +61,7 @@ export default async (request: IRequest, env: Env) => {
     const isAuthenticated = await validateLensAccount(accessToken, isMainnet);
     if (!isAuthenticated) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid access token!' })
+        JSON.stringify({ success: false, error: Errors.InvalidAccesstoken })
       );
     }
 
@@ -72,7 +73,7 @@ export default async (request: IRequest, env: Env) => {
     );
     if (!hasOwned) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid profile ID' })
+        JSON.stringify({ success: false, error: Errors.InvalidProfileId })
       );
     }
 

--- a/packages/workers/communities/src/handlers/post/community/joinOrLeave.ts
+++ b/packages/workers/communities/src/handlers/post/community/joinOrLeave.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import jwt from '@tsndr/cloudflare-worker-jwt';
@@ -44,7 +45,7 @@ export default async (request: IRequest, env: Env) => {
     const isAuthenticated = await validateLensAccount(accessToken, isMainnet);
     if (!isAuthenticated) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid access token!' })
+        JSON.stringify({ success: false, error: Errors.InvalidAccesstoken })
       );
     }
 
@@ -56,7 +57,7 @@ export default async (request: IRequest, env: Env) => {
     );
     if (!hasOwned) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid profile ID' })
+        JSON.stringify({ success: false, error: Errors.InvalidProfileId })
       );
     }
 

--- a/packages/workers/communities/src/handlers/post/community/joinOrLeave.ts
+++ b/packages/workers/communities/src/handlers/post/community/joinOrLeave.ts
@@ -1,4 +1,5 @@
 import { Errors } from '@lenster/data/errors';
+import { Regex } from '@lenster/data/regex';
 import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import jwt from '@tsndr/cloudflare-worker-jwt';
@@ -20,7 +21,7 @@ const validationSchema = object({
   communityId: string().uuid(),
   profileId: string(),
   join: boolean(),
-  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/),
+  accessToken: string().regex(Regex.accessToken),
   isMainnet: boolean()
 });
 

--- a/packages/workers/communities/src/handlers/post/rule/createOrUpdate.ts
+++ b/packages/workers/communities/src/handlers/post/rule/createOrUpdate.ts
@@ -1,4 +1,5 @@
 import { Errors } from '@lenster/data/errors';
+import { Regex } from '@lenster/data/regex';
 import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import type { Rule } from '@lenster/types/communities';
@@ -23,7 +24,7 @@ const validationSchema = object({
   description: string().min(1, { message: 'Description is required!' }),
   communityId: string().uuid(),
   profileId: string(),
-  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/),
+  accessToken: string().regex(Regex.accessToken),
   isMainnet: boolean()
 });
 

--- a/packages/workers/communities/src/handlers/post/rule/createOrUpdate.ts
+++ b/packages/workers/communities/src/handlers/post/rule/createOrUpdate.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import type { Rule } from '@lenster/types/communities';
@@ -54,7 +55,7 @@ export default async (request: IRequest, env: Env) => {
     const isAuthenticated = await validateLensAccount(accessToken, isMainnet);
     if (!isAuthenticated) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid access token!' })
+        JSON.stringify({ success: false, error: Errors.InvalidAccesstoken })
       );
     }
 
@@ -66,14 +67,14 @@ export default async (request: IRequest, env: Env) => {
     );
     if (!hasOwned) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid profile ID' })
+        JSON.stringify({ success: false, error: Errors.InvalidProfileId })
       );
     }
 
     const isAdmin = await isCommunityAdmin(env, profileId, communityId);
     if (!isAdmin) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Not a community admin!' })
+        JSON.stringify({ success: false, error: Errors.NotACommunityAdmin })
       );
     }
 

--- a/packages/workers/communities/src/handlers/post/rule/delete.ts
+++ b/packages/workers/communities/src/handlers/post/rule/delete.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import type { Rule } from '@lenster/types/communities';
@@ -45,7 +46,7 @@ export default async (request: IRequest, env: Env) => {
     const isAuthenticated = await validateLensAccount(accessToken, isMainnet);
     if (!isAuthenticated) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid access token!' })
+        JSON.stringify({ success: false, error: Errors.InvalidAccesstoken })
       );
     }
 
@@ -57,14 +58,14 @@ export default async (request: IRequest, env: Env) => {
     );
     if (!hasOwned) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid profile ID' })
+        JSON.stringify({ success: false, error: Errors.InvalidProfileId })
       );
     }
 
     const isAdmin = await isCommunityAdmin(env, profileId, communityId);
     if (!isAdmin) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Not a community admin!' })
+        JSON.stringify({ success: false, error: Errors.NotACommunityAdmin })
       );
     }
 

--- a/packages/workers/communities/src/handlers/post/rule/delete.ts
+++ b/packages/workers/communities/src/handlers/post/rule/delete.ts
@@ -1,4 +1,5 @@
 import { Errors } from '@lenster/data/errors';
+import { Regex } from '@lenster/data/regex';
 import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import type { Rule } from '@lenster/types/communities';
@@ -21,7 +22,7 @@ const validationSchema = object({
   id: string().uuid().optional().nullable(),
   communityId: string().uuid(),
   profileId: string(),
-  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/),
+  accessToken: string().regex(Regex.accessToken),
   isMainnet: boolean()
 });
 

--- a/packages/workers/communities/src/handlers/post/staff/staffPick.ts
+++ b/packages/workers/communities/src/handlers/post/staff/staffPick.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import { adminAddresses } from '@lenster/data/staffs';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import jwt from '@tsndr/cloudflare-worker-jwt';
@@ -41,7 +42,7 @@ export default async (request: IRequest, env: Env) => {
     const isAuthenticated = await validateLensAccount(accessToken, isMainnet);
     if (!isAuthenticated) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid access token!' })
+        JSON.stringify({ success: false, error: Errors.InvalidAccesstoken })
       );
     }
 
@@ -49,7 +50,7 @@ export default async (request: IRequest, env: Env) => {
 
     if (!adminAddresses.includes(payload.id)) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Unauthorized!' })
+        JSON.stringify({ success: false, error: Errors.NotAStaff })
       );
     }
 

--- a/packages/workers/communities/src/handlers/post/staff/staffPick.ts
+++ b/packages/workers/communities/src/handlers/post/staff/staffPick.ts
@@ -1,4 +1,5 @@
 import { Errors } from '@lenster/data/errors';
+import { Regex } from '@lenster/data/regex';
 import { adminAddresses } from '@lenster/data/staffs';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import jwt from '@tsndr/cloudflare-worker-jwt';
@@ -18,7 +19,7 @@ type ExtensionRequest = {
 const validationSchema = object({
   id: string().uuid(),
   type: string().regex(/^(add|remove)$/),
-  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/),
+  accessToken: string().regex(Regex.accessToken),
   isMainnet: boolean()
 });
 

--- a/packages/workers/communities/src/index.ts
+++ b/packages/workers/communities/src/index.ts
@@ -64,8 +64,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/ens/src/handlers/resolveEns.ts
+++ b/packages/workers/ens/src/handlers/resolveEns.ts
@@ -47,8 +47,7 @@ export default async (request: IRequest) => {
     });
 
     return new Response(JSON.stringify({ success: true, data }));
-  } catch (error) {
-    console.error('Failed to resolve ENS', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/ens/src/handlers/resolveEns.ts
+++ b/packages/workers/ens/src/handlers/resolveEns.ts
@@ -47,9 +47,7 @@ export default async (request: IRequest) => {
     });
 
     return new Response(JSON.stringify({ success: true, data }));
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/ens/src/index.ts
+++ b/packages/workers/ens/src/index.ts
@@ -19,8 +19,7 @@ const routerHandleStack = (request: Request, ctx: ExecutionContext) =>
 const handleFetch = async (request: Request, ctx: ExecutionContext) => {
   try {
     return await routerHandleStack(request, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/freshdesk/src/index.ts
+++ b/packages/workers/freshdesk/src/index.ts
@@ -51,8 +51,7 @@ const handleRequest = async (request: Request, env: EnvType) => {
     return new Response(JSON.stringify({ success: true }), {
       headers
     });
-  } catch (error) {
-    console.error('Failed to send email', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, message: 'Something went wrong!' }),
       { headers }

--- a/packages/workers/invite/src/handlers/invite.ts
+++ b/packages/workers/invite/src/handlers/invite.ts
@@ -67,9 +67,7 @@ export default async (request: IRequest, env: Env) => {
         data: inviteResponse
       })
     );
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/invite/src/handlers/invite.ts
+++ b/packages/workers/invite/src/handlers/invite.ts
@@ -1,4 +1,5 @@
 import { LensEndpoint } from '@lenster/data/lens-endpoints';
+import { Regex } from '@lenster/data/regex';
 import type { IRequest } from 'itty-router';
 import { error } from 'itty-router';
 import { boolean, object, string } from 'zod';
@@ -13,7 +14,7 @@ type ExtensionRequest = {
 
 const validationSchema = object({
   addresses: string().array(),
-  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/),
+  accessToken: string().regex(Regex.accessToken),
   isMainnet: boolean()
 });
 

--- a/packages/workers/invite/src/index.ts
+++ b/packages/workers/invite/src/index.ts
@@ -24,8 +24,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/leafwatch/src/handlers/ingest.ts
+++ b/packages/workers/leafwatch/src/handlers/ingest.ts
@@ -68,9 +68,7 @@ export default async (request: IRequest, env: Env) => {
         `https://pro.ip-api.com/json/${ip}?key=${env.IPAPI_KEY}`
       );
       ipData = await ipResponse.json();
-    } catch (error) {
-      console.error('Failed to get IP data', error);
-    }
+    } catch {}
 
     // Extract UTM parameters
     const parsedUrl = new URL(url);
@@ -133,8 +131,7 @@ export default async (request: IRequest, env: Env) => {
     }
 
     return new Response(JSON.stringify({ success: true }));
-  } catch (error) {
-    console.error('Failed to ingest', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/leafwatch/src/handlers/ingest.ts
+++ b/packages/workers/leafwatch/src/handlers/ingest.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import { ALL_EVENTS } from '@lenster/data/tracking';
 import type { IRequest } from 'itty-router';
 import { error } from 'itty-router';
@@ -126,14 +127,12 @@ export default async (request: IRequest, env: Env) => {
 
     if (response.status !== 200) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Status code is not 200!' })
+        JSON.stringify({ success: false, error: Errors.StatusCodeIsNot200 })
       );
     }
 
     return new Response(JSON.stringify({ success: true }));
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/leafwatch/src/index.ts
+++ b/packages/workers/leafwatch/src/index.ts
@@ -24,8 +24,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/metadata/src/handlers/postMetadata.ts
+++ b/packages/workers/metadata/src/handlers/postMetadata.ts
@@ -62,9 +62,7 @@ export default async (request: IRequest, env: Env) => {
         JSON.stringify({ success: false, message: 'Bundlr error!', bundlrRes })
       );
     }
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/metadata/src/handlers/postMetadata.ts
+++ b/packages/workers/metadata/src/handlers/postMetadata.ts
@@ -36,9 +36,7 @@ export default async (request: IRequest, env: Env) => {
         if (localeResponse.locale) {
           payload.locale = localeResponse.locale;
         }
-      } catch (error) {
-        console.error('Failed to fetch AI data', error);
-      }
+      } catch {}
     }
 
     const tx = createData(JSON.stringify(payload), signer, {
@@ -64,8 +62,7 @@ export default async (request: IRequest, env: Env) => {
         JSON.stringify({ success: false, message: 'Bundlr error!', bundlrRes })
       );
     }
-  } catch (error) {
-    console.error('Failed to create metadata data', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/metadata/src/index.ts
+++ b/packages/workers/metadata/src/index.ts
@@ -24,8 +24,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/oembed/src/handlers/getImage.ts
+++ b/packages/workers/oembed/src/handlers/getImage.ts
@@ -22,9 +22,7 @@ export default async (request: IRequest, env: Env) => {
     );
 
     return new Response(image.body);
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/oembed/src/handlers/getImage.ts
+++ b/packages/workers/oembed/src/handlers/getImage.ts
@@ -22,8 +22,7 @@ export default async (request: IRequest, env: Env) => {
     );
 
     return new Response(image.body);
-  } catch (error) {
-    console.error('Failed to get oembed data', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/oembed/src/handlers/getOembed.ts
+++ b/packages/workers/oembed/src/handlers/getOembed.ts
@@ -9,9 +9,7 @@ export default async (request: IRequest, env: Env) => {
     const data = await getMetadata(url as string, env);
 
     return new Response(JSON.stringify({ success: true, oembed: data }));
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/oembed/src/handlers/getOembed.ts
+++ b/packages/workers/oembed/src/handlers/getOembed.ts
@@ -9,8 +9,7 @@ export default async (request: IRequest, env: Env) => {
     const data = await getMetadata(url as string, env);
 
     return new Response(JSON.stringify({ success: true, oembed: data }));
-  } catch (error) {
-    console.error('Failed to get oembed data', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/oembed/src/index.ts
+++ b/packages/workers/oembed/src/index.ts
@@ -25,8 +25,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/snapshot-relay/src/handlers/createPoll.ts
+++ b/packages/workers/snapshot-relay/src/handlers/createPoll.ts
@@ -138,8 +138,7 @@ export default async (request: IRequest, env: Env) => {
         snapshotUrl: `${snapshotUrl}/#/${LENSTER_POLLS_SPACE}/proposal/${snapshotResponse.id}`
       })
     );
-  } catch (error) {
-    console.error('Failed to create poll', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/snapshot-relay/src/handlers/createPoll.ts
+++ b/packages/workers/snapshot-relay/src/handlers/createPoll.ts
@@ -138,9 +138,7 @@ export default async (request: IRequest, env: Env) => {
         snapshotUrl: `${snapshotUrl}/#/${LENSTER_POLLS_SPACE}/proposal/${snapshotResponse.id}`
       })
     );
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/snapshot-relay/src/index.ts
+++ b/packages/workers/snapshot-relay/src/index.ts
@@ -24,8 +24,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/spaces/package.json
+++ b/packages/workers/spaces/package.json
@@ -13,6 +13,7 @@
     "worker:deploy": "wrangler deploy"
   },
   "dependencies": {
+    "@lenster/data": "*",
     "@lenster/lib": "*",
     "@tsndr/cloudflare-worker-jwt": "^2.2.1",
     "itty-router": "^4.0.14",

--- a/packages/workers/spaces/src/handlers/createSpace.ts
+++ b/packages/workers/spaces/src/handlers/createSpace.ts
@@ -1,4 +1,5 @@
 import { Errors } from '@lenster/data/errors';
+import { Regex } from '@lenster/data/regex';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import jwt from '@tsndr/cloudflare-worker-jwt';
 import type { IRequest } from 'itty-router';
@@ -18,7 +19,7 @@ type CreateRoomResponse = {
 };
 
 const validationSchema = object({
-  accessToken: string().regex(/^([\w=]+)\.([\w=]+)\.([\w+/=\-]*)/),
+  accessToken: string().regex(Regex.accessToken),
   isMainnet: boolean()
 });
 

--- a/packages/workers/spaces/src/handlers/createSpace.ts
+++ b/packages/workers/spaces/src/handlers/createSpace.ts
@@ -75,8 +75,7 @@ export default async (request: IRequest, env: Env) => {
         spaceId: createRoomResponse.data.roomId
       })
     );
-  } catch (error) {
-    console.error('Failed to create space', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/spaces/src/handlers/createSpace.ts
+++ b/packages/workers/spaces/src/handlers/createSpace.ts
@@ -1,3 +1,4 @@
+import { Errors } from '@lenster/data/errors';
 import validateLensAccount from '@lenster/lib/validateLensAccount';
 import jwt from '@tsndr/cloudflare-worker-jwt';
 import type { IRequest } from 'itty-router';
@@ -41,7 +42,7 @@ export default async (request: IRequest, env: Env) => {
     const isAuthenticated = await validateLensAccount(accessToken, isMainnet);
     if (!isAuthenticated) {
       return new Response(
-        JSON.stringify({ success: false, error: 'Invalid access token!' })
+        JSON.stringify({ success: false, error: Errors.InvalidAccesstoken })
       );
     }
 
@@ -75,9 +76,7 @@ export default async (request: IRequest, env: Env) => {
         spaceId: createRoomResponse.data.roomId
       })
     );
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/spaces/src/handlers/isLive.ts
+++ b/packages/workers/spaces/src/handlers/isLive.ts
@@ -25,8 +25,7 @@ export default async (spaceId: string, env: Env) => {
         isLive: isLiveResponse.roomId === spaceId
       })
     );
-  } catch (error) {
-    console.error('Failed to get room isLive', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/spaces/src/handlers/isLive.ts
+++ b/packages/workers/spaces/src/handlers/isLive.ts
@@ -25,9 +25,7 @@ export default async (spaceId: string, env: Env) => {
         isLive: isLiveResponse.roomId === spaceId
       })
     );
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/spaces/src/index.ts
+++ b/packages/workers/spaces/src/index.ts
@@ -28,8 +28,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/packages/workers/sts-generator/src/handlers/getStsToken.ts
+++ b/packages/workers/sts-generator/src/handlers/getStsToken.ts
@@ -53,9 +53,7 @@ export default async (_request: IRequest, env: Env) => {
         sessionToken: credentials?.SessionToken
       })
     );
-  } catch {
-    return new Response(
-      JSON.stringify({ success: false, error: 'Something went wrong!' })
-    );
+  } catch (error) {
+    throw error;
   }
 };

--- a/packages/workers/sts-generator/src/handlers/getStsToken.ts
+++ b/packages/workers/sts-generator/src/handlers/getStsToken.ts
@@ -53,8 +53,7 @@ export default async (_request: IRequest, env: Env) => {
         sessionToken: credentials?.SessionToken
       })
     );
-  } catch (error) {
-    console.error('Failed to get STS data', error);
+  } catch {
     return new Response(
       JSON.stringify({ success: false, error: 'Something went wrong!' })
     );

--- a/packages/workers/sts-generator/src/index.ts
+++ b/packages/workers/sts-generator/src/index.ts
@@ -23,8 +23,7 @@ const handleFetch = async (
 ) => {
   try {
     return await routerHandleStack(request, env, ctx);
-  } catch (error_) {
-    console.error('Failed to handle request', error_);
+  } catch {
     return error(500);
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -864,6 +864,9 @@ importers:
 
   packages/workers/spaces:
     dependencies:
+      '@lenster/data':
+        specifier: '*'
+        version: link:../../data
       '@lenster/lib':
         specifier: '*'
         version: link:../../lib


### PR DESCRIPTION
- chore: remove console errors
- chore: refactor all errors in workers
- feat: add accessToken regex

## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbb39c0</samp>

This pull request removes redundant and unnecessary `console.error` statements from various components, hooks, and functions. It also improves error handling and messaging by using a common `Errors` enum and regular expressions. These changes aim to enhance the code quality, readability, and consistency.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dbb39c0</samp>

*  Removed redundant and unnecessary `console.error` statements from various components, hooks, functions, and handlers, as the errors are already handled or displayed to the user in other ways ([link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-dc7f47a750043dfcca0d0bca34caa131ec068b8537fbe5ba40dd64efcb5718ceL75-R75), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-54b5b2bd5aae2ded964da8918986b46a8ab55c56506e5712b177ec3cf6dfa046L97-R97), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-54b5b2bd5aae2ded964da8918986b46a8ab55c56506e5712b177ec3cf6dfa046L134-R132), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-a835aeea24dd98fe09a12db60720de3f06cb9b28277d5379e69d47bc1e7d5d18L30-R30), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L78-R78), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L135-R133), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3L128-R128), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-6c70ad5101b19c4e8951d1407b6ca53466a73c7f2e370cd4860c4f42bb1b678fL104-R104), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-9a28cdf282af8f7a290df75aefd6fc56df4c87d645df8404cc16b569bbc3e52dL205-R205), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-2b10663530d5e1d24985131acf7ffe974de2ef545982c50c4294e37b4c33859eL87-R87), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-ccf09c3e797ea2010b168b837363f5f0e12020ad158081ab379b463d98354046L22-R22), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-282f61368741e27a79f6fa59c5724f93d969cfe0f1a0d5cf7621abe047b7e7ebL26-R26), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-b1aedb60c7ba1c942c488f48e7912312cc0684d40b2bf3886c08ac583424fd91L109-R109), F13L24L24, [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-dbe0c1774214451bd8e49c0795be95392cc8fcd48da75fcf6314d2c8e89757e4L24-R24), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-1c55d53b567257d9ff2a2288333f41544873529fb0bc07373b488e2ef739c6dcL43-R44), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-946e55f268a73b9eac63e9cdebb33a891e56904165f0dfb3d58929095253ed24L59-R60), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-9a1159909c8f9b219d84ba37340331ced876e47f364bf263bcb344beebcefd8aL73-R74), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-ce7c111726a7c41db76bde60d1a5ce5fa6d99fd3f995c22a1763b1b76f427492L37-R37))
* Added a new `Errors` enum to the `packages/data/errors.ts` file, which contains common error messages that can be reused across different modules and components ([link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-3566fa05f14a364ec7f5a7aa2cfd03e2ec00d1df45b6d9d7aa80baaab9a6ff0fL3-R8))
* Imported the `Errors` enum from the `@lenster/data/errors` module and replaced the error messages with the corresponding enum values in various handlers, as they are more consistent and descriptive ([link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-1c55d53b567257d9ff2a2288333f41544873529fb0bc07373b488e2ef739c6dcL23-R24), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-946e55f268a73b9eac63e9cdebb33a891e56904165f0dfb3d58929095253ed24L34-R35), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-9a1159909c8f9b219d84ba37340331ced876e47f364bf263bcb344beebcefd8aL47-R48), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-1d7586e54200ef7fa9a91e767a6ac1b3fe38f06c22a1104b13b2159ee71fb160L63-R65), [link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-1d7586e54200ef7fa9a91e767a6ac1b3fe38f06c22a1104b13b2159ee71fb160L75-R77))
* Updated the `Regex` object in the `packages/data/regex.ts` file to include a new property `accessToken`, which contains a regular expression to validate the format of an access token ([link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-ccfbd417e113e2bc3a1dce0e85b9173f3df6ba5e31f624558e5e3d07b9409213L13-R14))
* Imported the `Regex` enum from the `@lenster/data/regex` module and replaced the regular expression for validating the access token with the corresponding enum value in the `post/community/createOrUpdate` handler, as it is more consistent and reusable ([link](https://github.com/lensterxyz/lenster/pull/3363/files?diff=unified&w=0#diff-1d7586e54200ef7fa9a91e767a6ac1b3fe38f06c22a1104b13b2159ee71fb160L27-R29))

## Emoji

<!--
copilot:emoji
-->

🧹🚚📝

<!--
1.  🧹 - This emoji represents cleaning or removing unnecessary or redundant code, such as the `console.error` statements.
2.  🚚 - This emoji represents moving or refactoring code to a different location or module, such as the `Errors` enum or the `Regex` object.
3.  📝 - This emoji represents improving or updating the code documentation or comments, such as the error messages or the regular expressions.
-->
