### PR TITLE
feat: add test cases for algo worker

### DIFF
--- a/apps/prerender/package.json
+++ b/apps/prerender/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@lenster/config": "workspace:*",
     "@lenster/lens": "workspace:*",
-    "@playwright/test": "^1.36.2",
+    "@playwright/test": "^1.37.0",
     "@types/react": "^18.2.19",
     "@types/react-dom": "^18.2.7",
     "typescript": "^5.1.6"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@lenster/config": "workspace:*",
     "@lingui/cli": "^4.4.0",
-    "@playwright/test": "^1.36.2",
+    "@playwright/test": "^1.37.0",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/forms": "^0.5.4",
     "@types/node": "^20.4.9",

--- a/apps/web/src/components/Shared/Navbar/Search.tsx
+++ b/apps/web/src/components/Shared/Navbar/Search.tsx
@@ -68,6 +68,7 @@ const Search: FC<SearchProps> = ({
         }
       });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [debouncedSearchText]);
 
   const searchResult = searchUsersData?.search as ProfileSearchResult;

--- a/packages/lib/getPublicationIds.ts
+++ b/packages/lib/getPublicationIds.ts
@@ -9,7 +9,7 @@ import axios from 'axios';
  */
 const getPublicationIds = async (provider: string, strategy: string) => {
   try {
-    const response = await axios(`${FEEDS_WORKER_URL}/publicationIds`, {
+    const response = await axios(`${FEEDS_WORKER_URL}/ids`, {
       params: { provider, strategy }
     });
 

--- a/packages/workers/feeds/package.json
+++ b/packages/workers/feeds/package.json
@@ -9,6 +9,8 @@
     "lint:fix": "eslint . --fix --ext .ts",
     "prettier": "prettier --check \"**/*.{js,ts,tsx,md}\"  --cache",
     "prettier:fix": "prettier --write \"**/*.{js,ts,tsx,md}\"  --cache",
+    "start": "pnpm dev",
+    "test:dev": "vitest --run",
     "typecheck": "tsc --pretty",
     "worker:deploy": "wrangler deploy"
   },
@@ -20,6 +22,7 @@
     "@cloudflare/workers-types": "^4.20230807.0",
     "@lenster/config": "workspace:*",
     "typescript": "^5.1.6",
+    "vitest": "^0.34.1",
     "wrangler": "^3.4.0"
   }
 }

--- a/packages/workers/feeds/src/constants.ts
+++ b/packages/workers/feeds/src/constants.ts
@@ -1,0 +1,1 @@
+export const TEST_URL = 'http://127.0.0.1:8092';

--- a/packages/workers/feeds/src/handlers/getPublicationIds.spec.ts
+++ b/packages/workers/feeds/src/handlers/getPublicationIds.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from 'vitest';
+
+import { TEST_URL } from '../constants';
+
+type Response = {
+  ids: string[];
+};
+
+describe('getPublicationIds', () => {
+  describe('k3l provider', () => {
+    test('should return ids for k3l provider and recent strategy', async () => {
+      const getRequest = await fetch(
+        `${TEST_URL}/ids?provider=k3l&strategy=recent`
+      );
+      const response: Response = await getRequest.json();
+      expect(response.ids.length).toBe(50);
+    });
+
+    test('should return ids for k3l provider and recommended strategy', async () => {
+      const getRequest = await fetch(
+        `${TEST_URL}/ids?provider=k3l&strategy=recommended`
+      );
+      const response: Response = await getRequest.json();
+      expect(response.ids.length).toBe(50);
+    });
+
+    test('should return ids for k3l provider and popular strategy', async () => {
+      const getRequest = await fetch(
+        `${TEST_URL}/ids?provider=k3l&strategy=popular`
+      );
+      const response: Response = await getRequest.json();
+      expect(response.ids.length).toBe(50);
+    });
+
+    test('should return ids for k3l provider and crowdsourced strategy', async () => {
+      const getRequest = await fetch(
+        `${TEST_URL}/ids?provider=k3l&strategy=crowdsourced`
+      );
+      const response: Response = await getRequest.json();
+      expect(response.ids.length).toBe(50);
+    });
+  });
+});

--- a/packages/workers/feeds/src/index.ts
+++ b/packages/workers/feeds/src/index.ts
@@ -12,9 +12,7 @@ const router = Router();
 
 router.all('*', preflight);
 router.get('/', () => new Response('gm, to feeds service 👋'));
-router.get('/publicationIds', (request, env) =>
-  getPublicationIds(request, env)
-);
+router.get('/ids', (request, env) => getPublicationIds(request, env));
 
 const routerHandleStack = (request: Request, env: Env, ctx: ExecutionContext) =>
   router.handle(request, env, ctx).then(json);

--- a/packages/workers/feeds/vitest.config.ts
+++ b/packages/workers/feeds/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { globals: true }
+});

--- a/packages/workers/feeds/wrangler.toml
+++ b/packages/workers/feeds/wrangler.toml
@@ -7,3 +7,6 @@ node_compat = true
 routes = [
 	{ pattern = "feeds.lenster.xyz", custom_domain = true }
 ]
