### PR TITLE
fix: change mention regex so that @mention can not end with "."

### DIFF
--- a/packages/data/regex.ts
+++ b/packages/data/regex.ts
@@ -2,7 +2,7 @@ const RESTRICTED_SYMBOLS = '☑️✓✔✅';
 
 export const Regex = {
   url: /(http|https):\/\/([\w+.?])+([\w!#$%&'()*+,./:;=?@\\^~\-]*)?/g,
-  mention: /(@[.A-Za-z\d-_]{1,31})/g,
+  mention: /(@[\w.\-]{1,30}[\w-])/g,
   hashtag: /(#\w*[A-Za-z]\w*)/g,
   ethereumAddress: /^(0x)?[\da-f]{40}$/i,
   handle: /^[\da-z]+$/g,


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5aad5d9</samp>

Updated the `mention` regex in `packages/data/regex.ts` to match Twitter usernames more accurately and avoid false positives.

## Related issues

Fixes #3388

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5aad5d9</samp>

*  Adjust `mention` regex to match Twitter username rules ([link](https://github.com/lensterxyz/lenster/pull/3389/files?diff=unified&w=0#diff-ccfbd417e113e2bc3a1dce0e85b9173f3df6ba5e31f624558e5e3d07b9409213L5-R5))

## Emoji

<!--
copilot:emoji
-->

🐦🔢🚫

<!--
1.  🐦 - This emoji represents Twitter, the platform where the mention regex is used, and suggests that the change is related to its specific rules and features.
2.  🔢 - This emoji represents numbers, and indicates that the change involves modifying the length limit of the username that can be matched by the regex.
3.  🚫 - This emoji represents exclusion or negation, and suggests that the change also involves preventing some characters or formats from being matched by the regex.
-->
