### PR TITLE
fix: do not show when a profile follows itself

### DIFF
--- a/apps/web/src/components/Profile/Followers.tsx
+++ b/apps/web/src/components/Profile/Followers.tsx
@@ -28,10 +28,7 @@ const Followers: FC<FollowersProps> = ({ profile }) => {
     skip: !profile?.id
   });
 
-  const followers = data?.followers?.items.filter(
-    (follower) => profile?.id !== follower?.wallet?.defaultProfile?.id
-  );
-
+  const followers = data?.followers?.items;
   const pageInfo = data?.followers?.pageInfo;
   const hasMore = pageInfo?.next;
 

--- a/apps/web/src/components/Profile/Followers.tsx
+++ b/apps/web/src/components/Profile/Followers.tsx
@@ -28,7 +28,10 @@ const Followers: FC<FollowersProps> = ({ profile }) => {
     skip: !profile?.id
   });
 
-  const followers = data?.followers?.items;
+  const followers = data?.followers?.items.filter(
+    (follower) => profile?.id !== follower?.wallet?.defaultProfile?.id
+  );
+
   const pageInfo = data?.followers?.pageInfo;
   const hasMore = pageInfo?.next;
 
@@ -92,6 +95,9 @@ const Followers: FC<FollowersProps> = ({ profile }) => {
                   followUnfollowSource={FollowUnfollowSource.FOLLOWERS_MODAL}
                   showBio
                   showFollow={
+                    currentProfile?.id !== follower?.wallet?.defaultProfile?.id
+                  }
+                  showUnfollow={
                     currentProfile?.id !== follower?.wallet?.defaultProfile?.id
                   }
                   showUserPreview={false}

--- a/apps/web/src/components/Profile/Following.tsx
+++ b/apps/web/src/components/Profile/Following.tsx
@@ -10,6 +10,7 @@ import { t, Trans } from '@lingui/macro';
 import { motion } from 'framer-motion';
 import type { FC } from 'react';
 import { Virtuoso } from 'react-virtuoso';
+import { useAppStore } from 'src/store/app';
 
 interface FollowingProps {
   profile: Profile;
@@ -19,13 +20,16 @@ interface FollowingProps {
 const Following: FC<FollowingProps> = ({ profile, onProfileSelected }) => {
   // Variables
   const request: FollowingRequest = { address: profile?.ownedBy, limit: 30 };
+  const currentProfile = useAppStore((state) => state.currentProfile);
 
   const { data, loading, error, fetchMore } = useFollowingQuery({
     variables: { request },
     skip: !profile?.id
   });
 
-  const followings = data?.following?.items;
+  const followings = data?.following?.items.filter(
+    (following) => profile?.id !== following?.profile.id
+  );
   const pageInfo = data?.following?.pageInfo;
   const hasMore = pageInfo?.next;
 
@@ -102,8 +106,8 @@ const Following: FC<FollowingProps> = ({ profile, onProfileSelected }) => {
                 followUnfollowPosition={index + 1}
                 followUnfollowSource={FollowUnfollowSource.FOLLOWING_MODAL}
                 showBio
-                showFollow
-                showUnfollow
+                showFollow={currentProfile?.id !== following?.profile.id}
+                showUnfollow={currentProfile?.id !== following?.profile.id}
                 showUserPreview={false}
               />
             </motion.div>

--- a/apps/web/src/components/Profile/Following.tsx
+++ b/apps/web/src/components/Profile/Following.tsx
@@ -27,9 +27,7 @@ const Following: FC<FollowingProps> = ({ profile, onProfileSelected }) => {
     skip: !profile?.id
   });
 
-  const followings = data?.following?.items.filter(
-    (following) => profile?.id !== following?.profile.id
-  );
+  const followings = data?.following?.items;
   const pageInfo = data?.following?.pageInfo;
   const hasMore = pageInfo?.next;
 


### PR DESCRIPTION
## What does this PR do?

If the signed-in user, appears in another user's (or in rare cases, their own) Following or Followers list, then hide the follow/unfollow button next to the signed-in user.

**sceenshot**

![Screenshot_2023-09-01_18-12-21](https://github.com/lensterxyz/lenster/assets/667227/2d074e57-62b1-408a-9cfb-304957b9f769)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91f0502</samp>

This pull request fixes a bug where the user could see and follow themselves on their own profile page. It modifies the `Followers.tsx` and `Following.tsx` components to exclude the user from the lists and actions.

## Related issues

Fixes #3683 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91f0502</samp>

*  Filter out the current profile from the lists of followers and followings in `Followers.tsx` and `Following.tsx` to prevent the user from seeing themselves as a follower or following of their own profile ([link](https://github.com/lensterxyz/lenster/pull/3685/files?diff=unified&w=0#diff-55dc73404c164c7379148792a303aad01fcc854056e412dd1a986f59e54a7d58L31-R34), [link](https://github.com/lensterxyz/lenster/pull/3685/files?diff=unified&w=0#diff-26b930a1517cdb6b85350e7d2aec8b151c8bde2181a998c5f71f82cca6e70903L28-R32))
*  Hide the follow and unfollow buttons for the current profile in `Followers.tsx` and `Following.tsx` to prevent the user from following or unfollowing themselves ([link](https://github.com/lensterxyz/lenster/pull/3685/files?diff=unified&w=0#diff-55dc73404c164c7379148792a303aad01fcc854056e412dd1a986f59e54a7d58R100-R102), [link](https://github.com/lensterxyz/lenster/pull/3685/files?diff=unified&w=0#diff-26b930a1517cdb6b85350e7d2aec8b151c8bde2181a998c5f71f82cca6e70903L105-R110))
*  Import and use the `useAppStore` hook in `Following.tsx` to get the current profile from the app state ([link](https://github.com/lensterxyz/lenster/pull/3685/files?diff=unified&w=0#diff-26b930a1517cdb6b85350e7d2aec8b151c8bde2181a998c5f71f82cca6e70903R13), [link](https://github.com/lensterxyz/lenster/pull/3685/files?diff=unified&w=0#diff-26b930a1517cdb6b85350e7d2aec8b151c8bde2181a998c5f71f82cca6e70903R23))

## Emoji

<!--
copilot:emoji
-->

🚫🛠️🗃️

<!--
1.  🚫 - This emoji represents the prevention of an unwanted action or behavior, such as seeing or unfollowing oneself as a follower.
2.  🛠️ - This emoji represents the update or improvement of an existing component or feature, such as the `Following.tsx` component.
3.  🗃️ - This emoji represents the use of a data source or storage, such as the app state and the current profile from the `useAppStore` hook.
-->
