### PR TITLE
fix: spotifyPlaylistUrlRegex

### DIFF
--- a/packages/workers/oembed/src/helper/meta/generateIframe.ts
+++ b/packages/workers/oembed/src/helper/meta/generateIframe.ts
@@ -53,12 +53,12 @@ const generateIframe = (
       const spotifySize = `style="max-width: 560px;" width="100%"`;
       if (spotifyTrackUrlRegex.test(url)) {
         const spotifyUrl = pickedUrl.replace('/track', '/embed/track');
-        return `<iframe src="${spotifyUrl}" ${spotifySize}  height="155" allow="encrypted-media"></iframe>`;
+        return `<iframe src="${spotifyUrl}" ${spotifySize} height="155" allow="encrypted-media"></iframe>`;
       }
 
       if (spotifyPlaylistUrlRegex.test(url)) {
         const spotifyUrl = pickedUrl.replace('/playlist', '/embed/playlist');
-        return `<iframe src="${spotifyUrl}" ${spotifySize}  height="380" allow="encrypted-media"></iframe>`;
+        return `<iframe src="${spotifyUrl}" ${spotifySize} height="380" allow="encrypted-media"></iframe>`;
       }
 
       return null;

--- a/packages/workers/oembed/src/helper/meta/generateIframe.ts
+++ b/packages/workers/oembed/src/helper/meta/generateIframe.ts
@@ -50,14 +50,15 @@ const generateIframe = (
 
       return null;
     case 'open.spotify.com':
+      const spotifySize = `style="max-width: 560px;" width="100%"`;
       if (spotifyTrackUrlRegex.test(url)) {
         const spotifyUrl = pickedUrl.replace('/track', '/embed/track');
-        return `<iframe src="${spotifyUrl}" width="560" height="155" allow="encrypted-media"></iframe>`;
+        return `<iframe src="${spotifyUrl}" ${spotifySize}  height="155" allow="encrypted-media"></iframe>`;
       }
 
       if (spotifyPlaylistUrlRegex.test(url)) {
         const spotifyUrl = pickedUrl.replace('/playlist', '/embed/playlist');
-        return `<iframe src="${spotifyUrl}" width="560" height="155" allow="encrypted-media"></iframe>`;
+        return `<iframe src="${spotifyUrl}" ${spotifySize}  height="380" allow="encrypted-media"></iframe>`;
       }
 
       return null;

--- a/packages/workers/oembed/src/helper/meta/generateIframe.ts
+++ b/packages/workers/oembed/src/helper/meta/generateIframe.ts
@@ -9,8 +9,10 @@ const knownSites = [
 
 const pickUrlSites = ['open.spotify.com'];
 
-const spotifyUrlRegex =
+const spotifyTrackUrlRegex =
   /^ht{2}ps?:\/{2}open\.spotify\.com\/track\/[\dA-Za-z]+(\?si=[\dA-Za-z]+)?$/;
+const spotifyPlaylistUrlRegex =
+  /^ht{2}ps?:\/{2}open\.spotify\.com\/playlist\/[\dA-Za-z]+(\?si=[\dA-Za-z]+)?$/;
 const oohlalaUrlRegex =
   /^ht{2}ps?:\/{2}oohlala\.xyz\/playlist\/[\dA-Fa-f-]+(\?si=[\dA-Za-z]+)?$/;
 const soundCloudRegex =
@@ -48,8 +50,13 @@ const generateIframe = (
 
       return null;
     case 'open.spotify.com':
-      if (spotifyUrlRegex.test(url)) {
+      if (spotifyTrackUrlRegex.test(url)) {
         const spotifyUrl = pickedUrl.replace('/track', '/embed/track');
+        return `<iframe src="${spotifyUrl}" width="560" height="155" allow="encrypted-media"></iframe>`;
+      }
+
+      if (spotifyPlaylistUrlRegex.test(url)) {
+        const spotifyUrl = pickedUrl.replace('/playlist', '/embed/playlist');
         return `<iframe src="${spotifyUrl}" width="560" height="155" allow="encrypted-media"></iframe>`;
       }
 


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6376fab</samp>

Added support for Spotify playlist embeds in `oembed` worker. Updated `generateIframe` function and variables in `generateIframe.ts` to handle different Spotify URL patterns.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6376fab</samp>

*  Rename `spotifyUrlRegex` to `spotifyTrackUrlRegex` and add `spotifyPlaylistUrlRegex` to distinguish between Spotify track and playlist URLs ([link](https://github.com/lensterxyz/lenster/pull/3543/files?diff=unified&w=0#diff-3fc76e1e5580e311391a78eb913f9112f6c6f55a2d97f5ea2f225f535e013167L12-R15))
*  Modify `generateIframe` to return an iframe tag for Spotify playlist URLs in addition to track URLs in `packages/workers/oembed/src/helper/meta/generateIframe.ts` ([link](https://github.com/lensterxyz/lenster/pull/3543/files?diff=unified&w=0#diff-3fc76e1e5580e311391a78eb913f9112f6c6f55a2d97f5ea2f225f535e013167L51-R62))

## Emoji

<!--
copilot:emoji
-->

🎵🔄📋

<!--
1.  🎵 - This emoji represents music and Spotify, the main topic of the change.
2.  🔄 - This emoji represents renaming and updating, the actions performed on the variables and function.
3.  📋 - This emoji represents a playlist, the new feature that Lenster can display.
-->
