### PR TITLE
fix: dms layout height issue

### DIFF
--- a/apps/web/src/components/Messages/Message.tsx
+++ b/apps/web/src/components/Messages/Message.tsx
@@ -151,7 +151,7 @@ const Message: FC<MessageProps> = ({ conversationKey }) => {
         selectedConversationKey={conversationKey}
       />
       <GridItemEight className="xs:mx-2 relative mb-0 sm:mx-2 md:col-span-8">
-        <Card className="flex h-[87vh] flex-col justify-between">
+        <Card className="flex h-[calc(100vh-8rem)] flex-col justify-between">
           {showLoading ? (
             <div className="flex h-full grow items-center justify-center">
               <Loader message={t`Loading messages`} />

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -100,7 +100,7 @@ const PreviewList: FC<PreviewListProps> = ({
   return (
     <GridItemFour
       className={clsx(
-        'xs:h-[85vh] xs:mx-2 mb-0 sm:mx-2 sm:h-[76vh] md:col-span-4 md:h-[80vh] xl:h-[84vh]',
+        'xs:mx-2 mb-0 h-[calc(100vh-8rem)] sm:mx-2 md:col-span-4',
         className
       )}
     >

--- a/apps/web/src/components/Messages/index.tsx
+++ b/apps/web/src/components/Messages/index.tsx
@@ -45,7 +45,7 @@ const Messages: NextPage = () => {
     <GridLayout classNameChild="md:gap-8">
       <MetaTags title={t`Messages • ${APP_NAME}`} />
       <PreviewList />
-      <GridItemEight className="xs:hidden xs:mx-2 mb-0 sm:mx-2 sm:hidden sm:h-[76vh] md:col-span-8 md:hidden md:h-[80vh] lg:block xl:h-[84vh]">
+      <GridItemEight className="xs:hidden xs:mx-2 mb-0 h-[calc(100vh-8rem)] sm:mx-2 sm:hidden md:col-span-8 md:hidden lg:block">
         <Card className="h-full">
           <NoConversationSelected />
         </Card>


### PR DESCRIPTION
## What does this PR do?

Height of two grids on dms screen was not same resolved it

## Related issues

Fixes #3033 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Emoji

🚀 
