### PR TITLE
fix: mention regex to have space before mention

### DIFF
--- a/packages/data/regex.ts
+++ b/packages/data/regex.ts
@@ -2,7 +2,7 @@ const RESTRICTED_SYMBOLS = '☑️✓✔✅';
 
 export const Regex = {
   url: /(?:(http|https):\/\/)?(?:[\w-]+\.)+[a-z]{2,6}\b([\w#%&()+./:=?@~-]*)?/gi,
-  mention: /@[\w.\-]{1,30}[\w-]/g,
+  mention: /\s@[\w.\-]{1,30}[\w-]/g,
   hashtag: /(#\w*[A-Za-z]\w*)/g,
   ethereumAddress: /^(0x)?[\da-f]{40}$/i,
   handle: /^[\da-z]+$/g,


### PR DESCRIPTION
## What does this PR do?

Updated the regex of mentions to have a space before

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Emoji

🚀 
