### PR TITLE
feat: truncate bio in user preview

### DIFF
--- a/apps/web/src/components/Shared/UserPreview.tsx
+++ b/apps/web/src/components/Shared/UserPreview.tsx
@@ -8,6 +8,7 @@ import hasMisused from '@lenster/lib/hasMisused';
 import nFormatter from '@lenster/lib/nFormatter';
 import sanitizeDisplayName from '@lenster/lib/sanitizeDisplayName';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
+import truncateByWords from '@lenster/lib/truncateByWords';
 import { Image } from '@lenster/ui';
 import isVerified from '@lib/isVerified';
 import { Plural } from '@lingui/macro';
@@ -114,7 +115,7 @@ const UserPreview: FC<UserPreviewProps> = ({
                 'linkify break-words leading-6'
               )}
             >
-              <Markup>{lazyProfile?.bio}</Markup>
+              <Markup>{truncateByWords(lazyProfile?.bio, 20)}</Markup>
             </div>
           )}
         </div>


### PR DESCRIPTION
## What does this PR do?

Truncate the bio text in user preview

Fixes #3080


**Before:**
![Screenshot_2023-08-16_18-43-17](https://github.com/lensterxyz/lenster/assets/667227/67722f48-75e8-40c2-a1c5-b8081803922d)

**After:**
![Screenshot_2023-08-16_18-46-38](https://github.com/lensterxyz/lenster/assets/667227/d61f3a92-1fdd-4520-9383-65338932bd32)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab44226</samp>

Applied `truncateByWords` function to user bio in `UserPreview` component. This improves the web app's UI by avoiding long and overflowing bios.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab44226</samp>

*  Import and use `truncateByWords` function to limit bio length in user preview component ([link](https://github.com/lensterxyz/lenster/pull/3545/files?diff=unified&w=0#diff-4cdf48abc8f0279e8ce53beea7dd66d71d57065e549bdf126de7bf715de38567R11), [link](https://github.com/lensterxyz/lenster/pull/3545/files?diff=unified&w=0#diff-4cdf48abc8f0279e8ce53beea7dd66d71d57065e549bdf126de7bf715de38567L117-R118))

## Emoji

<!--
copilot:emoji
-->

📝🎨🚀

<!--
1.  📝 - This emoji can be used to indicate that the bio text was edited or modified by truncating it to a shorter length.
2.  🎨 - This emoji can be used to indicate that the appearance or design of the user preview component was improved or enhanced by applying the truncation function.
3.  🚀 - This emoji can be used to indicate that the performance or speed of the user preview component was boosted or optimized by reducing the amount of text that needs to be rendered.
-->
