### PR TITLE
feat: add non profile collects

### DIFF
--- a/apps/web/src/components/Common/Layout.tsx
+++ b/apps/web/src/components/Common/Layout.tsx
@@ -38,9 +38,6 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   );
   const profileId = useAppPersistStore((state) => state.profileId);
   const setProfileId = useAppPersistStore((state) => state.setProfileId);
-  const walletAuthenticated = useAppPersistStore(
-    (state) => state.walletAuthenticated
-  );
   const setWalletAuthenticated = useAppPersistStore(
     (state) => state.setWalletAuthenticated
   );

--- a/apps/web/src/components/Common/Layout.tsx
+++ b/apps/web/src/components/Common/Layout.tsx
@@ -38,6 +38,12 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   );
   const profileId = useAppPersistStore((state) => state.profileId);
   const setProfileId = useAppPersistStore((state) => state.setProfileId);
+  const walletAuthenticated = useAppPersistStore(
+    (state) => state.walletAuthenticated
+  );
+  const setWalletAuthenticated = useAppPersistStore(
+    (state) => state.setWalletAuthenticated
+  );
 
   const isMounted = useIsMounted();
   const { address } = useAccount();
@@ -48,6 +54,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   const resetAuthState = () => {
     setProfileId(null);
     setCurrentProfile(null);
+    setWalletAuthenticated(false);
     resetProfileGuardianInformation();
   };
 