+
+[env.production.vars]
+CLICKHOUSE_REST_ENDPOINT = ""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -647,6 +647,9 @@ importers:
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
+      vitest:
+        specifier: ^0.34.1
+        version: 0.34.1
       wrangler:
         specifier: ^3.4.0
         version: 3.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/config
       '@playwright/test':
-        specifier: ^1.36.2
-        version: 1.36.2
+        specifier: ^1.37.0
+        version: 1.37.0
       '@types/react':
         specifier: ^18.2.19
         version: 18.2.19
@@ -272,8 +272,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.0
       '@playwright/test':
-        specifier: ^1.36.2
-        version: 1.36.2
+        specifier: ^1.37.0
+        version: 1.37.0
       '@tailwindcss/aspect-ratio':
         specifier: ^0.4.2
         version: 0.4.2(tailwindcss@3.3.3)
@@ -5224,13 +5224,13 @@ packages:
       tslib: 2.6.1
     dev: true
 
-  /@playwright/test@1.36.2:
-    resolution: {integrity: sha512-2rVZeyPRjxfPH6J0oGJqE8YxiM1IBRyM8hyrXYK7eSiAqmbNhxwcLa7dZ7fy9Kj26V7FYia5fh9XJRq4Dqme+g==}
+  /@playwright/test@1.37.0:
+    resolution: {integrity: sha512-181WBLk4SRUyH1Q96VZl7BP6HcK0b7lbdeKisn3N/vnjitk+9HbdlFz/L5fey05vxaAhldIDnzo8KUoy8S3mmQ==}
     engines: {node: '>=16'}
     hasBin: true
     dependencies:
       '@types/node': 20.4.9
-      playwright-core: 1.36.2
+      playwright-core: 1.37.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: true
@@ -12349,8 +12349,8 @@ packages:
     dependencies:
       find-up: 3.0.0
 
-  /playwright-core@1.36.2:
-    resolution: {integrity: sha512-sQYZt31dwkqxOrP7xy2ggDfEzUxM1lodjhsQ3NMMv5uGTRDsLxU0e4xf4wwMkF2gplIxf17QMBCodSFgm6bFVQ==}
+  /playwright-core@1.37.0:
+    resolution: {integrity: sha512-1c46jhTH/myQw6sesrcuHVtLoSNfJv8Pfy9t3rs6subY7kARv0HRw5PpyfPYPpPtQvBOmgbE6K+qgYUpj81LAA==}
     engines: {node: '>=16'}
     hasBin: true
     dev: true

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -41,7 +41,7 @@ pnpm install --frozen-lockfile
 echo "Dependencies installed 📦"
 # -------------------------------------
 echo "Installing playwright 🎭"
-npx --yes playwright install
+pnpx playwright install
 echo "Playwright installed 🎭"
 # -------------------------------------
 echo "GraphQL Codegen 🧬"


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 890cb4c</samp>

Added local development and testing capabilities to the `feeds` worker package. Updated the `getPublicationIds` function and handler to use a shorter endpoint path `/ids`. Added a production environment variable for the ClickHouse database service.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 890cb4c</samp>

*  Simplify endpoint path for getting publication ids from `/publicationIds` to `/ids` ([link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-28f5c9275ef67db786ab872ef3a1d4428cb8a305c7562af613d7ac7ef8eab736L12-R12), [link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-004edf2f855840628d8f5439c17155a79762b8ef82b490ae0b6555bfa3ac7964L15-R15))
* Add `vitest` dependency and configuration for testing Vite projects with TypeScript, ESM, and Cloudflare Workers ([link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-3eec0431aa038feceb1b6f0589723fe95f24ed04083e1aca531cd9c747454132R25), [link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-77a887246d81b1e1cf6027f71dbebd101d1a49785102fc64863b3a2479b0850eR1-R5), [link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR650-R652))
* Add `start` and `test:dev` scripts to `package.json` of `feeds` worker package for running development server and unit tests ([link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-3eec0431aa038feceb1b6f0589723fe95f24ed04083e1aca531cd9c747454132R12-R13))
* Add unit tests for `getPublicationIds` handler function in `getPublicationIds.spec.ts` using `vitest` ([link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-2d3e74b0d2323c86beb8030a12b8dacd24056d570736b4822aa565fdb8da4d9eR1-R43))
* Add `TEST_URL` constant to `constants.ts` of `feeds` worker package for holding base URL of local development server ([link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-1866b85682c690409687ba0a53138b92b46b1c1463a38b8e7f20f365c1e0cef1R1))
* Add production environment variable for `CLICKHOUSE_REST_ENDPOINT` to `wrangler.toml` of `feeds` worker package for querying publication ids from ClickHouse database service ([link](https://github.com/lensterxyz/lenster/pull/3500/files?diff=unified&w=0#diff-a2a445db744e4afab79f6dee1135b01cb427d5d39cbc486d59f4dab325e90b07R10-R12))

## Emoji

<!--
copilot:emoji
-->

🚀🧪🛠️

<!--
1.  🚀 - This emoji represents the improvement of the endpoint path to be shorter and more consistent, which could improve the performance and usability of the worker.
2.  🧪 - This emoji represents the addition of unit tests for the `getPublicationIds` handler function, which could increase the reliability and quality of the worker code.
3.  🛠️ - This emoji represents the addition of development and testing scripts and tools to the `feeds` worker package, which could enhance the productivity and convenience of the developer experience.
-->
