### PR TITLE
fix: bookmark cache

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -76,7 +76,7 @@
     "use-resize-observer": "^9.1.0",
     "usehooks-ts": "^2.9.1",
     "uuid": "^9.0.0",
-    "viem": "^1.6.3",
+    "viem": "^1.6.4",
     "wagmi": "^1.3.10",
     "xmtp-content-type-remote-attachment": "^1.0.7",
     "zod": "^3.22.2",

--- a/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
@@ -47,7 +47,7 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
       id: publicationKeyFields(bookmarkedPublications),
       fields: {
         bookmarked: () => bookmarked,
-        stats: (stats) => ({
+        stats: (stats: any) => ({
           ...stats,
           totalBookmarks: bookmarked
             ? stats.totalBookmarks + 1

--- a/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
@@ -38,7 +38,7 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
     publicationId: publication.id
   };
 
-  const updateCache = (cache: ApolloCache<any>, bookmarked: boolean) => {
+  const updateCache = (cache: ApolloCache<any>) => {
     const bookmarkedPublications = isMirror
       ? publication?.mirrorOf
       : publication;
@@ -46,8 +46,8 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
     cache.modify({
       id: publicationKeyFields(bookmarkedPublications),
       fields: {
-        bookmarked: () => bookmarked,
-        stats: (stats: any) => ({
+        bookmarked: (bookmarked) => !bookmarked,
+        stats: (stats) => ({
           ...stats,
           totalBookmarks: bookmarked
             ? stats.totalBookmarks + 1
@@ -77,7 +77,7 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
           bookmarked: true
         });
       },
-      update: (cache) => updateCache(cache, true)
+      update: (cache) => updateCache(cache)
     });
 
   const [removePublicationProfileBookmark] =
@@ -91,7 +91,7 @@ const Bookmark: FC<BookmarkProps> = ({ publication }) => {
           bookmarked: false
         });
       },
-      update: (cache) => updateCache(cache, false)
+      update: (cache) => updateCache(cache)
     });
 
   const togglePublicationProfileBookmark = async () => {

--- a/packages/bundlr/package.json
+++ b/packages/bundlr/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "base64url": "^3.0.1",
-    "viem": "^1.6.3"
+    "viem": "^1.6.4"
   },
   "devDependencies": {
     "@lenster/config": "workspace:*",

--- a/packages/lens/package.json
+++ b/packages/lens/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc --pretty"
   },
   "dependencies": {
-    "@apollo/client": "^3.7.17",
+    "@apollo/client": "^3.8.1",
     "@lenster/data": "workspace:*",
     "axios": "^1.4.0"
   },

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -15,7 +15,7 @@
     "@lenster/data": "workspace:*",
     "@lenster/lens": "workspace:*",
     "axios": "^1.4.0",
-    "viem": "^1.6.3"
+    "viem": "^1.6.4"
   },
   "devDependencies": {
     "@lenster/config": "workspace:*",

--- a/packages/snapshot/package.json
+++ b/packages/snapshot/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --pretty"
   },
   "dependencies": {
-    "@apollo/client": "^3.7.17",
+    "@apollo/client": "^3.8.1",
     "@lenster/data": "workspace:*"
   },
   "devDependencies": {

--- a/packages/workers/ens/package.json
+++ b/packages/workers/ens/package.json
@@ -18,7 +18,7 @@
     "@lenster/data": "workspace:*",
     "@lenster/lib": "workspace:*",
     "itty-router": "^4.0.20",
-    "viem": "^1.6.3",
+    "viem": "^1.6.4",
     "zod": "^3.22.2"
   },
   "devDependencies": {

--- a/packages/workers/snapshot-relay/package.json
+++ b/packages/workers/snapshot-relay/package.json
@@ -18,7 +18,7 @@
     "@lenster/data": "workspace:*",
     "@lenster/lib": "workspace:*",
     "itty-router": "^4.0.20",
-    "viem": "^1.6.3"
+    "viem": "^1.6.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230814.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,11 +250,11 @@ importers:
         specifier: ^9.0.0
         version: 9.0.0
       viem:
-        specifier: ^1.6.3
-        version: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+        specifier: ^1.6.4
+        version: 1.6.4(typescript@5.1.6)(zod@3.22.2)
       wagmi:
         specifier: ^1.3.10
-        version: 1.3.10(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(viem@1.6.3)(zod@3.22.2)
+        version: 1.3.10(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(viem@1.6.4)(zod@3.22.2)
       xmtp-content-type-remote-attachment:
         specifier: ^1.0.7
         version: 1.0.7
@@ -320,8 +320,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       viem:
-        specifier: ^1.6.3
-        version: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+        specifier: ^1.6.4
+        version: 1.6.4(typescript@5.1.6)(zod@3.22.2)
     devDependencies:
       '@lenster/config':
         specifier: workspace:*
@@ -409,8 +409,8 @@ importers:
   packages/lens:
     dependencies:
       '@apollo/client':
-        specifier: ^3.7.17
-        version: 3.7.17(graphql@16.8.0)
+        specifier: ^3.8.1
+        version: 3.8.1(graphql@16.8.0)(react-dom@18.2.0)(react@18.2.0)
       '@lenster/data':
         specifier: workspace:*
         version: link:../data
@@ -458,8 +458,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       viem:
-        specifier: ^1.6.3
-        version: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+        specifier: ^1.6.4
+        version: 1.6.4(typescript@5.1.6)(zod@3.22.2)
     devDependencies:
       '@lenster/config':
         specifier: workspace:*
@@ -477,8 +477,8 @@ importers:
   packages/snapshot:
     dependencies:
       '@apollo/client':
-        specifier: ^3.7.17
-        version: 3.7.17(graphql@16.8.0)
+        specifier: ^3.8.1
+        version: 3.8.1(graphql@16.8.0)(react-dom@18.2.0)(react@18.2.0)
       '@lenster/data':
         specifier: workspace:*
         version: link:../data
@@ -610,8 +610,8 @@ importers:
         specifier: ^4.0.20
         version: 4.0.20
       viem:
-        specifier: ^1.6.3
-        version: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+        specifier: ^1.6.4
+        version: 1.6.4(typescript@5.1.6)(zod@3.22.2)
       zod:
         specifier: ^3.22.2
         version: 3.22.2
@@ -860,8 +860,8 @@ importers:
         specifier: ^4.0.20
         version: 4.0.20
       viem:
-        specifier: ^1.6.3
-        version: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+        specifier: ^1.6.4
+        version: 1.6.4(typescript@5.1.6)(zod@3.22.2)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20230814.0
@@ -923,40 +923,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
-
-  /@apollo/client@3.7.17(graphql@16.8.0):
-    resolution: {integrity: sha512-0EErSHEtKPNl5wgWikHJbKFAzJ/k11O0WO2QyqZSHpdxdAnw7UWHY4YiLbHCFG7lhrD+NTQ3Z/H9Jn4rcikoJA==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-      graphql-ws: ^5.5.5
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
-    peerDependenciesMeta:
-      graphql-ws:
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      subscriptions-transport-ws:
-        optional: true
-    dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@16.8.0)
-      '@wry/context': 0.7.3
-      '@wry/equality': 0.5.6
-      '@wry/trie': 0.4.3
-      graphql: 16.8.0
-      graphql-tag: 2.12.6(graphql@16.8.0)
-      hoist-non-react-statics: 3.3.2
-      optimism: 0.16.2
-      prop-types: 15.8.1
-      response-iterator: 0.2.6
-      symbol-observable: 4.0.0
-      ts-invariant: 0.10.3
-      tslib: 2.6.1
-      zen-observable-ts: 1.2.5
-    dev: false
 
   /@apollo/client@3.8.1(graphql@16.8.0)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-JGGj/9bdoLEqzatRikDeN8etseY5qeFAY0vSAx/Pd0ePNsaflKzHx6V2NZ0NsGkInq+9IXXX3RLVDf0EotizMA==}
@@ -4920,7 +4886,7 @@ packages:
       '@motionone/easing': 10.15.1
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@motionone/dom@10.16.2:
@@ -4931,14 +4897,14 @@ packages:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
       hey-listen: 1.0.8
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@motionone/easing@10.15.1:
     resolution: {integrity: sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==}
     dependencies:
       '@motionone/utils': 10.15.1
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@motionone/generators@10.15.1:
@@ -4946,14 +4912,14 @@ packages:
     dependencies:
       '@motionone/types': 10.15.1
       '@motionone/utils': 10.15.1
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@motionone/svelte@10.16.2:
     resolution: {integrity: sha512-38xsroKrfK+aHYhuQlE6eFcGy0EwrB43Q7RGjF73j/kRUTcLNu/LAaKiLLsN5lyqVzCgTBVt4TMT/ShWbTbc5Q==}
     dependencies:
       '@motionone/dom': 10.16.2
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@motionone/types@10.15.1:
@@ -4965,14 +4931,14 @@ packages:
     dependencies:
       '@motionone/types': 10.15.1
       hey-listen: 1.0.8
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@motionone/vue@10.16.2:
     resolution: {integrity: sha512-7/dEK/nWQXOkJ70bqb2KyNfSWbNvWqKKq1C8juj+0Mg/AorgD8O5wE3naddK0G+aXuNMqRuc4jlsYHHWHtIzVw==}
     dependencies:
       '@motionone/dom': 10.16.2
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /@next/env@13.4.12:
@@ -5842,7 +5808,7 @@ packages:
     resolution: {integrity: sha512-gYw0ki/EAuV1oSyMxpqandHjnthZjYYy+YWpTAzf8BqfXM3ItcZLpjxfg+3+mXW8HIO+3jw6T9iiqEXsqHaMMw==}
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.8.0
-      viem: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+      viem: 1.6.4(typescript@5.1.6)(zod@3.22.2)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -7019,7 +6985,7 @@ packages:
       typescript: 5.1.6
     dev: false
 
-  /@wagmi/connectors@2.7.0(@wagmi/chains@1.7.0)(react@18.2.0)(typescript@5.1.6)(viem@1.6.3)(zod@3.22.2):
+  /@wagmi/connectors@2.7.0(@wagmi/chains@1.7.0)(react@18.2.0)(typescript@5.1.6)(viem@1.6.4)(zod@3.22.2):
     resolution: {integrity: sha512-1KOL0HTJl5kzSC/YdKwFwiokr6poUQn1V/tcT0TpG3iH2x0lSM7FTkvCjVVY/6lKzTXrLlo9y2aE7AsOPnkvqg==}
     peerDependencies:
       '@wagmi/chains': '>=1.7.0'
@@ -7043,7 +7009,7 @@ packages:
       abitype: 0.8.7(typescript@5.1.6)(zod@3.22.2)
       eventemitter3: 4.0.7
       typescript: 5.1.6
-      viem: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+      viem: 1.6.4(typescript@5.1.6)(zod@3.22.2)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - bufferutil
@@ -7055,7 +7021,7 @@ packages:
       - zod
     dev: false
 
-  /@wagmi/core@1.3.9(@types/react@18.2.20)(react@18.2.0)(typescript@5.1.6)(viem@1.6.3)(zod@3.22.2):
+  /@wagmi/core@1.3.9(@types/react@18.2.20)(react@18.2.0)(typescript@5.1.6)(viem@1.6.4)(zod@3.22.2):
     resolution: {integrity: sha512-SrnABCrsDvhiMCLLLyzyHnZbEumsFT/XWlJJQZeyEDcixL95R7XQwOaaoRI4MpNilCtMtu3jzN57tA5Z2iA+kw==}
     peerDependencies:
       typescript: '>=5.0.4'
@@ -7065,11 +7031,11 @@ packages:
         optional: true
     dependencies:
       '@wagmi/chains': 1.7.0(typescript@5.1.6)
-      '@wagmi/connectors': 2.7.0(@wagmi/chains@1.7.0)(react@18.2.0)(typescript@5.1.6)(viem@1.6.3)(zod@3.22.2)
+      '@wagmi/connectors': 2.7.0(@wagmi/chains@1.7.0)(react@18.2.0)(typescript@5.1.6)(viem@1.6.4)(zod@3.22.2)
       abitype: 0.8.7(typescript@5.1.6)(zod@3.22.2)
       eventemitter3: 4.0.7
       typescript: 5.1.6
-      viem: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+      viem: 1.6.4(typescript@5.1.6)(zod@3.22.2)
       zustand: 4.4.1(@types/react@18.2.20)(react@18.2.0)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
@@ -7625,13 +7591,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /@wry/trie@0.3.2:
-    resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      tslib: 2.6.1
-    dev: false
-
   /@wry/trie@0.4.3:
     resolution: {integrity: sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==}
     engines: {node: '>=8'}
@@ -7854,7 +7813,7 @@ packages:
     resolution: {integrity: sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==}
     engines: {node: '>=10'}
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /aria-query@5.3.0:
@@ -7974,7 +7933,7 @@ packages:
   /async-mutex@0.2.6:
     resolution: {integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==}
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /async-mutex@0.4.0:
@@ -12255,13 +12214,6 @@ packages:
       is-wsl: 2.2.0
     dev: true
 
-  /optimism@0.16.2:
-    resolution: {integrity: sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==}
-    dependencies:
-      '@wry/context': 0.7.3
-      '@wry/trie': 0.3.2
-    dev: false
-
   /optimism@0.17.5:
     resolution: {integrity: sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==}
     dependencies:
@@ -13086,7 +13038,7 @@ packages:
       '@types/react': 18.2.20
       react: 18.2.0
       react-style-singleton: 2.2.1(@types/react@18.2.20)(react@18.2.0)
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /react-remove-scroll@2.5.5(@types/react@18.2.20)(react@18.2.0):
@@ -13103,7 +13055,7 @@ packages:
       react: 18.2.0
       react-remove-scroll-bar: 2.3.4(@types/react@18.2.20)(react@18.2.0)
       react-style-singleton: 2.2.1(@types/react@18.2.20)(react@18.2.0)
-      tslib: 2.6.1
+      tslib: 2.6.2
       use-callback-ref: 1.3.0(@types/react@18.2.20)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.20)(react@18.2.0)
     dev: false
@@ -13135,7 +13087,7 @@ packages:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.2.0
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /react-virtuoso@4.5.0(react-dom@18.2.0)(react@18.2.0):
@@ -13457,7 +13409,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.6.1
+      tslib: 2.6.2
 
   /sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -14623,7 +14575,7 @@ packages:
     dependencies:
       '@types/react': 18.2.20
       react: 18.2.0
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /use-resize-observer@9.1.0(react-dom@18.2.0)(react@18.2.0):
@@ -14650,7 +14602,7 @@ packages:
       '@types/react': 18.2.20
       detect-node-es: 1.1.0
       react: 18.2.0
-      tslib: 2.6.1
+      tslib: 2.6.2
     dev: false
 
   /use-sync-external-store@1.2.0(react@18.2.0):
@@ -14755,8 +14707,8 @@ packages:
       vfile-message: 3.1.4
     dev: false
 
-  /viem@1.6.3(typescript@5.1.6)(zod@3.22.2):
-    resolution: {integrity: sha512-DO4cRCQEi+pZ502hSBr/POgBHC4RuhpLsOUXxuYY4yQMjmi1ACODmMgHvvk7lWMPc8dFJipKBa5rOfIUJDgX8Q==}
+  /viem@1.6.4(typescript@5.1.6)(zod@3.22.2):
+    resolution: {integrity: sha512-NUZIZRQnvjViP6P8PTQsPev9va9hYwFzAWR6y0UCtd4LBOUaAKUZqFoPTanX83rHInyHtyVTGr/Dl4qy7CbMNA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -14903,7 +14855,7 @@ packages:
       - terser
     dev: true
 
-  /wagmi@1.3.10(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(viem@1.6.3)(zod@3.22.2):
+  /wagmi@1.3.10(@types/react@18.2.20)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.6)(viem@1.6.4)(zod@3.22.2):
     resolution: {integrity: sha512-MMGJcnxOmeUZWDmzUxgRGcB1cqxbJoSFSa+pNY4vBCWMz0n4ptpE5F8FKISLCx+BGoDwsaz2ldcMALcdJZ+29w==}
     peerDependencies:
       react: '>=17.0.0'
@@ -14916,12 +14868,12 @@ packages:
       '@tanstack/query-sync-storage-persister': 4.32.6
       '@tanstack/react-query': 4.33.0(react-dom@18.2.0)(react@18.2.0)
       '@tanstack/react-query-persist-client': 4.32.6(@tanstack/react-query@4.33.0)
-      '@wagmi/core': 1.3.9(@types/react@18.2.20)(react@18.2.0)(typescript@5.1.6)(viem@1.6.3)(zod@3.22.2)
+      '@wagmi/core': 1.3.9(@types/react@18.2.20)(react@18.2.0)(typescript@5.1.6)(viem@1.6.4)(zod@3.22.2)
       abitype: 0.8.7(typescript@5.1.6)(zod@3.22.2)
       react: 18.2.0
       typescript: 5.1.6
       use-sync-external-store: 1.2.0(react@18.2.0)
-      viem: 1.6.3(typescript@5.1.6)(zod@3.22.2)
+      viem: 1.6.4(typescript@5.1.6)(zod@3.22.2)
     transitivePeerDependencies:
       - '@react-native-async-storage/async-storage'
       - '@types/react'


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 171df7f</samp>

This pull request updates the `viem` and `@apollo/client` dependencies to their latest versions in various `package.json` files, and fixes a TypeScript error in the `Bookmark` component. The purpose of these changes is to use the latest features and bug fixes of the libraries, and to improve the type safety of the code.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 171df7f</samp>

*  Updated `viem` dependency from version `1.6.3` to `1.6.4` in all packages that use it, to use the latest version of the data validation and transformation library ([link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L79-R79), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-e0bf3fc5872f59c831dacd7b82a39063628888671005bd41dc595e376dda9b41L15-R15), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-f11fdfd051a9039f87286aa9c327c257e9619660394143b2d0d8dbade3c3abd5L18-R18), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-94b7382dd579ab991570594f6a56fd18c85d3df29ed745bf1bb7080da8405e01L21-R21), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-190bb47eeddf0230d5d8ffdab97e4336f1b2e254b608c0818fa4478c44686a74L21-R21), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL253-R257), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL323-R324), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL461-R462), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL613-R614), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL863-R864), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5845-R5811), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7022-R6988), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7046-R7012), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7058-R7024), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7068-R7038), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14758-R14711), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14906-R14858), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14919-R14876))
*  Updated `@apollo/client` dependency from version `3.7.17` to `3.8.1` in packages that use it, to use the latest version of the GraphQL client library with bug fixes and improvements ([link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-844e7e7237755894506b2221ff9dea76ae4f4b5c336c3f2473d3f7ea9d19c9c1L17-R17), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-7ce58c543d1dad86fa444289b592b1a0403e2dbd9278c81c1d1908366a23a8a3L16-R16), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL412-R413), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL480-R481))
*  Removed unused dependencies from the lock file, such as `@apollo/client`, `@wry/trie`, and `optimism` ([link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL927-L960), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7628-L7634), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12258-L12264))
*  Updated `tslib` dependency from version `2.6.1` to `2.6.2` in the lock file, to use the latest version of the TypeScript runtime library with bug fixes and improvements ([link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4923-R4889), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4934-R4900), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4941-R4907), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4949-R4915), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4956-R4922), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4968-R4934), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4975-R4941), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7857-R7816), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7977-R7936), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13089-R13041), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13106-R13058), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13138-R13090), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13460-R13412), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14626-R14578), [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14653-R14605))
*  Added an explicit `any` type annotation to the `stats` parameter in the `Bookmark` component, to avoid TypeScript errors when using the custom type from the `usePublication` hook (`apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx`, [link](https://github.com/lensterxyz/lenster/pull/3591/files?diff=unified&w=0#diff-092d5ebe6db060904cad2182f60783e0a48febafd2d8d24a907537c858b0c89cL50-R50))

## Emoji

<!--
copilot:emoji
-->

📦🛠️🔒

<!--
1.  📦 - This emoji represents the updates to the package dependencies, such as `viem` and `@apollo/client`.
2.  🛠️ - This emoji represents the fix to the TypeScript error in the `Bookmark` component by adding an explicit type annotation.
3.  🔒 - This emoji represents the update to the `pnpm-lock.yaml` file, which ensures the consistency and security of the dependencies.
-->
