### PR TITLE
feat: add loadingPreferences indicator

### DIFF
--- a/apps/web/src/components/Common/Layout.tsx
+++ b/apps/web/src/components/Common/Layout.tsx
@@ -28,20 +28,11 @@ interface LayoutProps {
 
 const Layout: FC<LayoutProps> = ({ children }) => {
   const { resolvedTheme } = useTheme();
-  const setProfiles = useAppStore((state) => state.setProfiles);
-  const currentProfile = useAppStore((state) => state.currentProfile);
-  const setCurrentProfile = useAppStore((state) => state.setCurrentProfile);
-  const setProfileGuardianInformation = useProfileGuardianInformationStore(
-    (state) => state.setProfileGuardianInformation
-  );
-  const resetPreferences = usePreferencesStore(
-    (state) => state.resetPreferences
-  );
-  const resetProfileGuardianInformation = useProfileGuardianInformationStore(
-    (state) => state.resetProfileGuardianInformation
-  );
-  const profileId = useAppPersistStore((state) => state.profileId);
-  const setProfileId = useAppPersistStore((state) => state.setProfileId);
+  const { setProfiles, currentProfile, setCurrentProfile } = useAppStore();
+  const { setProfileGuardianInformation, resetProfileGuardianInformation } =
+    useProfileGuardianInformationStore();
+  const { profileId, setProfileId } = useAppPersistStore();
+  const { loadingPreferences, resetPreferences } = usePreferencesStore();
 
   const isMounted = useIsMounted();
   const { address } = useAccount();
@@ -109,7 +100,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
     validateAuthentication();
   }, [address, chain, disconnect, profileId]);
 
-  if (loading || !isMounted()) {
+  if (loading || loadingPreferences || !isMounted()) {
     return <Loading />;
   }
 

--- a/apps/web/src/components/Common/Providers/PreferencesProvider.tsx
+++ b/apps/web/src/components/Common/Providers/PreferencesProvider.tsx
@@ -15,31 +15,35 @@ const PreferencesProvider: FC = () => {
     setStaffMode,
     setGardenerMode,
     setIsPride,
-    setHighSignalNotificationFilter
+    setHighSignalNotificationFilter,
+    setLoadingPreferences
   } = usePreferencesStore();
 
   const fetchPreferences = async () => {
     try {
-      const response = await axios(
-        `${PREFERENCES_WORKER_URL}/get/${profileId}`
-      );
-      const { data } = response;
+      if (Boolean(profileId)) {
+        const response = await axios(
+          `${PREFERENCES_WORKER_URL}/get/${profileId}`
+        );
+        const { data } = response;
 
-      setIsStaff(data.result?.is_staff || false);
-      setIsGardener(data.result?.is_gardener || false);
-      setIsTrustedMember(data.result?.is_trusted_member || false);
-      setStaffMode(data.result?.staff_mode || false);
-      setGardenerMode(data.result?.gardener_mode || false);
-      setIsPride(data.result?.is_pride || false);
-      setHighSignalNotificationFilter(
-        data.result?.high_signal_notification_filter || false
-      );
-    } catch {}
+        setIsStaff(data.result?.is_staff || false);
+        setIsGardener(data.result?.is_gardener || false);
+        setIsTrustedMember(data.result?.is_trusted_member || false);
+        setStaffMode(data.result?.staff_mode || false);
+        setGardenerMode(data.result?.gardener_mode || false);
+        setIsPride(data.result?.is_pride || false);
+        setHighSignalNotificationFilter(
+          data.result?.high_signal_notification_filter || false
+        );
+      }
+    } catch {
+    } finally {
+      setLoadingPreferences(false);
+    }
   };
 
-  useQuery(['preferences', profileId], () => fetchPreferences(), {
-    enabled: Boolean(profileId)
-  });
+  useQuery(['preferences', profileId], () => fetchPreferences());
 
   const fetchVerifiedMembers = async () => {
     try {

--- a/apps/web/src/store/preferences.ts
+++ b/apps/web/src/store/preferences.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 
 interface PreferencesState {
+  loadingPreferences: boolean;
+  setLoadingPreferences: (loadingPreferences: boolean) => void;
   isStaff: boolean;
   setIsStaff: (isStaff: boolean) => void;
   isGardener: boolean;
@@ -21,6 +23,9 @@ interface PreferencesState {
 }
 
 export const usePreferencesStore = create<PreferencesState>((set) => ({
+  loadingPreferences: true,
+  setLoadingPreferences: (loadingPreferences) =>
+    set(() => ({ loadingPreferences })),
   isStaff: false,
   setIsStaff: (isStaff) => set(() => ({ isStaff })),
   isGardener: false,


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bd0d11</samp>

Improved the web app's performance and user experience by adding a loading state and indicator for preferences data. Refactored the `Layout` component and the `preferences` store to use object destructuring and simplify the logic. Moved the `PreferencesProvider` component to the `Layout` component file.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bd0d11</samp>

* Refactor `Layout` component to use object destructuring for state selectors ([link](https://github.com/lensterxyz/lenster/pull/3590/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637L31-R35))
* Add `loadingPreferences` state to `preferences` store and initialize it with `true` ([link](https://github.com/lensterxyz/lenster/pull/3590/files?diff=unified&w=0#diff-1a375bfb322aa332b37803f1d7ae1a19bd7fefab084008b95c410bbe48856f59R4-R5), [link](https://github.com/lensterxyz/lenster/pull/3590/files?diff=unified&w=0#diff-1a375bfb322aa332b37803f1d7ae1a19bd7fefab084008b95c410bbe48856f59R26-R28))
* Update `Layout` component to check `loadingPreferences` state before rendering `Loading` component ([link](https://github.com/lensterxyz/lenster/pull/3590/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637L112-R103))
* Move `PreferencesProvider` component to `Layout.tsx` file and simplify `useQuery` hook ([link](https://github.com/lensterxyz/lenster/pull/3590/files?diff=unified&w=0#diff-42a87ccc328ac34a5d618f96581e4b735707d91aeead245bbe955f1015cba04eL18-R46))
* Modify `fetchPreferences` function to only make API call if `profileId` is truthy and set `loadingPreferences` to false after call ([link](https://github.com/lensterxyz/lenster/pull/3590/files?diff=unified&w=0#diff-42a87ccc328ac34a5d618f96581e4b735707d91aeead245bbe955f1015cba04eL18-R46))

## Emoji

<!--
copilot:emoji
-->

🔀🔄⏳

<!--
1.  🔀 - This emoji represents the moving of the `PreferencesProvider` component to the `Layout` component file, as it implies a change of location or order.
2.  🔄 - This emoji represents the refactoring and improvement of the `Layout` component and the `fetchPreferences` function, as it implies a change of logic or functionality.
3.  ⏳ - This emoji represents the addition of the loading state and action to the `preferences` store, as it implies a change of status or progress.
-->
