### PR TITLE
feat: changed capitalization

### DIFF
--- a/apps/web/src/components/Composer/Actions/CollectSettings/AmountConfig.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/AmountConfig.tsx
@@ -60,7 +60,7 @@ const AmountConfig: FC<AmountConfigProps> = ({
             />
             <div>
               <div className="label">
-                <Trans>Select Currency</Trans>
+                <Trans>Select currency</Trans>
               </div>
               <select
                 className="focus:border-brand-500 focus:ring-brand-400 w-full rounded-xl border border-gray-300 bg-white outline-none dark:border-gray-700 dark:bg-gray-800"

--- a/apps/web/src/components/Home/EnableDispatcher.tsx
+++ b/apps/web/src/components/Home/EnableDispatcher.tsx
@@ -33,9 +33,9 @@ const EnableDispatcher: FC = () => {
 
   const getTitle = () => {
     if (isOldDispatcherEnabled) {
-      return <Trans>Signless Transactions Upgrade</Trans>;
+      return <Trans>Signless transactions upgrade</Trans>;
     }
-    return <Trans>Signless Transactions</Trans>;
+    return <Trans>Signless transactions</Trans>;
   };
 
   if (isDispatcherEnabled) {

--- a/apps/web/src/components/Profile/Menu/Report.tsx
+++ b/apps/web/src/components/Profile/Menu/Report.tsx
@@ -25,7 +25,7 @@ const Report: FC<ReportProfileProps> = ({ profile }) => {
       <div className="flex items-center space-x-2">
         <FlagIcon className="h-4 w-4" />
         <div>
-          <Trans>Report Profile</Trans>
+          <Trans>Report profile</Trans>
         </div>
       </div>
     </button>

--- a/apps/web/src/components/Publication/Actions/Menu/NotInterested.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/NotInterested.tsx
@@ -65,7 +65,7 @@ const NotInterested: FC<NotInterestedProps> = ({ publication }) => {
       variables: { request },
       onError,
       onCompleted: () => {
-        toast.success(t`Undo Not Interested`);
+        toast.success(t`Undo Not interested`);
         Leafwatch.track(PUBLICATION.TOGGLE_NOT_INTERESTED, {
           publication_id: publication.id,
           not_interested: false
@@ -100,12 +100,12 @@ const NotInterested: FC<NotInterestedProps> = ({ publication }) => {
         {notInterested ? (
           <>
             <EyeIcon className="h-4 w-4" />
-            <div>Undo Not Interested</div>
+            <div>Undo Not interested</div>
           </>
         ) : (
           <>
             <EyeOffIcon className="h-4 w-4" />
-            <div>Not Interested</div>
+            <div>Not interested</div>
           </>
         )}
       </div>

--- a/apps/web/src/components/Publication/Actions/Menu/Report.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Report.tsx
@@ -31,7 +31,7 @@ const Report: FC<ReportProps> = ({ publication }) => {
     >
       <div className="flex items-center space-x-2">
         <ShieldExclamationIcon className="h-4 w-4" />
-        <div>Report Post</div>
+        <div>Report post</div>
       </div>
     </Menu.Item>
   );

--- a/apps/web/src/components/Settings/Account/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Account/SuperFollow.tsx
@@ -48,7 +48,7 @@ const SuperFollow: FC = () => {
     }
 
     setIsLoading(false);
-    toast.success(t`Super Follow updated successfully!`);
+    toast.success(t`Super follow updated successfully!`);
     Leafwatch.track(SETTINGS.ACCOUNT.SET_SUPER_FOLLOW);
   };
 
@@ -142,7 +142,7 @@ const SuperFollow: FC = () => {
         <div className="space-y-2 p-5 py-10 text-center">
           <Spinner size="md" className="mx-auto" />
           <div>
-            <Trans>Loading super follow settings</Trans>
+            <Trans>Loading Super follow settings</Trans>
           </div>
         </div>
       </Card>
@@ -161,18 +161,18 @@ const SuperFollow: FC = () => {
         }}
       >
         <div className="text-lg font-bold">
-          <Trans>Set super follow</Trans>
+          <Trans>Set Super follow</Trans>
         </div>
         <p>
           <Trans>
-            Setting super follow makes users spend crypto to follow you, and
+            Setting Super follow makes users spend crypto to follow you, and
             it's a good way to earn it, you can change the amount and currency
             or disable/enable it anytime.
           </Trans>
         </p>
         <div className="pt-2">
           <div className="label">
-            <Trans>Select Currency</Trans>
+            <Trans>Select currency</Trans>
           </div>
           <select
             className="focus:border-brand-500 focus:ring-brand-400 w-full rounded-xl border border-gray-300 bg-white outline-none dark:border-gray-700 dark:bg-gray-800"

--- a/apps/web/src/components/Settings/Allowance/Button.tsx
+++ b/apps/web/src/components/Settings/Allowance/Button.tsx
@@ -119,7 +119,7 @@ const AllowanceButton: FC<AllowanceButtonProps> = ({
                 <Trans>
                   Please be aware that by allowing this module, the amount
                   indicated will be automatically deducted when you{' '}
-                  <b>collect</b> and <b>super follow</b>.
+                  <b>Collect</b> and <b>Super follow</b>.
                 </Trans>
               </div>
             }

--- a/apps/web/src/components/Settings/Allowance/index.tsx
+++ b/apps/web/src/components/Settings/Allowance/index.tsx
@@ -75,7 +75,7 @@ const AllowanceSettings: NextPage = () => {
           <div className="mx-5 mt-5">
             <div className="space-y-5">
               <div className="text-lg font-bold">
-                <Trans>Allow / Revoke modules</Trans>
+                <Trans>Allow / revoke modules</Trans>
               </div>
               <p>
                 <Trans>
@@ -86,7 +86,7 @@ const AllowanceSettings: NextPage = () => {
             </div>
             <div className="divider my-5" />
             <div className="label mt-6">
-              <Trans>Select Currency</Trans>
+              <Trans>Select currency</Trans>
             </div>
             <select
               className="focus:border-brand-500 focus:ring-brand-400 w-full rounded-xl border border-gray-300 bg-white outline-none dark:border-gray-700 dark:bg-gray-800"

--- a/apps/web/src/components/Settings/Cleanup/index.tsx
+++ b/apps/web/src/components/Settings/Cleanup/index.tsx
@@ -47,13 +47,13 @@ const CleanupSettings: NextPage = () => {
         <Card className="p-5">
           <div className="space-y-5">
             <div className="text-lg font-bold">
-              <Trans>Cleanup Localstorage</Trans>
+              <Trans>Cleanup local storage</Trans>
             </div>
             <p>
               <Trans>
                 If you stuck with some issues, you can try to clean up the
-                localstorage. This will remove all the data stored in your
-                browser.
+                browser's internal local storage. This will remove all the data
+                stored in your browser.
               </Trans>
             </p>
           </div>

--- a/apps/web/src/components/Settings/Danger/Delete.tsx
+++ b/apps/web/src/components/Settings/Danger/Delete.tsx
@@ -136,7 +136,7 @@ const DeleteSettings: FC = () => {
         {isLoading ? t`Deleting...` : t`Delete your account`}
       </Button>
       <Modal
-        title={t`Danger Zone`}
+        title={t`Danger zone`}
         icon={<ExclamationIcon className="h-5 w-5 text-red-500" />}
         show={showWarningModal}
         onClose={() => setShowWarningModal(false)}

--- a/apps/web/src/components/Settings/Danger/Guardian.tsx
+++ b/apps/web/src/components/Settings/Danger/Guardian.tsx
@@ -104,7 +104,7 @@ const GuardianSettings: FC = () => {
         </Button>
       )}
       <Modal
-        title={t`Danger Zone`}
+        title={t`Danger zone`}
         icon={<ExclamationIcon className="h-5 w-5 text-red-500" />}
         show={showWarningModal}
         onClose={() => setShowWarningModal(false)}

--- a/apps/web/src/components/Settings/Dispatcher/index.tsx
+++ b/apps/web/src/components/Settings/Dispatcher/index.tsx
@@ -26,11 +26,11 @@ const DispatcherSettings: FC = () => {
 
   const getTitleText = () => {
     if (canUseRelay) {
-      return <Trans>Disable Signless Transactions</Trans>;
+      return <Trans>Disable signless transactions</Trans>;
     } else if (isOldDispatcherEnabled) {
-      return <Trans>Signless Transactions Upgrade</Trans>;
+      return <Trans>Signless transactions upgrade</Trans>;
     } else {
-      return <Trans>Signless Transactions</Trans>;
+      return <Trans>Signless transactions</Trans>;
     }
   };
 

--- a/apps/web/src/components/Settings/Profile/NftPicture.tsx
+++ b/apps/web/src/components/Settings/Profile/NftPicture.tsx
@@ -27,7 +27,7 @@ const NftPicture: FC<NftPictureProps> = ({ profile }) => {
         icon={<PhotographIcon className="h-4 w-4" />}
         onClick={() => setShowNftAvatarModal(true)}
       >
-        <Trans>Choose NFT Avatar</Trans>
+        <Trans>Choose NFT avatar</Trans>
       </Button>
       <NftAvatarModal
         showNftAvatarModal={showNftAvatarModal}

--- a/apps/web/src/components/Settings/Profile/index.tsx
+++ b/apps/web/src/components/Settings/Profile/index.tsx
@@ -73,7 +73,7 @@ const ProfileSettings: NextPage = () => {
               onClick={() => setSettingsType('AVATAR')}
             />
             <TabButton
-              name="NFT Avatar"
+              name="NFT avatar"
               icon={<CubeIcon className="h-5 w-5" />}
               active={settingsType === 'NFT'}
               onClick={() => setSettingsType('NFT')}

--- a/apps/web/src/components/Settings/Sidebar.tsx
+++ b/apps/web/src/components/Settings/Sidebar.tsx
@@ -66,7 +66,7 @@ const SettingsSidebar: FC = () => {
           {
             title: (
               <div className="text-red-500">
-                <Trans>Danger Zone</Trans>
+                <Trans>Danger zone</Trans>
               </div>
             ),
             icon: <ExclamationIcon className="h-4 w-4 text-red-500" />,

--- a/apps/web/src/components/Shared/GlobalModals.tsx
+++ b/apps/web/src/components/Shared/GlobalModals.tsx
@@ -82,7 +82,7 @@ const GlobalModals: FC = () => {
         <ReportPublication publication={reportingPublication} />
       </Modal>
       <Modal
-        title={t`Report Profile`}
+        title={t`Report profile`}
         icon={<ShieldCheckIcon className="text-brand h-5 w-5" />}
         show={showReportProfileModal}
         onClose={() => setShowReportProfileModal(false, reportingProfile)}

--- a/apps/web/src/components/Shared/Navbar/NavItems/SwitchProfile.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/SwitchProfile.tsx
@@ -25,7 +25,7 @@ const SwitchProfile: FC<SwitchProfileProps> = ({ className = '' }) => {
       <div className="flex items-center space-x-2">
         <SwitchHorizontalIcon className="h-4 w-4" />
         <span>
-          <Trans>Switch Profile</Trans>
+          <Trans>Switch profile</Trans>
         </span>
       </div>
     </button>

--- a/apps/web/src/components/Shared/Navbar/NavItems/YourProfile.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/YourProfile.tsx
@@ -17,7 +17,7 @@ const YourProfile: FC<YourProfileProps> = ({ className = '' }) => {
     >
       <UserIcon className="h-4 w-4" />
       <div>
-        <Trans>Your Profile</Trans>
+        <Trans>Your profile</Trans>
       </div>
     </div>
   );

--- a/apps/web/src/components/Shared/SuperFollow/FollowModule.tsx
+++ b/apps/web/src/components/Shared/SuperFollow/FollowModule.tsx
@@ -187,7 +187,7 @@ const FollowModule: FC<FollowModuleProps> = ({
   };
 
   if (loading) {
-    return <Loader message={t`Loading super follow`} />;
+    return <Loader message={t`Loading Super follow`} />;
   }
 
   return (
@@ -257,7 +257,7 @@ const FollowModule: FC<FollowModuleProps> = ({
             <div>•</div>
             <div>
               <Trans>
-                You will get super follow badge in @
+                You will get Super follow badge in @
                 {formatHandle(profile?.handle)}'s profile
               </Trans>
             </div>

--- a/apps/web/src/components/Shared/SuperFollow/index.tsx
+++ b/apps/web/src/components/Shared/SuperFollow/index.tsx
@@ -15,7 +15,7 @@ import Loader from '../Loader';
 import Slug from '../Slug';
 
 const FollowModule = dynamic(() => import('./FollowModule'), {
-  loading: () => <Loader message={t`Loading super follow`} />
+  loading: () => <Loader message={t`Loading Super follow`} />
 });
 
 interface SuperFollowProps {
@@ -57,7 +57,7 @@ const SuperFollow: FC<SuperFollowProps> = ({
           setShowFollowModal(!showFollowModal);
           Leafwatch.track(PROFILE.OPEN_SUPER_FOLLOW);
         }}
-        aria-label="Super Follow"
+        aria-label="Super follow"
         icon={<StarIcon className="h-4 w-4" />}
       >
         {showText && t`Super follow`}

--- a/apps/web/src/lib/getAllowanceModule.ts
+++ b/apps/web/src/lib/getAllowanceModule.ts
@@ -16,19 +16,19 @@ const getAllowanceModule = (
   switch (name) {
     // Collect Modules
     case CollectModules.MultirecipientFeeCollectModule:
-      return { name: t`Multirecipient Paid Collect`, field: 'collectModule' };
+      return { name: t`Multirecipient paid collect`, field: 'collectModule' };
     case CollectModules.SimpleCollectModule:
-      return { name: t`Basic Collect`, field: 'collectModule' };
+      return { name: t`Basic collect`, field: 'collectModule' };
     case CollectModules.RevertCollectModule:
-      return { name: t`No Collect`, field: 'collectModule' };
+      return { name: t`No collect`, field: 'collectModule' };
 
     // Follow modules
     case FollowModules.FeeFollowModule:
-      return { name: t`Fee Follow`, field: 'followModule' };
+      return { name: t`Fee follow`, field: 'followModule' };
 
     // Reference modules
     case ReferenceModules.FollowerOnlyReferenceModule:
-      return { name: t`Follower Only Reference`, field: 'referenceModule' };
+      return { name: t`Follower only reference`, field: 'referenceModule' };
     default:
       return { name, field: 'collectModule' };
   }

--- a/apps/web/tests/publication/publication.spec.ts
+++ b/apps/web/tests/publication/publication.spec.ts
@@ -28,7 +28,7 @@ test.describe('Publication', () => {
       const localeSelectorMenuItems = page.getByTestId(
         'publication-0x0d-0x01-menu-items'
       );
-      await expect(localeSelectorMenuItems).toContainText('Report Post');
+      await expect(localeSelectorMenuItems).toContainText('Report post');
       await expect(localeSelectorMenuItems).toContainText('Share');
       await expect(localeSelectorMenuItems).toContainText('Translate');
       await expect(localeSelectorMenuItems).toContainText('Copy post text');

--- a/packages/data/algorithms.ts
+++ b/packages/data/algorithms.ts
@@ -10,7 +10,7 @@ export const algorithms: {
   isPersonalized?: boolean;
 }[] = [
   {
-    name: 'Most Viewed',
+    name: 'Most viewed',
     feedType: HomeFeedType.LENSTER_MOSTVIEWED,
     description:
       'Most viewed posts sorted by the number of views in the last 24 hours in Lenster.',
@@ -18,7 +18,7 @@ export const algorithms: {
     by: 'Lenster'
   },
   {
-    name: 'Most Interacted',
+    name: 'Most interacted',
     feedType: HomeFeedType.LENSTER_MOSTINTERACTED,
     description:
       'Most interacted posts sorted by the number of interactions in the last 24 hours in Lenster.',


### PR DESCRIPTION
## What does this PR do?

Changed capitalization from "Every Word Capitalized" to "First word capitalized"

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 74fd89b</samp>

This pull request changes the text and capitalization of various UI elements in the web app to improve the consistency and readability of the user interface. It mainly affects the components related to the Super follow, Collect, NFT avatar, and report features, as well as some titles, labels, and menu items. The files modified are `NotInterested.tsx`, `SuperFollow.tsx`, `Allowance/index.tsx`, `FollowModule.tsx`, `SuperFollow/index.tsx`, `AmountConfig.tsx`, `EnableDispatcher.tsx`, `Report.tsx`, `Button.tsx`, `Cleanup/index.tsx`, `Delete.tsx`, `Guardian.tsx`, `Dispatcher/index.tsx`, `Profile/index.tsx`, `NftPicture.tsx`, `Sidebar.tsx`, `GlobalModals.tsx`, `SwitchProfile.tsx`, and `YourProfile.tsx`.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 74fd89b</samp>

*  Lowercase the text of various labels, titles, menu items, toast messages, and modal messages for consistency ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-8b0247ad958206c7b769effec612db871ad803e92f8ae0c920d24e247f810d2dL63-R63), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-cd4601f195c5c8ddb639d0e43b4146b32bfe5192cb9e2d1c72abbcfe299e7e7dL36-R38), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-7b72b7c38975c0882e8817f8644ce533478bd9674a306ff2d6780cfc8b92d34aL28-R28), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-9ba1d3c8baea3342dc08be11c56c3eb29cd24773243c37b9f56c698aae449090L68-R68), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-9ba1d3c8baea3342dc08be11c56c3eb29cd24773243c37b9f56c698aae449090L103-R108), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-9c0a70867df1590f0f8af2fc9d2fa3fb6cdee9e4fb96f2ba14006f571ed9de93L34-R34), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L51-R51), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-23a1c59b7d2b2543480683246af5951dc9b0c95fd6b4ae9bf6df327105704e68L78-R78), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-53f4ad8d0d0cd0249226620ffd5b5c0e95cf9f9a3e4077efb08fba46c375fc57L50-R56), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-aae51350297a3caa87f5b2cfa0307b6b207a4891cfb3be7074a340b9eb9b6df6L139-R139), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-7c93d329c665824b282d39c9a9a417223094b14938f2f1e27a541666a4c7b11fL107-R107), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-984090921221d9d884d75401d68470768953a9f2fc91d95cb1fee11ac7fb5662L29-R33), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-cf0a97986c4205646f837237d73d253f968c2212d1745a1bf33b795784a7db1cL30-R30), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-0de412fc4efcb88f662f60a811710f85034369cb41dbe1a4962cbed58ed80203L76-R76), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-464cfc03ff20f2199bbff2659eece544d3cf9463d6e5405ae54e345f3ad469a1L69-R69), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-fdb706900e098449623e377a52b54f379ea7ae04d182358e10a6dccb233890c2L85-R85), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-413aa9fea127c744a9a7e4da451fd8a12a5823ada5b7d4d2fcf2f1973d0182f9L28-R28), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-b46950cf27d39629f9396e196477a89e8aaedc44d9371a10ef599e7c5cc8825fL20-R20), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-8d76c880d7997e4bc2c047840de037491cdfe8c70748107e7d5ec6715963ad8eL60-R60))
* Capitalize the term Super follow as a feature name in various loader messages, descriptions, and titles ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L145-R145), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249L164-R168), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-cfc16ec8965a8ee0f8d417864ef8445f94b2dea6959342a0f0db76ab033f0408L122-R122), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-c9dc50d00ae6e20957ce95b12e76c80b0548fc9743ca5969a597c8e7a9ec9ea6L190-R190), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-c9dc50d00ae6e20957ce95b12e76c80b0548fc9743ca5969a597c8e7a9ec9ea6L260-R260), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-8d76c880d7997e4bc2c047840de037491cdfe8c70748107e7d5ec6715963ad8eL18-R18))
* Lowercase the term local storage and clarify that it refers to the browser's internal storage in the title and description of the cleanup settings component ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-53f4ad8d0d0cd0249226620ffd5b5c0e95cf9f9a3e4077efb08fba46c375fc57L50-R56))
* Lowercase the term NFT avatar in the button and tab button for choosing the NFT avatar in the profile settings component ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-cf0a97986c4205646f837237d73d253f968c2212d1745a1bf33b795784a7db1cL30-R30), [link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-0de412fc4efcb88f662f60a811710f85034369cb41dbe1a4962cbed58ed80203L76-R76))
* Lowercase the term signless transactions in the title of the dispatcher settings component ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-984090921221d9d884d75401d68470768953a9f2fc91d95cb1fee11ac7fb5662L29-R33))
* Lowercase the term report profile in the title of the modal for reporting a profile in the global modals component ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-fdb706900e098449623e377a52b54f379ea7ae04d182358e10a6dccb233890c2L85-R85))
* Lowercase the term switch profile in the menu item for switching the profile in the navbar component ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-413aa9fea127c744a9a7e4da451fd8a12a5823ada5b7d4d2fcf2f1973d0182f9L28-R28))
* Lowercase the term your profile in the menu item for viewing the profile in the navbar component ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-b46950cf27d39629f9396e196477a89e8aaedc44d9371a10ef599e7c5cc8825fL20-R20))
* Lowercase the term super follow in the aria-label of the Super follow button in the super follow component ([link](https://github.com/lensterxyz/lenster/pull/3571/files?diff=unified&w=0#diff-8d76c880d7997e4bc2c047840de037491cdfe8c70748107e7d5ec6715963ad8eL60-R60))

## Emoji

<!--
copilot:emoji
-->

📝🖼️🎨

<!--
1.  📝 This emoji can be used to indicate that the changes involve text editing, such as changing the capitalization, wording, or formatting of the UI elements.
2.  🖼️ This emoji can be used to indicate that the changes affect the appearance or layout of the UI elements, such as the labels, titles, buttons, or menus.
3.  🎨 This emoji can be used to indicate that the changes improve the design or aesthetics of the UI elements, such as the color, contrast, or alignment.
-->
