### PR TITLE
feat: add more regex test cases

### DIFF
--- a/apps/web/src/components/Publication/RelevantPeople.tsx
+++ b/apps/web/src/components/Publication/RelevantPeople.tsx
@@ -15,7 +15,7 @@ interface RelevantPeopleProps {
 
 const RelevantPeople: FC<RelevantPeopleProps> = ({ publication }) => {
   const mentions =
-    publication?.metadata?.content?.match(Regex.allHandles, '$1[~$2]') ?? [];
+    publication?.metadata?.content?.match(Regex.mention, '$1[~$2]') ?? [];
 
   const processedMentions = mentions.map((mention: string) => {
     const trimmedMention = mention.trim().replace('@', '').replace("'s", '');

--- a/packages/data/regex.ts
+++ b/packages/data/regex.ts
@@ -2,11 +2,10 @@ const RESTRICTED_SYMBOLS = '☑️✓✔✅';
 
 export const Regex = {
   url: /(http|https):\/\/([\w+.?])+([\w!#$%&'()*+,./:;=?@\\^~\-]*)?/g,
-  mention: /(@[\w.\-]{1,30}[\w-])/g,
+  mention: /@[\w.\-]{1,30}[\w-]/g,
   hashtag: /(#\w*[A-Za-z]\w*)/g,
   ethereumAddress: /^(0x)?[\da-f]{40}$/i,
   handle: /^[\da-z]+$/g,
-  allHandles: /([\s+])@(\S+)/g,
   santiizeHandle: /[^\d .A-Za-z]/g,
   profileNameValidator: new RegExp('^[^' + RESTRICTED_SYMBOLS + ']+$'),
   profileNameFilter: new RegExp('[' + RESTRICTED_SYMBOLS + ']', 'gu'),

--- a/packages/data/tests/regex/ethereumAddress.spec.ts
+++ b/packages/data/tests/regex/ethereumAddress.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import { Regex } from '../../regex';
+
+const validate = (text: string) => {
+  Regex.ethereumAddress.lastIndex = 0;
+  return Regex.ethereumAddress.test(text);
+};
+
+describe('ethereumAddress regex', () => {
+  test('should pass for valid Ethereum addresses', () => {
+    expect(validate('0x5AEDA56215b167893e80B4fE645BA6d5Bab767DE')).toBe(true);
+    expect(validate('5aeda56215b167893e80b4fe645ba6d5bab767de')).toBe(true);
+    expect(validate('0xB794F5eA0ba39494cE839613fffBA74279579268')).toBe(true);
+  });
+
+  test('should fail for Ethereum addresses with invalid characters', () => {
+    expect(validate('0xG28F3B8e87E48F7F32A7D4e1df178aE9F14b0Ee2')).toBe(false);
+    expect(validate('0xabcdefg0123456789abcdef0123456789abcdef')).toBe(false);
+    expect(validate('0x5aeda56215b167893e80b4fe645ba6d5bab767deg')).toBe(false);
+  });
+
+  test('should fail for Ethereum addresses with incorrect length', () => {
+    expect(validate('0x5AEDA56215b167893e80B4fE645BA6d5Bab767D')).toBe(false);
+    expect(validate('0xB794F5eA0ba39494cE839613fffBA742795792688')).toBe(false);
+  });
+
+  test('should fail for empty string', () => {
+    expect(validate('')).toBe(false);
+  });
+});

--- a/packages/data/tests/regex/handle.spec.ts
+++ b/packages/data/tests/regex/handle.spec.ts
@@ -3,37 +3,32 @@ import { describe, expect, test } from 'vitest';
 import { Regex } from '../../regex';
 
 const validate = (text: string) => {
-  Regex.mention.lastIndex = 0;
-  return Regex.mention.test(text);
+  Regex.handle.lastIndex = 0;
+  return Regex.handle.test(text);
 };
 
 describe('handle regex', () => {
-  test('should pass for string starting with @ followed by 1-30 characters', () => {
-    expect(validate('@john_doe-123')).toBe(true);
-    expect(validate('@example.email-service')).toBe(true);
-    expect(validate('@a.b-c')).toBe(true);
-    expect(validate('@username')).toBe(true);
-    expect(validate('@abc123')).toBe(true);
+  test('should pass for valid handles', () => {
+    expect(validate('example')).toBe(true);
+    expect(validate('handle123')).toBe(true);
+    expect(validate('username')).toBe(true);
+    expect(validate('abc123')).toBe(true);
   });
 
-  test.skip('should fail for string with uppercase letters after @', () => {
-    expect(validate('@Abc123')).toBe(false);
+  test('should fail for underscore', () => {
+    expect(validate('john_doe_123')).toBe(false);
   });
 
-  test.skip('should fail for string with spaces after @', () => {
-    expect(validate('@abc 123')).toBe(false);
+  test('should fail for uppercase letters', () => {
+    expect(validate('Abc123')).toBe(false);
+    expect(validate('Handle')).toBe(false);
+    expect(validate('TestUser')).toBe(false);
   });
 
-  test.skip('should fail for string with special characters after @', () => {
-    expect(validate('@abc!def')).toBe(false);
-  });
-
-  test('should fail for string that does not end with a word character or a hyphen', () => {
-    expect(validate('@.....')).toBe(false);
-  });
-
-  test.skip('should fail for string longer than 30 characters after @', () => {
-    expect(validate('@abcdefghij1234567890abcdefghij12')).toBe(false);
+  test('should fail for special characters', () => {
+    expect(validate('handle@user')).toBe(false);
+    expect(validate('user*name')).toBe(false);
+    expect(validate('name#123')).toBe(false);
   });
 
   test('should fail for empty string', () => {

--- a/packages/data/tests/regex/hashtag.spec.ts
+++ b/packages/data/tests/regex/hashtag.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import { Regex } from '../../regex';
+
+const validate = (text: string) => {
+  Regex.hashtag.lastIndex = 0;
+  return Regex.hashtag.test(text);
+};
+
+describe('hashtag regex', () => {
+  test('should pass for valid hashtags', () => {
+    expect(validate('#hashtag')).toBe(true);
+    expect(validate('#HelloWorld')).toBe(true);
+    expect(validate('#_underscored_tag_')).toBe(true);
+    expect(validate('#123number')).toBe(true);
+  });
+
+  test('should fail for hashtags filled with a digit', () => {
+    expect(validate('#2023')).toBe(false);
+  });
+
+  test('should fail for hashtags without any alphabet characters', () => {
+    expect(validate('#123')).toBe(false);
+    expect(validate('#_!@')).toBe(false);
+  });
+
+  test('should fail for empty string', () => {
+    expect(validate('')).toBe(false);
+    expect(validate('#')).toBe(false);
+  });
+});

--- a/packages/data/tests/regex/mention.spec.ts
+++ b/packages/data/tests/regex/mention.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+
+import { Regex } from '../../regex';
+
+const validate = (text: string) => {
+  Regex.mention.lastIndex = 0;
+  return Regex.mention.test(text);
+};
+
+describe('mention regex', () => {
+  test('should pass for string starting with @ followed by 1-30 characters', () => {
+    expect(validate('@john_doe-123')).toBe(true);
+    expect(validate('@example.email-service')).toBe(true);
+    expect(validate('@a.b-c')).toBe(true);
+    expect(validate('@username')).toBe(true);
+    expect(validate('@abc123')).toBe(true);
+  });
+
+  test.skip('should fail for string with uppercase letters after @', () => {
+    expect(validate('@Abc123')).toBe(false);
+  });
+
+  test.skip('should fail for string with spaces after @', () => {
+    expect(validate('@abc 123')).toBe(false);
+  });
+
+  test.skip('should fail for string with special characters after @', () => {
+    expect(validate('@abc!def')).toBe(false);
+  });
+
+  test('should fail for string that does not end with a word character or a hyphen', () => {
+    expect(validate('@.....')).toBe(false);
+  });
+
+  test.skip('should fail for string longer than 30 characters after @', () => {
+    expect(validate('@abcdefghij1234567890abcdefghij12')).toBe(false);
+  });
+
+  test('should fail for empty string', () => {
+    expect(validate('')).toBe(false);
+  });
+});

--- a/packages/data/tests/regex/mention.spec.ts
+++ b/packages/data/tests/regex/mention.spec.ts
@@ -7,6 +7,17 @@ const validate = (text: string) => {
   return Regex.mention.test(text);
 };
 
+const findAllHandles = (text: string) => {
+  Regex.mention.lastIndex = 0;
+  const handles: string[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = Regex.mention.exec(text)) !== null) {
+    handles.push(match[0].trim());
+  }
+
+  return handles;
+};
+
 describe('mention regex', () => {
   test('should pass for string starting with @ followed by 1-30 characters', () => {
     expect(validate('@john_doe-123')).toBe(true);
@@ -38,5 +49,55 @@ describe('mention regex', () => {
 
   test('should fail for empty string', () => {
     expect(validate('')).toBe(false);
+  });
+});
+
+describe('all mention regex', () => {
+  test('should find all handles in the string', () => {
+    const text = 'Hey @user1, check this out: @user2 and @user3!';
+    const handles = findAllHandles(text);
+    expect(handles).toEqual(['@user1', '@user2', '@user3']);
+  });
+
+  test('should find handles with underscores and digits', () => {
+    const text = 'Hello @_test_user_123';
+    const handles = findAllHandles(text);
+    expect(handles).toEqual(['@_test_user_123']);
+  });
+
+  test('should find multiple handles in the same string', () => {
+    const text = 'Message from @user1 and @user2';
+    const handles = findAllHandles(text);
+    expect(handles).toEqual(['@user1', '@user2']);
+  });
+
+  test('should find handles at the beginning, middle, and end of the string', () => {
+    const text = '@start middle @end';
+    const handles = findAllHandles(text);
+    expect(handles).toEqual(['@start', '@end']);
+  });
+
+  test('should not match handles with spaces in between', () => {
+    const text = '@user 123';
+    const handles = findAllHandles(text);
+    expect(handles).toEqual(['@user']);
+  });
+
+  test('should not match handles starting with digits', () => {
+    const text = '1handle @2user';
+    const handles = findAllHandles(text);
+    expect(handles).toEqual(['@2user']);
+  });
+
+  test('should not match handles with special characters', () => {
+    const text = '@user#123';
+    const handles = findAllHandles(text);
+    expect(handles).toEqual(['@user']);
+  });
+
+  test('should not match empty string', () => {
+    const text = '';
+    const handles = findAllHandles(text);
+    expect(handles).toEqual([]);
   });
 });

--- a/packages/data/tests/regex/url.spec.ts
+++ b/packages/data/tests/regex/url.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+
+import { Regex } from '../../regex';
+
+const validate = (text: string) => {
+  Regex.url.lastIndex = 0;
+  return Regex.url.test(text);
+};
+
+describe('url regex', () => {
+  test('should pass for valid URLs', () => {
+    expect(validate('http://www.example.com')).toBe(true);
+    expect(validate('https://www.example.com')).toBe(true);
+    expect(validate('http://subdomain.example.com')).toBe(true);
+    expect(validate('https://www.example.com/path/to/something')).toBe(true);
+    expect(validate('http://www.example.com/page?id=123&name=John')).toBe(true);
+    expect(validate('https://www.example.com/@username')).toBe(true);
+    expect(validate('https://www.example.com/#selector')).toBe(true);
+  });
+
+  test('should fail for invalid URLs', () => {
+    expect(validate('www.example.com')).toBe(false);
+    expect(validate('example.com')).toBe(false);
+    expect(validate('example')).toBe(false);
+    expect(validate('example.')).toBe(false);
+    expect(validate('example.c')).toBe(false);
+  });
+
+  test('should pass for multiple URLs in the same string', () => {
+    expect(
+      validate(
+        'Check out this website: https://www.example.com and also https://sub.example.com'
+      )
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1df2d81</samp>

This pull request fixes a bug in the `RelevantPeople` component by using the `Regex.mention` property instead of the `Regex.allHandles` property. It also removes the unused `Regex.allHandles` property and simplifies the `Regex.mention` property. Additionally, it adds and updates unit tests for the `Regex` object properties in the `packages/data/tests/regex` folder.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1df2d81</samp>

*  Fixed a bug where invalid handles were matched as mentions in the publication content by using a stricter regex ([link](https://github.com/lensterxyz/lenster/pull/3442/files?diff=unified&w=0#diff-f685fa6c4e1aa01dda2b70054e651b2f2b73e5812f25609f37ed592100f60e5bL18-R18))
* Removed the unused `Regex.allHandles` property and simplified the `Regex.mention` property ([link](https://github.com/lensterxyz/lenster/pull/3442/files?diff=unified&w=0#diff-ccfbd417e113e2bc3a1dce0e85b9173f3df6ba5e31f624558e5e3d07b9409213L5-R8))
* Added unit tests for the `Regex.ethereumAddress`, `Regex.hashtag`, `Regex.mention`, and `Regex.url` properties in the `packages/data/tests/regex` folder ([link](https://github.com/lensterxyz/lenster/pull/3442/files?diff=unified&w=0#diff-5d6ad3c643f10fb2ac4b64599c74b252556582e776e831c23ddab2a323d2245fR1-R31), [link](https://github.com/lensterxyz/lenster/pull/3442/files?diff=unified&w=0#diff-43425167822d1f7d74ba1df4c6a006ffbfdaf38358a4ac5b0b835a69780dc449R1-R31), [link](https://github.com/lensterxyz/lenster/pull/3442/files?diff=unified&w=0#diff-33287643597971982cd39ee080fc5dc789aaadadd39f79b5c892ea01692b1c59R1-R103), [link](https://github.com/lensterxyz/lenster/pull/3442/files?diff=unified&w=0#diff-80e94c8b49c95ade894d65798cce364003c833e154ed38a6dc9b333c00de0d21R1-R36))
* Updated the unit tests for the `Regex.handle` property to reflect the difference from the `Regex.mention` property and removed the skipped tests ([link](https://github.com/lensterxyz/lenster/pull/3442/files?diff=unified&w=0#diff-f359084041745b6b3c0abde2a4c95f1dcb4e733929ab061794e9d9e301c31111L6-R33))

## Emoji

<!--
copilot:emoji
-->

🐛🧪🔥

<!--
1.  🐛 - This emoji represents the bug fix that was made to the `RelevantPeople` component by using the `Regex.mention` instead of the `Regex.allHandles`. This emoji is commonly used to indicate bug fixes or issues in code.
2.  🧪 - This emoji represents the addition of several unit test files for the different regex properties in the `Regex` object. This emoji is commonly used to indicate testing, experimentation, or science-related topics in code.
3.  🔥 - This emoji represents the removal of the `Regex.allHandles` property from the `Regex` object, since it was no longer used after the bug fix. This emoji is commonly used to indicate deletion, removal, or burning of code.
-->
