### PR TITLE
feat: add categories in contact page

### DIFF
--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -13,6 +13,7 @@ export { LightBox } from './src/LightBox';
 export { Modal } from './src/Modal';
 export { PageLoading } from './src/PageLoading';
 export { Radio } from './src/Radio';
+export { Select } from './src/Select';
 export { Spinner } from './src/Spinner';
 export { default as TabButton } from './src/TabButton';
 export { TextArea } from './src/TextArea';

--- a/packages/ui/src/Select.tsx
+++ b/packages/ui/src/Select.tsx
@@ -9,6 +9,7 @@ interface SelectProps extends ComponentProps<'select'> {
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
   function TextArea({ label, values }, ref) {
     const id = useId();
+
     return (
       <label htmlFor={id}>
         {label ? <div className="label">{label}</div> : null}

--- a/packages/ui/src/Select.tsx
+++ b/packages/ui/src/Select.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps } from 'react';
+import { forwardRef, useId } from 'react';
+
+interface SelectProps extends ComponentProps<'select'> {
+  label?: string;
+  values: string[];
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(
+  function TextArea({ label, values }, ref) {
+    const id = useId();
+    return (
+      <label htmlFor={id}>
+        {label ? <div className="label">{label}</div> : null}
+        <select
+          id={id}
+          className="focus:border-brand-500 focus:ring-brand-400 w-full rounded-xl border border-gray-300 bg-white outline-none dark:border-gray-700 dark:bg-gray-800"
+          ref={ref}
+        >
+          {values.map((value: string) => (
+            <option value={value}>{value}</option>
+          ))}
+        </select>
+      </label>
+    );
+  }
+);

--- a/packages/workers/freshdesk/src/index.ts
+++ b/packages/workers/freshdesk/src/index.ts
@@ -50,6 +50,7 @@ const handleRequest = async (request: Request, env: EnvType) => {
       if (response.status >= 400 && response.status < 600) {
         throw new Error(`Bad response: ${response.status}`);
       }
+
       return response;
     });
     return new Response(JSON.stringify({ success: true }), {

--- a/packages/workers/freshdesk/src/index.ts
+++ b/packages/workers/freshdesk/src/index.ts
@@ -20,9 +20,9 @@ const handleRequest = async (request: Request, env: EnvType) => {
   }
 
   const payload: any = await request.json();
-  const { email, subject, body } = payload;
+  const { email, category, subject, body } = payload;
 
-  if (!email || !subject || !body) {
+  if (!email || !category || !subject || !body) {
     return new Response(
       JSON.stringify({ success: false, message: 'Please fill all the fields' }),
       {
@@ -42,12 +42,16 @@ const handleRequest = async (request: Request, env: EnvType) => {
         From: 'contact@lenster.xyz',
         ReplyTo: email,
         To: 'support@lenster.freshdesk.com',
-        Subject: subject,
+        Subject: category + ': ' + subject,
         TextBody: body,
         MessageStream: 'outbound'
       })
+    }).then((response) => {
+      if (response.status >= 400 && response.status < 600) {
+        throw new Error(`Bad response: ${response.status}`);
+      }
+      return response;
     });
-
     return new Response(JSON.stringify({ success: true }), {
       headers
     });


### PR DESCRIPTION
## What does this PR do?

Add a Category dropdown to contact page.
Also add fix for #3611, checking the status response from api.postmarkapp.com call
Add error message when contact message could not be sent (before, there was either no reaction, or even a Success message, depending on postmarkapp server behavior)

Opening as draft because I don't have the API key for to api.postmarkapp.com, so I have not been able to check the final step, that the email looks OK. @bigint Also, I hope that I correctly understood the objective of this task, to add a category selection menu on the contact page?

![Screenshot_2023-08-24_12-36-04](https://github.com/lensterxyz/lenster/assets/667227/badb18a0-dd28-49d8-be4d-3ea6609782d1)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ddd5a4</samp>

This pull request adds a `category` field to the contact form and the Freshdesk integration, and improves the form validation, UI, and error handling. It also introduces a new custom `Select` component from the `@lenster/ui` package, which is used in the contact form. The changes affect the files `apps/web/src/components/Pages/Contact.tsx`, `packages/workers/freshdesk/src/index.ts`, `packages/ui/index.ts`, and `packages/ui/src/Select.tsx`.

## Related issues

Fixes #2351
Fixes #3611

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ddd5a4</samp>

*  Add and validate `category` field to contact form and send it to Freshdesk API ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R6), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R17), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R27), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R33), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R60), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R68), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R75-R76), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1L96-R105), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R113-R122), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-505f50476edc2f66e660ae1a1999ad69f07c61252b02e0a1484f93154128e38cR16), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-218d499c04c01e79166c2461c5c5ec4194f7447d9b28cbc70cf34ecd8438750eR1-R27), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-68c0014b029838a9b81301e10a18bb593563eac1d430c01708b4106f6f29b2faL23-R25), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-68c0014b029838a9b81301e10a18bb593563eac1d430c01708b4106f6f29b2faL45-R54))
  * Import `Errors` enum from `@lenster/data/errors` to use common error messages ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R6))
  * Import `Select` component from `@lenster/ui` to use custom select input ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R17), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-505f50476edc2f66e660ae1a1999ad69f07c61252b02e0a1484f93154128e38cR16))
  * Import `toast` function from `react-hot-toast` to display toast notifications ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R27))
  * Add `category` field to `newContactSchema` object and `Contact` interface to validate and type contact form data ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R33), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R60))
  * Add `category` parameter to `submitToFreshdesk` function and pass it to Cloudflare worker ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R68), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1L96-R105))
  * Handle unsuccessful response from Cloudflare worker and display toast notification with error message ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R75-R76))
  * Add `Select` component to `Form` component and register `category` field with `react-hook-form` ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-10fa70e6053fe1d84241598d9bbea0e3b28cf7103f61edc7ba00f445db1ecdf1R113-R122))
  * Define `Select` component in `packages/ui/src/Select.tsx` and apply custom styles with Tailwind CSS ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-218d499c04c01e79166c2461c5c5ec4194f7447d9b28cbc70cf34ecd8438750eR1-R27))
  * Add `category` field to payload and email subject in `handleRequest` function in `packages/workers/freshdesk/src/index.ts` and validate it along with other fields ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-68c0014b029838a9b81301e10a18bb593563eac1d430c01708b4106f6f29b2faL23-R25), [link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-68c0014b029838a9b81301e10a18bb593563eac1d430c01708b4106f6f29b2faL45-R54))
  * Check status code of fetch response and throw error if not successful in `handleRequest` function in `packages/workers/freshdesk/src/index.ts` ([link](https://github.com/lensterxyz/lenster/pull/3619/files?diff=unified&w=0#diff-68c0014b029838a9b81301e10a18bb593563eac1d430c01708b4106f6f29b2faL45-R54))

## Emoji

<!--
copilot:emoji
-->

🎨🆕🐛

<!--
1.  🎨 - This emoji represents the addition of the `Select` component to the `@lenster/ui` package, which is a change that improves the UI and design of the application. The `Select` component is a custom select input component that will be used in the contact form, and it applies some custom styles using Tailwind CSS classes.
2.  🆕 - This emoji represents the addition of the `category` field to the contact form and the Freshdesk integration, which is a change that introduces a new feature and functionality to the application. The `category` field allows the user to select the type of inquiry they have when submitting the contact form, and it is sent to the Freshdesk API as part of the email subject.
3.  🐛 - This emoji represents the improvement of the error handling for the Freshdesk API call, which is a change that fixes a bug and enhances the reliability of the application. The error handling ensures that the Cloudflare worker responds with a meaningful message and status code when the Freshdesk API call fails or returns an error.
-->
