### PR TITLE
fix: use unique React key props for comment list rendering

### DIFF
--- a/apps/web/src/components/Comment/Feed.tsx
+++ b/apps/web/src/components/Comment/Feed.tsx
@@ -114,9 +114,9 @@ const Feed: FC<FeedProps> = ({ publication }) => {
           )
       )}
       {comments?.map((comment, index) =>
-        comment?.__typename === 'Comment' && comment.hidden ? null : (
+        comment?.__typename !== 'Comment' || comment.hidden ? null : (
           <SinglePublication
-            key={`${publicationId}_${index}`}
+            key={`${comment.id}`}
             isFirst={index === 0}
             isLast={index === comments.length - 1}
             publication={comment as Comment}


### PR DESCRIPTION
## What does this PR do?

Use a key that is persistent for each comment, so that rendering works even if the array changes.

Fixes #3595

(Before, the comment array index was used as React key prop, but after a comment was created or deleted, index 0, 1, 2, etc., will refer to different comments, which messes up React rendering.)


**After:**

https://github.com/lensterxyz/lenster/assets/667227/7b71545a-9794-4d70-9921-c3ea8beed21c


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60183dc</samp>

Simplified comment rendering logic and improved key prop in `Feed.tsx`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60183dc</samp>

*  Simplify condition for rendering a comment and use comment id as key prop for `SinglePublication` component ([link](https://github.com/lensterxyz/lenster/pull/3633/files?diff=unified&w=0#diff-92573b726b084d05a197c040a5ec0f3a357331fdbe006100cc17662f002ee7f9L117-R119))

## Emoji

<!--
copilot:emoji
-->

🧹🔑🆔

<!--
1.  🧹 - This emoji can be used to represent the simplification of the condition for rendering a comment, as it implies cleaning up or removing unnecessary complexity from the code.
2.  🔑 - This emoji can be used to represent the change of the key prop for the `SinglePublication` component, as it implies using a more suitable or secure identifier for the component.
3.  🆔 - This emoji can be used to represent the use of the comment id instead of the publication id and index, as it implies using a more specific or unique attribute for the component.
-->
