### PR TITLE
fix: url regex, use same regex for getURLs as for url detection

### DIFF
--- a/packages/data/regex.ts
+++ b/packages/data/regex.ts
@@ -1,7 +1,8 @@
 const RESTRICTED_SYMBOLS = '☑️✓✔✅';
 
 export const Regex = {
-  url: /(http|https):\/\/([\w+.?])+([\w!#$%&'()*+,./:;=?@\\^~\-]*)?/g,
+  // modified version of https://stackoverflow.com/a/6041965/961254 to support unicode international characters
+  url: /\b(http|https):\/\/([\p{L}\p{N}_-]+(?:(?:\.[\p{L}\p{N}_-]+)+))([\p{L}\p{N}_.,@?^=%&:\/~+#-]*[\p{L}\p{N}_@?^=%&\/~+#-])/gu,
   mention: /@[\w.\-]{1,30}[\w-]/g,
   hashtag: /(#\w*[A-Za-z]\w*)/g,
   ethereumAddress: /^(0x)?[\da-f]{40}$/i,

--- a/packages/lib/getURLs.spec.ts
+++ b/packages/lib/getURLs.spec.ts
@@ -26,4 +26,32 @@ describe('getURLs', () => {
     const expectedUrls = ['https://example.com', 'http://www.example.net'];
     expect(getURLs(text)).toEqual(expectedUrls);
   });
+
+  test('should not match trailing parentesis', () => {
+    const text =
+      'URL1: (https://example.com/) URL2: (https://example.net) URL3: (https://example.net). test';
+    const expectedUrls = [
+      'https://example.com/',
+      'https://example.net',
+      'https://example.net'
+    ];
+    expect(getURLs(text)).toEqual(expectedUrls);
+  });
+
+  test('should handle international characters', () => {
+    const text = 'URL1: http://example.com/引き割り.html';
+    const expectedUrls = ['http://example.com/引き割り.html'];
+    expect(getURLs(text)).toEqual(expectedUrls);
+  });
+
+  test('should handle trailing full stop', () => {
+    const text =
+      'i have visited http://example.com, http://example.net. https://example.net/.';
+    const expectedUrls = [
+      'http://example.com',
+      'http://example.net',
+      'https://example.net/'
+    ];
+    expect(getURLs(text)).toEqual(expectedUrls);
+  });
 });

--- a/packages/lib/getURLs.ts
+++ b/packages/lib/getURLs.ts
@@ -1,3 +1,5 @@
+import { Regex } from '@lenster/data/regex';
+
 /**
  * Returns an array of URLs found in the specified text.
  *
@@ -8,9 +10,7 @@ const getURLs = (text: string): string[] => {
   if (!text) {
     return [];
   }
-
-  const urlRegex = /(((https?:\/\/)|(www\.))\S+)/g;
-  return text.match(urlRegex) || [];
+  return text.match(Regex.url) || [];
 };
 
 export default getURLs;


### PR DESCRIPTION
## What does this PR do?

Updated regex to support trailing full stop, parenthesis, unicode characters.
Added unit tests.
Also changed to using one and the same regex (not a separate one for oembed).
Fixes #3567

Example post used in screenshots: https://testnet.lenster.xyz/posts/0x57-0xb0-DA-6fbfffec

**Before:**
![Screenshot_2023-08-21_17-11-00](https://github.com/lensterxyz/lenster/assets/667227/f2518589-7d3f-4ceb-ad92-1859390ca118)
**After:**
![Screenshot_2023-08-21_18-21-43](https://github.com/lensterxyz/lenster/assets/667227/9b7e8b20-21ac-46a4-86fa-d316990160bc)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f558d9</samp>

Refactored `getURLs` function to use a shared `Regex` object and improved the `url` regex to handle more cases. Added new tests to verify the changes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9f558d9</samp>

*  Modify `url` regex to support unicode characters and exclude trailing punctuation ([link](https://github.com/lensterxyz/lenster/pull/3599/files?diff=unified&w=0#diff-ccfbd417e113e2bc3a1dce0e85b9173f3df6ba5e31f624558e5e3d07b9409213L4-R5))
*  Update `getURLs` function to use imported `Regex` object instead of local variable ([link](https://github.com/lensterxyz/lenster/pull/3599/files?diff=unified&w=0#diff-1351d30a8aa9c70a1d1b6d904a6658ff44768d05a9f3c39bb8dfcdb9e50a386cR1-R2), [link](https://github.com/lensterxyz/lenster/pull/3599/files?diff=unified&w=0#diff-1351d30a8aa9c70a1d1b6d904a6658ff44768d05a9f3c39bb8dfcdb9e50a386cL11-R13))
*  Add test cases for `getURLs` function with modified `url` regex in `getURLs.spec.ts` ([link](https://github.com/lensterxyz/lenster/pull/3599/files?diff=unified&w=0#diff-c8ef34da3e3c38ffecf9de63db91cb7d0fad6daa2d09282bea22fd8d69acae03R29-R56))

## Emoji

<!--
copilot:emoji
-->

🌐🧪♻️

<!--
1.  🌐 - This emoji represents the support for unicode international characters in the `url` regex, which makes the function more inclusive and accessible for different languages and scripts.
2.  🧪 - This emoji represents the addition of new test cases to the `getURLs.spec.ts` file, which increases the code coverage and reliability of the function.
3.  ♻️ - This emoji represents the refactoring of the `getURLs.ts` file to use a shared `Regex` object, which reduces code duplication and improves code quality.
-->
