### PR TITLE
feat: changed dropdown menu margins

### DIFF
--- a/apps/web/src/components/Profile/Menu/Report.tsx
+++ b/apps/web/src/components/Profile/Menu/Report.tsx
@@ -18,7 +18,7 @@ const Report: FC<ReportProfileProps> = ({ profile }) => {
     <button
       type="button"
       className={clsx(
-        'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm hover:bg-gray-300/20'
+        'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm hover:bg-gray-300/20'
       )}
       onClick={() => setShowReportProfileModal(true, profile)}
     >

--- a/apps/web/src/components/Profile/Menu/Share.tsx
+++ b/apps/web/src/components/Profile/Menu/Share.tsx
@@ -21,7 +21,7 @@ const Share: FC<ShareProps> = ({ profile }) => {
       className={({ active }) =>
         clsx(
           { 'dropdown-active': active },
-          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm'
+          'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm'
         )
       }
       onClick={async (event) => {

--- a/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
@@ -108,7 +108,7 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
       className={({ active }) =>
         clsx(
           { 'dropdown-active': active },
-          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm'
+          'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm'
         )
       }
       onClick={(event) => {

--- a/apps/web/src/components/Publication/Actions/Menu/CopyPostText.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/CopyPostText.tsx
@@ -25,7 +25,7 @@ const CopyPostText: FC<CopyPostTextProps> = ({ publication }) => {
       className={({ active }) =>
         clsx(
           { 'dropdown-active': active },
-          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm'
+          'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm'
         )
       }
       onClick={async (event) => {

--- a/apps/web/src/components/Publication/Actions/Menu/Delete.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Delete.tsx
@@ -21,7 +21,7 @@ const Delete: FC<DeleteProps> = ({ publication }) => {
       className={({ active }) =>
         clsx(
           { 'dropdown-active': active },
-          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm text-red-500'
+          'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm text-red-500'
         )
       }
       onClick={(event) => {

--- a/apps/web/src/components/Publication/Actions/Menu/NotInterested.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/NotInterested.tsx
@@ -88,7 +88,7 @@ const NotInterested: FC<NotInterestedProps> = ({ publication }) => {
       className={({ active }) =>
         clsx(
           { 'dropdown-active': active },
-          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm'
+          'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm'
         )
       }
       onClick={(event) => {

--- a/apps/web/src/components/Publication/Actions/Menu/Report.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Report.tsx
@@ -21,7 +21,7 @@ const Report: FC<ReportProps> = ({ publication }) => {
       className={({ active }) =>
         clsx(
           { 'dropdown-active': active },
-          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm text-red-500'
+          'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm text-red-500'
         )
       }
       onClick={(event) => {

--- a/apps/web/src/components/Publication/Actions/Menu/Share.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Share.tsx
@@ -20,7 +20,7 @@ const Share: FC<ShareProps> = ({ publication }) => {
       className={({ active }) =>
         clsx(
           { 'dropdown-active': active },
-          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm'
+          'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm'
         )
       }
       onClick={async (event) => {

--- a/apps/web/src/components/Publication/Actions/Menu/Translate.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Translate.tsx
@@ -26,7 +26,7 @@ const Translate: FC<TranslateProps> = ({ publication }) => {
       className={({ active }) =>
         clsx(
           { 'dropdown-active': active },
-          'm-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm'
+          'm-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm'
         )
       }
       href={getGoogleTranslateUrl(publication?.metadata?.content)}

--- a/apps/web/src/components/Shared/Navbar/NavItems/Bookmarks.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Bookmarks.tsx
@@ -14,7 +14,7 @@ const Bookmarks: FC<BookmarksProps> = ({ onClick, className = '' }) => {
     <Link
       href="/bookmarks"
       className={clsx(
-        'flex w-full items-center space-x-1.5 px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full items-center space-x-1.5 px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
       onClick={onClick}

--- a/apps/web/src/components/Shared/Navbar/NavItems/Contact.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Contact.tsx
@@ -14,7 +14,7 @@ const Contact: FC<ContactProps> = ({ onClick, className = '' }) => {
     <Link
       href="/contact"
       className={clsx(
-        'flex w-full items-center space-x-1.5 px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full items-center space-x-1.5 px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
       onClick={onClick}

--- a/apps/web/src/components/Shared/Navbar/NavItems/GardenerMode.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/GardenerMode.tsx
@@ -45,7 +45,7 @@ const GardenerMode: FC<ModModeProps> = ({ className = '' }) => {
     <button
       onClick={toggleModMode}
       className={clsx(
-        'flex w-full items-center space-x-1.5 px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full items-center space-x-1.5 px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
     >

--- a/apps/web/src/components/Shared/Navbar/NavItems/Invites.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Invites.tsx
@@ -18,7 +18,7 @@ const Invites: FC<InvitesProps> = ({ className = '' }) => {
   return (
     <button
       className={clsx(
-        'flex w-full items-center space-x-1.5 px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full items-center space-x-1.5 px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
       onClick={() => {

--- a/apps/web/src/components/Shared/Navbar/NavItems/Logout.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Logout.tsx
@@ -46,7 +46,7 @@ const Logout: FC<LogoutProps> = ({ onClick, className = '' }) => {
         onClick?.();
       }}
       className={clsx(
-        'flex w-full px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
     >

--- a/apps/web/src/components/Shared/Navbar/NavItems/ReportBug.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/ReportBug.tsx
@@ -15,7 +15,7 @@ const ReportBug: FC<ReportBugProps> = ({ onClick, className = '' }) => {
       href="https://github.com/lensterxyz/lenster/issues/new?assignees=bigint&labels=needs+review&template=bug_report.yml"
       target="_blank"
       className={clsx(
-        'flex w-full items-center justify-between px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full items-center justify-between px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
       onClick={onClick}

--- a/apps/web/src/components/Shared/Navbar/NavItems/StaffMode.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/StaffMode.tsx
@@ -45,7 +45,7 @@ const StaffMode: FC<StaffModeProps> = ({ className = '' }) => {
     <button
       onClick={toggleStaffMode}
       className={clsx(
-        'flex w-full items-center space-x-1.5 px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full items-center space-x-1.5 px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
     >

--- a/apps/web/src/components/Shared/Navbar/NavItems/Status.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Status.tsx
@@ -30,7 +30,7 @@ const Status: FC<StatusProps> = ({ className = '' }) => {
     <button
       type="button"
       className={clsx(
-        'flex w-full items-center space-x-2 px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full items-center space-x-2 px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
       onClick={() => setShowStatusModal(true)}

--- a/apps/web/src/components/Shared/Navbar/NavItems/SwitchProfile.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/SwitchProfile.tsx
@@ -17,7 +17,7 @@ const SwitchProfile: FC<SwitchProfileProps> = ({ className = '' }) => {
     <button
       type="button"
       className={clsx(
-        'flex w-full px-4 py-1.5 text-sm text-gray-700 focus:outline-none dark:text-gray-200',
+        'flex w-full px-2 py-1.5 text-sm text-gray-700 focus:outline-none dark:text-gray-200',
         className
       )}
       onClick={() => setShowProfileSwitchModal(true)}

--- a/apps/web/src/components/Shared/Navbar/NavItems/ThemeSwitch.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/ThemeSwitch.tsx
@@ -18,7 +18,7 @@ const ThemeSwitch: FC<ThemeSwitchProps> = ({ onClick, className = '' }) => {
     <button
       type="button"
       className={clsx(
-        'flex w-full px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200',
+        'flex w-full px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200',
         className
       )}
       onClick={() => {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -35,7 +35,7 @@ progress::-moz-progress-bar {
 }
 
 .menu-item {
-  @apply m-2 block cursor-pointer rounded-lg px-4 py-1.5 text-sm text-gray-700 dark:text-gray-200;
+  @apply m-2 block cursor-pointer rounded-lg px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200;
 }
 
 .text-brand {


### PR DESCRIPTION
## What does this PR do?

Updated dropdown margins (technically the padding)
Fixes #2565

![Screenshot_2023-08-17_09-10-55](https://github.com/lensterxyz/lenster/assets/667227/67498f0d-ae55-4afb-95df-d2926ca60840)
![Screenshot_2023-08-17_09-11-04](https://github.com/lensterxyz/lenster/assets/667227/cd3e07c6-480d-4b12-8651-d1a91236a7f7)
![Screenshot_2023-08-17_09-11-24](https://github.com/lensterxyz/lenster/assets/667227/a7536b4a-694e-487e-9431-f9d39867280d)
![Screenshot_2023-08-17_09-16-22](https://github.com/lensterxyz/lenster/assets/667227/f4ae3f7c-65de-4bfb-bc82-984314828a00)
![Screenshot_2023-08-17_09-20-01](https://github.com/lensterxyz/lenster/assets/667227/d2fb9ca9-e0a0-47f9-bc84-8b05bc36836e)



<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a255636</samp>

Reduced the horizontal padding of all menu items by changing the `px-4` class to `px-2` in various components. Created a new `menu-item` class in `styles.css` to apply the same styles to all menu items and avoid repetition. This improves the consistency and efficiency of the UI.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a255636</samp>

*  Reduced the horizontal padding of various buttons and links in the profile, publication, and navbar components by replacing the `px-4` class with `px-2` ([link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-7b72b7c38975c0882e8817f8644ce533478bd9674a306ff2d6780cfc8b92d34aL21-R21), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-36f61041577579fe85b0d8a1b73bfc83ecaab50028ff499eb0e07afbf792eaacL24-R24), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-092d5ebe6db060904cad2182f60783e0a48febafd2d8d24a907537c858b0c89cL111-R111), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-9206e05e7a77f34d756d51e4787db404955740f385a52b17806540f2baa92008L28-R28), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-b1fa539d0435f86e24747102dedaef4c59f14d827751278f0ca4b85e1148df22L24-R24), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-9ba1d3c8baea3342dc08be11c56c3eb29cd24773243c37b9f56c698aae449090L91-R91), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-9c0a70867df1590f0f8af2fc9d2fa3fb6cdee9e4fb96f2ba14006f571ed9de93L24-R24), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-62db6b2d4db1aa4081d4d2e4538d746981dc05522f7a48b164fe99c4c4502721L23-R23), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-416530b39f8648e77fa13599dc1e1c30ee67574919212a864620f0e51aebb39eL29-R29), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-a04391ac719f0e596be818fbc2da83aaeab34176483a95f3da37c11acba7e6b1L17-R17), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-bc94ce41138fbb6e7d967455013a1273144f0fc6baecbbfb9c139e70529270f6L17-R17), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-e352bde6c4704d4fa7433e0c58b94c1386c56e3ba28b3dbceda7a6dfdd83af54L48-R48), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-8560795391d738fcac0b11db65278b07729ae4db70ac4a2202be56cdc66e12daL21-R21), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-d90e0368d501b4099610344c247b27d5be1597632d7dc2e08299da97723e4587L49-R49), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-4afd3014c22414d4989ec9310dc702e6baad332acd2a51c25e0ce1bc993d41ecL18-R18), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-522e9b1d3b32a7e320eedad337be78754c4058ccf8dc87a8969300c480e12ec8L48-R48), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-f7dfd2f3606ebeac81cccf7099f0c10630aa52bcd14f9e07b303d2dde1c7de44L33-R33), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-413aa9fea127c744a9a7e4da451fd8a12a5823ada5b7d4d2fcf2f1973d0182f9L20-R20), [link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-bc44765ee34e6353be0106129507d5e4e85f5bb5ad7efb714f671e02411dd8ebL21-R21))
*  Created a new `menu-item` class in `styles.css` to apply the same styles as the previous change to all menu items ([link](https://github.com/lensterxyz/lenster/pull/3554/files?diff=unified&w=0#diff-8695905e235830a8430629a67e7b6b265305775a6ed81fe2116cdec08d29af15L38-R38))

## Emoji

<!--
copilot:emoji
-->

🛠️🎨🗑️

<!--
1.  🛠️ - This emoji represents the fixing or improving of the UI elements by reducing the padding and making them more consistent.
2.  🎨 - This emoji represents the changing or updating of the styles or appearance of the components by using a common class and a CSS file.
3.  🗑️ - This emoji represents the removing or deleting of the unnecessary or redundant classes from the components by using the `menu-item` class instead.
-->