@@ -59,6 +66,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
     },
     skip: !profileId,
     onCompleted: (data) => {
+      setWalletAuthenticated(true);
       const profiles = data?.profiles?.items
         ?.slice()
         ?.sort((a, b) => Number(a.id) - Number(b.id))

--- a/apps/web/src/components/Home/index.tsx
+++ b/apps/web/src/components/Home/index.tsx
@@ -7,7 +7,7 @@ import { GridItemEight, GridItemFour, GridLayout } from '@lenster/ui';
 import { Leafwatch } from '@lib/leafwatch';
 import type { NextPage } from 'next';
 import { useState } from 'react';
-import { useAppStore } from 'src/store/app';
+import { useAppPersistStore, useAppStore } from 'src/store/app';
 import { useEffectOnce } from 'usehooks-ts';
 
 import EnableDispatcher from './EnableDispatcher';
@@ -23,6 +23,9 @@ import Timeline from './Timeline';
 
 const Home: NextPage = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
+  const walletAuthenticated = useAppPersistStore(
+    (state) => state.walletAuthenticated
+  );
   const [feedType, setFeedType] = useState<Type>(Type.FOLLOWING);
 
   useEffectOnce(() => {
@@ -32,7 +35,7 @@ const Home: NextPage = () => {
   return (
     <>
       <MetaTags />
-      {!currentProfile && <Hero />}
+      {!walletAuthenticated && <Hero />}
       <GridLayout>
         <GridItemEight className="space-y-5">
           {currentProfile ? (

--- a/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
+++ b/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
@@ -49,7 +49,7 @@ import Link from 'next/link';
 import type { Dispatch, FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
-import { useAppStore } from 'src/store/app';
+import { useAppPersistStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
 import { useUpdateEffect } from 'usehooks-ts';
 import {
@@ -76,7 +76,9 @@ const CollectModule: FC<CollectModuleProps> = ({
 }) => {
   const userSigNonce = useNonceStore((state) => state.userSigNonce);
   const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
-  const currentProfile = useAppStore((state) => state.currentProfile);
+  const walletAuthenticated = useAppPersistStore(
+    (state) => state.walletAuthenticated
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [revenue, setRevenue] = useState(0);
   const [hasCollectedByMe, setHasCollectedByMe] = useState(
@@ -173,7 +175,7 @@ const CollectModule: FC<CollectModuleProps> = ({
           referenceModules: []
         }
       },
-      skip: !assetAddress || !currentProfile,
+      skip: !assetAddress || !walletAuthenticated,
       onCompleted: ({ approvedModuleAllowanceAmount }) => {
         setAllowed(approvedModuleAllowanceAmount[0]?.allowance !== '0x00');
       }
@@ -264,7 +266,7 @@ const CollectModule: FC<CollectModuleProps> = ({
   };
 
   const createCollect = async () => {
-    if (!currentProfile) {
+    if (!walletAuthenticated) {
       return toast.error(Errors.SignWallet);
     }
 
@@ -496,7 +498,7 @@ const CollectModule: FC<CollectModuleProps> = ({
           )}
         </div>
         <div className="flex items-center space-x-2">
-          {currentProfile &&
+          {walletAuthenticated &&
           (!hasCollectedByMe ||
             (!isFreeCollectModule && !isSimpleFreeCollectModule)) ? (
             allowanceLoading || balanceLoading ? (

--- a/apps/web/src/components/Shared/Login/WalletSelector.tsx
+++ b/apps/web/src/components/Shared/Login/WalletSelector.tsx
@@ -33,16 +33,15 @@ import {
 
 interface WalletSelectorProps {
   setHasConnected: Dispatch<boolean>;
-  setHasProfile: Dispatch<boolean>;
 }
 
-const WalletSelector: FC<WalletSelectorProps> = ({
-  setHasConnected,
-  setHasProfile
-}) => {
+const WalletSelector: FC<WalletSelectorProps> = ({ setHasConnected }) => {
   const setProfiles = useAppStore((state) => state.setProfiles);
   const setCurrentProfile = useAppStore((state) => state.setCurrentProfile);
   const setProfileId = useAppPersistStore((state) => state.setProfileId);
+  const setWalletAuthenticated = useAppPersistStore(
+    (state) => state.setWalletAuthenticated
+  );
   const setShowAuthModal = useGlobalModalStateStore(
     (state) => state.setShowAuthModal
   );
@@ -79,7 +78,6 @@ const WalletSelector: FC<WalletSelectorProps> = ({
   };
 
   const handleSign = async () => {
-    let keepModal = false;
     try {
       setIsLoading(true);
       // Get challenge
@@ -114,10 +112,8 @@ const WalletSelector: FC<WalletSelectorProps> = ({
         variables: { request: { ownedBy: [address] } }
       });
 
-      if (profilesData?.profiles?.items?.length === 0) {
-        setHasProfile(false);
-        keepModal = true;
-      } else {
+      setWalletAuthenticated(true);
+      if (profilesData?.profiles?.items?.length !== 0) {
         const profiles: any = profilesData?.profiles?.items
           ?.slice()
           ?.sort((a, b) => Number(a.id) - Number(b.id))
@@ -133,9 +129,7 @@ const WalletSelector: FC<WalletSelectorProps> = ({
     } catch {
     } finally {
       setIsLoading(false);
-      if (!keepModal) {
-        setShowAuthModal(false);
-      }
+      setShowAuthModal(false);
     }
   };
 

--- a/apps/web/src/components/Shared/Login/index.tsx
+++ b/apps/web/src/components/Shared/Login/index.tsx
@@ -1,85 +1,42 @@
 import WalletSelector from '@components/Shared/Login/WalletSelector';
-import {
-  APP_NAME,
-  IS_MAINNET,
-  STATIC_IMAGES_URL
-} from '@lenster/data/constants';
+import { APP_NAME } from '@lenster/data/constants';
 import { Trans } from '@lingui/macro';
-import Link from 'next/link';
 import type { FC } from 'react';
 import { useState } from 'react';
 
-import NewProfile from './New';
-
 const Login: FC = () => {
   const [hasConnected, setHasConnected] = useState(false);
-  const [hasProfile, setHasProfile] = useState(true);
 
   return (
     <div className="p-5">
-      {hasProfile ? (
-        <div className="space-y-5">
-          {hasConnected ? (
-            <div className="space-y-1">
-              <div className="text-xl font-bold">
-                <Trans>Please sign the message</Trans>.
-              </div>
-              <div className="lt-text-gray-500 text-sm">
-                <Trans>
-                  {APP_NAME} uses this signature to verify that you're the owner
-                  of this address.
-                </Trans>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-1">
-              <div className="text-xl font-bold">
-                <Trans>Connect your wallet</Trans>.
-              </div>
-              <div className="lt-text-gray-500 text-sm">
-                <Trans>
-                  Connect with one of our available wallet providers or create a
-                  new one.
-                </Trans>
-              </div>
-            </div>
-          )}
-          <WalletSelector
-            setHasConnected={setHasConnected}
-            setHasProfile={setHasProfile}
-          />
-        </div>
-      ) : IS_MAINNET ? (
-        <div className="mb-2 space-y-4">
-          <img
-            className="h-16 w-16 rounded-full"
-            height={64}
-            width={64}
-            src={`${STATIC_IMAGES_URL}/brands/lens.png`}
-            alt="Logo"
-          />
-          <div className="text-xl font-bold">Claim your Lens profile 🌿</div>
+      <div className="space-y-5">
+        {hasConnected ? (
           <div className="space-y-1">
-            <div className="linkify">
-              Visit{' '}
-              <Link
-                className="font-bold"
-                href="https://claim.lens.xyz"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                claiming site
-              </Link>{' '}
-              to claim your profile now 🏃‍♂️
+            <div className="text-xl font-bold">
+              <Trans>Please sign the message</Trans>.
             </div>
             <div className="lt-text-gray-500 text-sm">
-              Make sure to check back here when done!
+              <Trans>
+                {APP_NAME} uses this signature to verify that you're the owner
+                of this address.
+              </Trans>
             </div>
           </div>
-        </div>
-      ) : (
-        <NewProfile isModal />
-      )}
+        ) : (
+          <div className="space-y-1">
+            <div className="text-xl font-bold">
+              <Trans>Connect your wallet</Trans>.
+            </div>
+            <div className="lt-text-gray-500 text-sm">
+              <Trans>
+                Connect with one of our available wallet providers or create a
+                new one.
+              </Trans>
+            </div>
+          </div>
+        )}
+        <WalletSelector setHasConnected={setHasConnected} />
+      </div>
     </div>
   );
 };

--- a/apps/web/src/components/Shared/Navbar/MenuItems.tsx
+++ b/apps/web/src/components/Shared/Navbar/MenuItems.tsx
@@ -1,9 +1,10 @@
 import Link from 'next/link';
 import type { FC } from 'react';
-import { useAppStore } from 'src/store/app';
+import { useAppPersistStore, useAppStore } from 'src/store/app';
 
 import LoginButton from './LoginButton';
 import SignedUser from './SignedUser';
+import WalletUser from './WalletUser';
 
 export const NextLink = ({ href, children, ...rest }: Record<string, any>) => (
   <Link href={href} {...rest}>
@@ -13,6 +14,13 @@ export const NextLink = ({ href, children, ...rest }: Record<string, any>) => (
 
 const MenuItems: FC = () => {
   const currentProfile = useAppStore((state) => state.currentProfile);
+  const walletAuthenticated = useAppPersistStore(
+    (state) => state.walletAuthenticated
+  );
+
+  if (walletAuthenticated && !currentProfile) {
+    return <WalletUser />;
+  }
 
   if (!currentProfile) {
     return <LoginButton />;

--- a/apps/web/src/components/Shared/Navbar/NavItems/Logout.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Logout.tsx
@@ -24,6 +24,9 @@ const Logout: FC<LogoutProps> = ({ onClick, className = '' }) => {
     (state) => state.resetProfileGuardianInformation
   );
   const setProfileId = useAppPersistStore((state) => state.setProfileId);
+  const setWalletAuthenticated = useAppPersistStore(
+    (state) => state.setWalletAuthenticated
+  );
 
   const logout = () => {
     Leafwatch.track(PROFILE.LOGOUT);
@@ -31,6 +34,7 @@ const Logout: FC<LogoutProps> = ({ onClick, className = '' }) => {
     setCurrentProfile(null);
     resetProfileGuardianInformation();
     setProfileId(null);
+    setWalletAuthenticated(false);
     resetAuthData();
     disconnect?.();
   };

--- a/apps/web/src/components/Shared/Navbar/WalletUser.tsx
+++ b/apps/web/src/components/Shared/Navbar/WalletUser.tsx
@@ -1,0 +1,82 @@
+import { Menu } from '@headlessui/react';
+import getStampFyiURL from '@lenster/lib/getStampFyiURL';
+import { Image } from '@lenster/ui';
+import clsx from 'clsx';
+import type { FC } from 'react';
+import { useAppStore } from 'src/store/app';
+import { useGlobalModalStateStore } from 'src/store/modals';
+import { useAccount } from 'wagmi';
+
+import MenuTransition from '../MenuTransition';
+import MobileDrawerMenu from './MobileDrawerMenu';
+import AppVersion from './NavItems/AppVersion';
+import Logout from './NavItems/Logout';
+import ThemeSwitch from './NavItems/ThemeSwitch';
+
+const WalletUser: FC = () => {
+  const currentProfile = useAppStore((state) => state.currentProfile);
+  const setShowMobileDrawer = useGlobalModalStateStore(
+    (state) => state.setShowMobileDrawer
+  );
+  const showMobileDrawer = useGlobalModalStateStore(
+    (state) => state.showMobileDrawer
+  );
+  const { address } = useAccount();
+
+  const Avatar = () => (
+    <Image
+      src={getStampFyiURL(address as string)}
+      className="h-8 w-8 cursor-pointer rounded-full border dark:border-gray-700"
+      alt={address}
+    />
+  );
+
+  const openMobileMenuDrawer = () => {
+    setShowMobileDrawer(true);
+  };
+
+  return (
+    <>
+      {showMobileDrawer && <MobileDrawerMenu />}
+      <button
+        className="focus:outline-none md:hidden"
+        onClick={() => openMobileMenuDrawer()}
+      >
+        <Avatar />
+      </button>
+      <Menu as="div" className="hidden md:block">
+        <Menu.Button className="flex self-center">
+          <Avatar />
+        </Menu.Button>
+        <MenuTransition>
+          <Menu.Items
+            static
+            className="absolute right-0 mt-2 w-48 rounded-xl border bg-white py-1 shadow-sm focus:outline-none dark:border-gray-700 dark:bg-black"
+          >
+            <Menu.Item
+              as="div"
+              className={({ active }) =>
+                clsx({ 'dropdown-active': active }, 'm-2 rounded-lg')
+              }
+            >
+              <Logout />
+            </Menu.Item>
+            <div className="divider" />
+            <Menu.Item
+              as="div"
+              className={({ active }) =>
+                clsx({ 'dropdown-active': active }, 'm-2 rounded-lg')
+              }
+            >
+              <ThemeSwitch />
+            </Menu.Item>
+            <div className="divider" />
+            <AppVersion />
+          </Menu.Items>
+        </MenuTransition>
+      </Menu>
+    </>
+  );
+};
+
+export default WalletUser;

--- a/apps/web/src/store/app.ts
+++ b/apps/web/src/store/app.ts
@@ -20,6 +20,8 @@ export const useAppStore = create<AppState>((set) => ({
 interface AppPersistState {
   profileId: string | null;
   setProfileId: (profileId: string | null) => void;
+  walletAuthenticated: boolean;
+  setWalletAuthenticated: (walletAuthenticated: boolean) => void;
   staffMode: boolean;
   setStaffMode: (staffMode: boolean) => void;
   modMode: boolean;
@@ -31,6 +33,9 @@ export const useAppPersistStore = create(
     (set) => ({
       profileId: null,
       setProfileId: (profileId) => set(() => ({ profileId })),
+      walletAuthenticated: false,
+      setWalletAuthenticated: (walletAuthenticated) =>
+        set(() => ({ walletAuthenticated })),
       staffMode: false,
       setStaffMode: (staffMode) => set(() => ({ staffMode })),
       modMode: false,


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f51d0f6</samp>

This pull request introduces a new state variable `walletAuthenticated` to the app, which indicates whether the user has authenticated their wallet. It uses this state to improve the user experience and security of various components, such as the `Home`, `CollectModule`, `WalletSelector`, and `Logout` components. It also adds a new feature that shows the user's wallet avatar and menu when the user does not have a profile, using the `WalletUser` component. It simplifies the logic of the `Login` component by removing redundant and unnecessary states and components.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f51d0f6</samp>

*  Add and use `walletAuthenticated` state to store and update the user's wallet authentication status ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R41-R46), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R57), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R69), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-1e0c36f1fd8d7a0211eeffd2774b6686081f15fe550031223f83adeb0b294405L10-R10), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-1e0c36f1fd8d7a0211eeffd2774b6686081f15fe550031223f83adeb0b294405R26-R28), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-1e0c36f1fd8d7a0211eeffd2774b6686081f15fe550031223f83adeb0b294405L35-R38), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL52-R52), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL79-R81), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL176-R178), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL267-R269), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL499-R501), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-3c54b2f7a43063da70bed40300eeee3e4e15c75f1c86f2f9c528cfbb5a6bb7dfL16-R24), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-d90e0368d501b4099610344c247b27d5be1597632d7dc2e08299da97723e4587R27-R29), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-d90e0368d501b4099610344c247b27d5be1597632d7dc2e08299da97723e4587R37), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-9390cfccb3090a6b6b18dfaea3caaee07c9b76c4778a9ab1ac08ee61b8ca0c70R23-R24), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-9390cfccb3090a6b6b18dfaea3caaee07c9b76c4778a9ab1ac08ee61b8ca0c70R36-R38))
  * Replace `currentProfile` with `walletAuthenticated` in conditional rendering and logic of `Hero`, `CollectModule`, and collect button ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-1e0c36f1fd8d7a0211eeffd2774b6686081f15fe550031223f83adeb0b294405L35-R38), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL176-R178), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL267-R269), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL499-R501))
  * Reset `walletAuthenticated` to `false` on component mount and logout ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R57), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-d90e0368d501b4099610344c247b27d5be1597632d7dc2e08299da97723e4587R37))
  * Set `walletAuthenticated` to `true` on wallet connection and profile change ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637R69), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L117-R116))
  * Skip query and mutation hooks when `walletAuthenticated` is `false` in `CollectModule` ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL176-R178), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebL267-R269))
  * Use `walletAuthenticated` to show `Hero` component only when wallet is not authenticated in `Home` ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-1e0c36f1fd8d7a0211eeffd2774b6686081f15fe550031223f83adeb0b294405R26-R28))
  * Use `walletAuthenticated` to render `WalletUser` component when wallet is authenticated but profile is not in `MenuItems` ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-3c54b2f7a43063da70bed40300eeee3e4e15c75f1c86f2f9c528cfbb5a6bb7dfL16-R24))
* Remove `hasProfile` and `keepModal` states and logic from `Login` and `WalletSelector` components ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-2651e17cf710192ef49ce2ee5343fa8b1e6a9ec371535aa8f0b792c285d25b9dL2-R39), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L36-R44), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L82), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L117-R116), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L136-R132))
  * Simplify `Login` component by removing `NewProfile` component and `hasProfile` state ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-2651e17cf710192ef49ce2ee5343fa8b1e6a9ec371535aa8f0b792c285d25b9dL2-R39))
  * Simplify `WalletSelector` component by removing `keepModal` state and always closing auth modal after wallet connection ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L82), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-29f5f49801e061d7d361d09c51d906806f8a75493cf5c6894c54f93d7dd624e5L136-R132))
* Add `WalletUser` component to render user's avatar and menu when wallet is authenticated but profile is not ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-3c54b2f7a43063da70bed40300eeee3e4e15c75f1c86f2f9c528cfbb5a6bb7dfL3-R7), [link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-94454b11adac6b088d10de204b36e2eafe2bd3099fcee3c203c6516ede3230c1R1-R82))
  * Use `useAccount` hook to get user's address and `getStampFyiURL` function to get user's avatar URL in `WalletUser` component ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-94454b11adac6b088d10de204b36e2eafe2bd3099fcee3c203c6516ede3230c1R1-R82))
  * Use `Menu` component from `@headlessui/react` to create dropdown menu with `Logout`, `ThemeSwitch`, and `AppVersion` components in `WalletUser` component ([link](https://github.com/lensterxyz/lenster/pull/3377/files?diff=unified&w=0#diff-94454b11adac6b088d10de204b36e2eafe2bd3099fcee3c203c6516ede3230c1R1-R82))

## Emoji

<!--
copilot:emoji
-->

🧑‍💻🔒🧹

<!--
1.  🧑‍💻 - This emoji represents the user's wallet avatar and menu feature, which is a new and user-friendly way to interact with the app when the user does not have a profile.
2.  🔒 - This emoji represents the improved security and logic of the collect feature, which now uses the `walletAuthenticated` state to ensure that the user has a valid wallet connection before querying or mutating the collect data.
3.  🧹 - This emoji represents the simplification and cleanup of the `Login`, `WalletSelector`, and `NewProfile` components, which removes redundant and unnecessary code and states.
-->
