### PR TITLE
feat: featured channels

### DIFF
--- a/apps/web/src/components/Publication/Actions/index.tsx
+++ b/apps/web/src/components/Publication/Actions/index.tsx
@@ -28,7 +28,7 @@ const PublicationActions: FC<PublicationActionsProps> = ({
 
   return (
     <span
-      className="-ml-2 flex flex-wrap items-center gap-x-6 gap-y-1 pt-3 sm:gap-8"
+      className="-ml-2 mt-3 flex flex-wrap items-center gap-x-6 gap-y-1 sm:gap-8"
       onClick={stopEventPropagation}
       aria-hidden="true"
     >

--- a/apps/web/src/components/Publication/FeaturedChannel.tsx
+++ b/apps/web/src/components/Publication/FeaturedChannel.tsx
@@ -1,4 +1,6 @@
+import { FeatureFlag } from '@lenster/data/feature-flags';
 import type { MetadataOutput } from '@lenster/lens';
+import isFeatureEnabled from '@lenster/lib/isFeatureEnabled';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import getChannelByTag from '@lib/getChannelByTag';
 import clsx from 'clsx';
@@ -14,9 +16,10 @@ const FeaturedChannel: FC<FeaturedChannelProps> = ({
   tags,
   className = ''
 }) => {
+  const isChannelsEnabled = isFeatureEnabled(FeatureFlag.Channels);
   const channel = getChannelByTag(tags);
 
-  if (!channel) {
+  if (!channel || !isChannelsEnabled) {
     return null;
   }
 

--- a/apps/web/src/components/Publication/FeaturedChannel.tsx
+++ b/apps/web/src/components/Publication/FeaturedChannel.tsx
@@ -1,12 +1,19 @@
 import type { MetadataOutput } from '@lenster/lens';
+import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import getChannelByTag from '@lib/getChannelByTag';
+import clsx from 'clsx';
+import Link from 'next/link';
 import type { FC } from 'react';
 
 interface FeaturedChannelProps {
   tags: MetadataOutput['tags'];
+  className?: string;
 }
 
-const FeaturedChannel: FC<FeaturedChannelProps> = ({ tags }) => {
+const FeaturedChannel: FC<FeaturedChannelProps> = ({
+  tags,
+  className = ''
+}) => {
   const channel = getChannelByTag(tags);
 
   if (!channel) {
@@ -14,10 +21,17 @@ const FeaturedChannel: FC<FeaturedChannelProps> = ({ tags }) => {
   }
 
   return (
-    <div className="mt-3 flex items-center space-x-2 text-xs">
+    <Link
+      href={`/c/${channel.slug}`}
+      className={clsx(
+        'flex items-center space-x-2 text-xs hover:underline',
+        className
+      )}
+      onClick={(e) => stopEventPropagation(e)}
+    >
       <img src={channel.avatar} className="h-4 w-4 rounded" />
       <div className="font-bold">{channel.name}</div>
-    </div>
+    </Link>
   );
 };
 

--- a/apps/web/src/components/Publication/FeaturedChannel.tsx
+++ b/apps/web/src/components/Publication/FeaturedChannel.tsx
@@ -1,0 +1,24 @@
+import type { MetadataOutput } from '@lenster/lens';
+import getChannelByTag from '@lib/getChannelByTag';
+import type { FC } from 'react';
+
+interface FeaturedChannelProps {
+  tags: MetadataOutput['tags'];
+}
+
+const FeaturedChannel: FC<FeaturedChannelProps> = ({ tags }) => {
+  const channel = getChannelByTag(tags);
+
+  if (!channel) {
+    return null;
+  }
+
+  return (
+    <div className="mt-3 flex items-center space-x-2 text-xs">
+      <img src={channel.avatar} className="h-4 w-4 rounded" />
+      <div className="font-bold">{channel.name}</div>
+    </div>
+  );
+};
+
+export default FeaturedChannel;

--- a/apps/web/src/components/Publication/FullPublication.tsx
+++ b/apps/web/src/components/Publication/FullPublication.tsx
@@ -4,6 +4,7 @@ import { formatDate, formatTime } from '@lib/formatTime';
 import type { FC } from 'react';
 
 import PublicationActions from './Actions';
+import FeaturedChannel from './FeaturedChannel';
 import HiddenPublication from './HiddenPublication';
 import PublicationBody from './PublicationBody';
 import PublicationHeader from './PublicationHeader';
@@ -43,13 +44,16 @@ const FullPublication: FC<FullPublicationProps> = ({ publication }) => {
           ) : (
             <>
               <PublicationBody publication={publication} />
-              <div className="lt-text-gray-500 my-3 text-sm">
-                <span title={formatTime(timestamp)}>
-                  {formatDate(new Date(timestamp), 'hh:mm A · MMM D, YYYY')}
-                </span>
-                {publication?.appId ? (
-                  <span> · Posted via {getAppName(publication?.appId)}</span>
-                ) : null}
+              <div className="flex items-center gap-x-3">
+                <div className="lt-text-gray-500 my-3 text-sm">
+                  <span title={formatTime(timestamp)}>
+                    {formatDate(new Date(timestamp), 'hh:mm A · MMM D, YYYY')}
+                  </span>
+                  {publication?.appId ? (
+                    <span> · Posted via {getAppName(publication.appId)}</span>
+                  ) : null}
+                </div>
+                <FeaturedChannel tags={publication.metadata.tags} />
               </div>
               {showStats ? (
                 <>

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -77,7 +77,10 @@ const SinglePublication: FC<SinglePublicationProps> = ({
                   electedMirror={feedItem?.electedMirror as ElectedMirror}
                 />
               ) : null}
-              <FeaturedChannel tags={publication.metadata.tags} />
+              <FeaturedChannel
+                className="mt-3"
+                tags={publication.metadata.tags}
+              />
             </div>
             {showModActions ? (
               <ModAction

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -6,6 +6,7 @@ import type { FC } from 'react';
 
 import PublicationActions from './Actions';
 import ModAction from './Actions/ModAction';
+import FeaturedChannel from './FeaturedChannel';
 import HiddenPublication from './HiddenPublication';
 import PublicationBody from './PublicationBody';
 import PublicationHeader from './PublicationHeader';
@@ -69,12 +70,15 @@ const SinglePublication: FC<SinglePublicationProps> = ({
               publication={rootPublication}
               showMore={showMore}
             />
-            {showActions ? (
-              <PublicationActions
-                publication={rootPublication}
-                electedMirror={feedItem?.electedMirror as ElectedMirror}
-              />
-            ) : null}
+            <div className="flex flex-wrap items-center gap-x-5">
+              {showActions ? (
+                <PublicationActions
+                  publication={rootPublication}
+                  electedMirror={feedItem?.electedMirror as ElectedMirror}
+                />
+              ) : null}
+              <FeaturedChannel tags={publication.metadata.tags} />
+            </div>
             {showModActions ? (
               <ModAction
                 publication={rootPublication}

--- a/apps/web/src/components/Publication/SinglePublication.tsx
+++ b/apps/web/src/components/Publication/SinglePublication.tsx
@@ -70,7 +70,7 @@ const SinglePublication: FC<SinglePublicationProps> = ({
               publication={rootPublication}
               showMore={showMore}
             />
-            <div className="flex flex-wrap items-center gap-x-5">
+            <div className="flex flex-wrap items-center gap-x-7">
               {showActions ? (
                 <PublicationActions
                   publication={rootPublication}

--- a/apps/web/src/lib/getChannelByTag.ts
+++ b/apps/web/src/lib/getChannelByTag.ts
@@ -1,10 +1,17 @@
 import type { Channel } from '@lenster/types/lenster';
 import { featuredChannels } from 'src/store/app';
 
-const getChannelByTag = (tag: string): Channel | undefined => {
-  return featuredChannels().find(
-    (channel: Channel) => channel.tags?.includes(tag)
-  );
+const getChannelByTag = (tags: string[]): Channel | undefined => {
+  for (const tag of tags) {
+    const channel = featuredChannels().find(
+      (channel) => channel.tags?.includes(tag)
+    );
+    if (channel) {
+      return channel;
+    }
+  }
+
+  return undefined;
 };
 
 export default getChannelByTag;

--- a/packages/data/feature-flags.ts
+++ b/packages/data/feature-flags.ts
@@ -7,6 +7,7 @@ export enum FeatureFlag {
   WTF2 = 'wtf2',
   ExploreTags = 'explore-tags',
   Spaces = 'spaces',
+  Channels = 'channels',
   NftLogin = 'nft-login'
 }
 
@@ -33,6 +34,10 @@ export const featureFlags = [
   },
   {
     key: FeatureFlag.Spaces,
+    enabledFor: ['0x0d']
+  },
+  {
+    key: FeatureFlag.Channels,
     enabledFor: ['0x0d']
   },
   {


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8c3987</samp>

Added a `FeaturedChannel` component to show the channel of a publication on the web app. Improved the layout of the publication components using flexbox. Refactored the `getChannelByTag` function to handle multiple tags.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8c3987</samp>

*  Add `FeaturedChannel` component to display a link to a channel that matches one of the publication tags ([link](https://github.com/lensterxyz/lenster/pull/3676/files?diff=unified&w=0#diff-5a5f8c775995c1e98abb42cfc7aca48a574609ea3f26c56bb27b6e29565357b9R1-R38), [link](https://github.com/lensterxyz/lenster/pull/3676/files?diff=unified&w=0#diff-ac289083df76e3e6d7b153ec983bf8337dd0ce9b7ae98dc5d986862a1e9aef4aL4-R14))
*  Import `FeaturedChannel` component in `FullPublication` and `SinglePublication` components and adjust layout to use flexbox ([link](https://github.com/lensterxyz/lenster/pull/3676/files?diff=unified&w=0#diff-1aee7d7d3e211bad8d39a43eb3dd2841d10d43e1477c3333d47bc30e68b13217R7), [link](https://github.com/lensterxyz/lenster/pull/3676/files?diff=unified&w=0#diff-1aee7d7d3e211bad8d39a43eb3dd2841d10d43e1477c3333d47bc30e68b13217L46-R56), [link](https://github.com/lensterxyz/lenster/pull/3676/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9R9), [link](https://github.com/lensterxyz/lenster/pull/3676/files?diff=unified&w=0#diff-7ab19827d51c4496ff4e377082c24300f32219890d0bb8d2d8af80316a62eac9L72-R84))
*  Add top margin to `PublicationActions` component to create some space between it and the publication body ([link](https://github.com/lensterxyz/lenster/pull/3676/files?diff=unified&w=0#diff-62afa772382218b438f99bec5d9a172fc9beafa2de0ef1f667ca3cc06be8d699L31-R31))

## Emoji

<!--
copilot:emoji
-->

📚📺🔎

<!--
1.  📚 - This emoji represents the publication component and the changes made to its layout and appearance.
2.  📺 - This emoji represents the channel component and the new feature of displaying a featured channel based on the publication's tags.
3.  🔎 - This emoji represents the improved functionality of the `getChannelByTag` function and the ability to find a channel that matches any of the publication's tags.
-->
