### PR TITLE
feat: add check for change network

### DIFF
--- a/apps/web/src/components/Common/Layout.tsx
+++ b/apps/web/src/components/Common/Layout.tsx
@@ -10,7 +10,6 @@ import Head from 'next/head';
 import { useTheme } from 'next-themes';
 import type { FC, ReactNode } from 'react';
 import { Toaster } from 'react-hot-toast';
-import { CHAIN_ID } from 'src/constants';
 import { useAppPersistStore, useAppStore } from 'src/store/app';
 import { usePreferencesStore } from 'src/store/preferences';
 import { useProfileGuardianInformationStore } from 'src/store/profile-guardian-information';
@@ -83,9 +82,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
     const currentProfileAddress = currentProfile?.ownedBy;
     const isSwitchedAccount =
       currentProfileAddress !== undefined && currentProfileAddress !== address;
-    const isWrongNetworkChain = chain?.id !== CHAIN_ID;
-    const shouldLogout =
-      !getIsAuthTokensAvailable() || isWrongNetworkChain || isSwitchedAccount;
+    const shouldLogout = !getIsAuthTokensAvailable() || isSwitchedAccount;
 
     // If there are no auth data, clear and logout
     if (shouldLogout && profileId) {

--- a/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
+++ b/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
@@ -49,6 +49,7 @@ import Link from 'next/link';
 import type { Dispatch, FC, SetStateAction } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
 import { useUpdateEffect } from 'usehooks-ts';
@@ -85,6 +86,7 @@ const CollectModule: FC<CollectModuleProps> = ({
   const [showCollectorsModal, setShowCollectorsModal] = useState(false);
   const [allowed, setAllowed] = useState(true);
   const { address } = useAccount();
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const { data, loading } = useCollectModuleQuery({
     variables: { request: { publicationId: publication?.id } }
@@ -266,6 +268,10 @@ const CollectModule: FC<CollectModuleProps> = ({
   const createCollect = async () => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/components/Publication/Actions/Share/Mirror.tsx
+++ b/apps/web/src/components/Publication/Actions/Share/Mirror.tsx
@@ -25,6 +25,7 @@ import clsx from 'clsx';
 import type { FC } from 'react';
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
 import { useContractWrite, useSignTypedData } from 'wagmi';
@@ -46,6 +47,7 @@ const Mirror: FC<MirrorProps> = ({ publication, setIsLoading, isLoading }) => {
       : // @ts-expect-error
         publication?.mirrors?.length > 0
   );
+  const handleWrongNetwork = useHandleWrongNetwork();
   const { cache } = useApolloClient();
 
   // Dispatcher
@@ -162,6 +164,10 @@ const Mirror: FC<MirrorProps> = ({ publication, setIsLoading, isLoading }) => {
   const createMirror = async () => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     if (publication.isDataAvailability && !isSponsored) {

--- a/apps/web/src/components/Settings/Account/SetProfile.tsx
+++ b/apps/web/src/components/Settings/Account/SetProfile.tsx
@@ -18,6 +18,7 @@ import { t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import Custom404 from 'src/pages/404';
 import { useAppStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
@@ -31,6 +32,7 @@ const SetProfile: FC = () => {
   const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
   const [selectedUser, setSelectedUser] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const onCompleted = (__typename?: 'RelayError' | 'RelayerResult') => {
     if (__typename === 'RelayError') {
@@ -93,6 +95,10 @@ const SetProfile: FC = () => {
   const setDefaultProfile = async () => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/components/Settings/Account/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Account/SuperFollow.tsx
@@ -19,6 +19,7 @@ import { t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
 import { useContractWrite, useSignTypedData } from 'wagmi';
@@ -41,6 +42,7 @@ const SuperFollow: FC = () => {
   );
   const [selectedCurrencySymbol, setSelectedCurrencySymbol] =
     useState('WMATIC');
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const onCompleted = (__typename?: 'RelayError' | 'RelayerResult') => {
     if (__typename === 'RelayError') {
@@ -111,6 +113,10 @@ const SuperFollow: FC = () => {
   ) => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/components/Settings/Danger/Delete.tsx
+++ b/apps/web/src/components/Settings/Danger/Delete.tsx
@@ -14,6 +14,7 @@ import { t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useDisconnectXmtp } from 'src/hooks/useXmtpClient';
 import { useAppPersistStore, useAppStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
@@ -29,6 +30,7 @@ const DeleteSettings: FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const disconnectXmtp = useDisconnectXmtp();
   const { disconnect } = useDisconnect();
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const onCompleted = () => {
     Leafwatch.track(SETTINGS.DANGER.DELETE_PROFILE);
@@ -71,6 +73,10 @@ const DeleteSettings: FC = () => {
   const handleDelete = async () => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/components/Settings/Danger/Guardian.tsx
+++ b/apps/web/src/components/Settings/Danger/Guardian.tsx
@@ -11,6 +11,7 @@ import { t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useProfileGuardianInformationStore } from 'src/store/profile-guardian-information';
 import { useContractWrite } from 'wagmi';
@@ -22,6 +23,7 @@ const GuardianSettings: FC = () => {
   );
   const [showWarningModal, setShowWarningModal] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const onError = (error: any) => {
     setIsLoading(false);
@@ -43,6 +45,10 @@ const GuardianSettings: FC = () => {
   const handleDisable = async () => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/components/Settings/Profile/NftAvatarModal.tsx
+++ b/apps/web/src/components/Settings/Profile/NftAvatarModal.tsx
@@ -19,6 +19,7 @@ import { t, Trans } from '@lingui/macro';
 import type { Dispatch, FC, SetStateAction } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useNftGalleryStore } from 'src/store/nft-gallery';
 import { useNonceStore } from 'src/store/nonce';
@@ -37,10 +38,10 @@ const NftAvatarModal: FC<NftAvatarModalProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const currentProfile = useAppStore((state) => state.currentProfile);
   const gallery = useNftGalleryStore((state) => state.gallery);
-
-  const { signMessageAsync } = useSignMessage();
-
   const setUserSigNonce = useNonceStore((state) => state.setUserSigNonce);
+
+  const handleWrongNetwork = useHandleWrongNetwork();
+  const { signMessageAsync } = useSignMessage();
 
   const onCompleted = (__typename?: 'RelayError' | 'RelayerResult') => {
     if (__typename === 'RelayError') {
@@ -118,6 +119,10 @@ const NftAvatarModal: FC<NftAvatarModalProps> = ({
   const setAvatar = async () => {
     if (!currentProfile || gallery.items.length === 0) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -42,6 +42,7 @@ import { t, Trans } from '@lingui/macro';
 import type { ChangeEvent, FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { v4 as uuid } from 'uuid';
 import { useContractWrite, useSignTypedData } from 'wagmi';
@@ -81,6 +82,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
   const [showCropModal, setShowCropModal] = useState(false);
   const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
   const [uploadedImageUrl, setUploadedImageUrl] = useState('');
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   // Dispatcher
   const canUseRelay = currentProfile?.dispatcher?.canUseRelay;
@@ -176,6 +178,10 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
       return toast.error(Errors.SignWallet);
     }
 
+    if (handleWrongNetwork()) {
+      return;
+    }
+
     try {
       setIsLoading(true);
       const id = await uploadToArweave({
@@ -233,12 +239,16 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
     }
-    const croppedImage = await getCroppedImg(imageSrc, croppedAreaPixels);
-    if (!croppedImage) {
-      return toast.error(Errors.SomethingWentWrong);
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {
+      const croppedImage = await getCroppedImg(imageSrc, croppedAreaPixels);
+      if (!croppedImage) {
+        return toast.error(Errors.SomethingWentWrong);
+      }
       setUploading(true);
       const ipfsUrl = await uploadCroppedImage(croppedImage);
       const dataUrl = croppedImage.toDataURL('image/png');

--- a/apps/web/src/components/Shared/Follow.tsx
+++ b/apps/web/src/components/Shared/Follow.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'next/router';
 import type { FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useGlobalModalStateStore } from 'src/store/modals';
 import { useNonceStore } from 'src/store/nonce';
@@ -50,6 +51,7 @@ const Follow: FC<FollowProps> = ({
     (state) => state.setShowAuthModal
   );
   const [isLoading, setIsLoading] = useState(false);
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const updateCache = (cache: ApolloCache<any>) => {
     cache.modify({
@@ -134,6 +136,10 @@ const Follow: FC<FollowProps> = ({
   const createFollow = async () => {
     if (!currentProfile) {
       setShowAuthModal(true);
+      return;
+    }
+
+    if (handleWrongNetwork()) {
       return;
     }
 

--- a/apps/web/src/components/Shared/GlobalModals.tsx
+++ b/apps/web/src/components/Shared/GlobalModals.tsx
@@ -13,6 +13,7 @@ import { useGlobalModalStateStore } from 'src/store/modals';
 import { usePublicationStore } from 'src/store/publication';
 
 import Login from './Login';
+import WrongNetwork from './Login/WrongNetwork';
 import Invites from './Modal/Invites';
 import ReportProfile from './Modal/ReportProfile';
 import Status from './Status';
@@ -32,6 +33,8 @@ const GlobalModals: FC = () => {
     setShowNewPostModal,
     showAuthModal,
     setShowAuthModal,
+    showWrongNetworkModal,
+    setShowWrongNetworkModal,
     showInvitesModal,
     setShowInvitesModal,
     showReportProfileModal,
@@ -113,6 +116,14 @@ const GlobalModals: FC = () => {
         dataTestId="login-modal"
       >
         <Login />
+      </Modal>
+      <Modal
+        title={t`Wrong Network`}
+        show={showWrongNetworkModal}
+        onClose={() => setShowWrongNetworkModal(false)}
+        dataTestId="wrong-network-modal"
+      >
+        <WrongNetwork />
       </Modal>
       <Modal
         title={t`Create post`}

--- a/apps/web/src/components/Shared/Login/WrongNetwork.tsx
+++ b/apps/web/src/components/Shared/Login/WrongNetwork.tsx
@@ -1,0 +1,27 @@
+import { Trans } from '@lingui/macro';
+import type { FC } from 'react';
+import { useGlobalModalStateStore } from 'src/store/modals';
+
+import SwitchNetwork from '../SwitchNetwork';
+
+const WrongNetwork: FC = () => {
+  const setShowWrongNetworkModal = useGlobalModalStateStore(
+    (state) => state.setShowWrongNetworkModal
+  );
+
+  return (
+    <div className="p-5">
+      <div className="mb-4 space-y-1">
+        <div className="text-xl font-bold">
+          <Trans>Change network</Trans>.
+        </div>
+        <div className="lt-text-gray-500 text-sm">
+          <Trans>Connect to the correct network to continue</Trans>
+        </div>
+      </div>
+      <SwitchNetwork onSwitch={() => setShowWrongNetworkModal(false)} />
+    </div>
+  );
+};
+
+export default WrongNetwork;

--- a/apps/web/src/components/Shared/Snapshot/Choices.tsx
+++ b/apps/web/src/components/Shared/Snapshot/Choices.tsx
@@ -16,6 +16,7 @@ import clsx from 'clsx';
 import type { FC } from 'react';
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useSignTypedData } from 'wagmi';
 
@@ -43,6 +44,7 @@ const Choices: FC<ChoicesProps> = ({
     position: 0
   });
   const { signTypedDataAsync } = useSignTypedData({});
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const { id, choices, symbol, scores, scores_total, state, type, end } =
     proposal;

--- a/apps/web/src/components/Shared/Status.tsx
+++ b/apps/web/src/components/Shared/Status.tsx
@@ -27,6 +27,7 @@ import { t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useGlobalModalStateStore } from 'src/store/modals';
 import { v4 as uuid } from 'uuid';
@@ -50,6 +51,7 @@ const Status: FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [emoji, setEmoji] = useState<string>('');
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   // Dispatcher
   const canUseRelay = currentProfile?.dispatcher?.canUseRelay;
@@ -141,6 +143,10 @@ const Status: FC = () => {
   const editStatus = async (emoji: string, status: string) => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/components/Shared/SuperFollow/FollowModule.tsx
+++ b/apps/web/src/components/Shared/SuperFollow/FollowModule.tsx
@@ -25,6 +25,7 @@ import { useRouter } from 'next/router';
 import type { Dispatch, FC, SetStateAction } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useNonceStore } from 'src/store/nonce';
 import { useBalance, useContractWrite, useSignTypedData } from 'wagmi';
@@ -58,6 +59,7 @@ const FollowModule: FC<FollowModuleProps> = ({
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [isLoading, setIsLoading] = useState(false);
   const [allowed, setAllowed] = useState(true);
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const onCompleted = (__typename?: 'RelayError' | 'RelayerResult') => {
     if (__typename === 'RelayError') {
@@ -157,6 +159,10 @@ const FollowModule: FC<FollowModuleProps> = ({
   const createFollow = async () => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/components/Shared/SwitchNetwork.tsx
+++ b/apps/web/src/components/Shared/SwitchNetwork.tsx
@@ -10,9 +10,13 @@ import { useSwitchNetwork } from 'wagmi';
 
 interface SwitchNetworkProps {
   className?: string;
+  onSwitch?: () => void;
 }
 
-const SwitchNetwork: FC<SwitchNetworkProps> = ({ className = '' }) => {
+const SwitchNetwork: FC<SwitchNetworkProps> = ({
+  className = '',
+  onSwitch
+}) => {
   const { switchNetwork } = useSwitchNetwork();
 
   return (
@@ -22,6 +26,7 @@ const SwitchNetwork: FC<SwitchNetworkProps> = ({ className = '' }) => {
       variant="danger"
       icon={<SwitchHorizontalIcon className="h-4 w-4" />}
       onClick={() => {
+        onSwitch?.();
         if (switchNetwork) {
           switchNetwork(CHAIN_ID);
         } else {

--- a/apps/web/src/components/Shared/Unfollow.tsx
+++ b/apps/web/src/components/Shared/Unfollow.tsx
@@ -16,6 +16,7 @@ import { t } from '@lingui/macro';
 import type { FC } from 'react';
 import { useState } from 'react';
 import toast from 'react-hot-toast';
+import useHandleWrongNetwork from 'src/hooks/useHandleWrongNetwork';
 import { useAppStore } from 'src/store/app';
 import { useContractWrite, useSignTypedData } from 'wagmi';
 
@@ -32,6 +33,7 @@ const Unfollow: FC<UnfollowProps> = ({
 }) => {
   const currentProfile = useAppStore((state) => state.currentProfile);
   const [isLoading, setIsLoading] = useState(false);
+  const handleWrongNetwork = useHandleWrongNetwork();
 
   const updateCache = (cache: ApolloCache<any>) => {
     cache.modify({
@@ -88,6 +90,10 @@ const Unfollow: FC<UnfollowProps> = ({
   const createUnfollow = async () => {
     if (!currentProfile) {
       return toast.error(Errors.SignWallet);
+    }
+
+    if (handleWrongNetwork()) {
+      return;
     }
 
     try {

--- a/apps/web/src/hooks/useHandleWrongNetwork.ts
+++ b/apps/web/src/hooks/useHandleWrongNetwork.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react';
+import { CHAIN_ID } from 'src/constants';
+import { useGlobalModalStateStore } from 'src/store/modals';
+import { useNetwork } from 'wagmi';
+
+const useHandleWrongNetwork = () => {
+  const setShowWrongNetworkModal = useGlobalModalStateStore(
+    (state) => state.setShowWrongNetworkModal
+  );
+  const { chain } = useNetwork();
+
+  const handleWrongNetwork = useCallback(() => {
+    if (chain?.id !== CHAIN_ID) {
+      setShowWrongNetworkModal(true);
+      return true;
+    }
+
+    return false;
+  }, [chain?.id, setShowWrongNetworkModal]);
+
+  return handleWrongNetwork;
+};
+
+export default useHandleWrongNetwork;

--- a/apps/web/src/store/modals.ts
+++ b/apps/web/src/store/modals.ts
@@ -4,6 +4,8 @@ import { create } from 'zustand';
 interface GlobalModalState {
   showAuthModal: boolean;
   setShowAuthModal: (showAuthModal: boolean) => void;
+  showWrongNetworkModal: boolean;
+  setShowWrongNetworkModal: (showWrongNetworkModal: boolean) => void;
   showNewPostModal: boolean;
   setShowNewPostModal: (showNewPostModal: boolean) => void;
   showDiscardModal: boolean;
@@ -33,6 +35,9 @@ interface GlobalModalState {
 export const useGlobalModalStateStore = create<GlobalModalState>((set) => ({
   showAuthModal: false,
   setShowAuthModal: (showAuthModal) => set(() => ({ showAuthModal })),
+  showWrongNetworkModal: false,
+  setShowWrongNetworkModal: (showWrongNetworkModal) =>
+    set(() => ({ showWrongNetworkModal })),
   showNewPostModal: false,
   setShowNewPostModal: (showNewPostModal) => set(() => ({ showNewPostModal })),
   showDiscardModal: false,


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f8d2c1</samp>

This pull request adds network validation and error handling features to various components in the web app. It uses a custom hook `useHandleWrongNetwork` and a new modal component `WrongNetwork` to check the user's network connection and inform them of any errors. It also enhances the `SwitchNetwork` component to accept a callback function. These changes improve the user experience and prevent invalid actions on the wrong network.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4f8d2c1</samp>

*  Simplify network check logic and remove unused import in `Layout` component ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637L13),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-0e16eaa722dcbe43f850552755cc5fafac704a32a39761450c6d2edf5a91a637L86-R85))
* Add `useHandleWrongNetwork` hook to various components that perform actions that require the correct network ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517R80),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebR52),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-4240d7e3152a99edc7ce5b40d6f6b9025ba441e0cf8032de9ff6b8d093cc91f3R28),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-4140e9fa5dba053d642a89f16e93d79a9b944b23e11e6f1746e3411ad9b0542aR21),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249R22),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-aae51350297a3caa87f5b2cfa0307b6b207a4891cfb3be7074a340b9eb9b6df6R17),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-7c93d329c665824b282d39c9a9a417223094b14938f2f1e27a541666a4c7b11fR14),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-f812e30ce8d62ce0819c4ca5083bd62ced375837b120d5a757a1ee6b7f843934R22),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526R32),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-cc605dc6510d575486ca4cc4d51a003ca10dfeb338fced8f413d3c60d1543c90R45),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-13d4bceb37aa9a8fbfb289da32670451dffff4b1aa212cc07a4559e5bef0c3f2R21),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3R19),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-ea16fcefe5daf9bfbf6d18ab7dde87b5140ecfeb5999e72401c4c411322a4fb0R30),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-c9dc50d00ae6e20957ce95b12e76c80b0548fc9743ca5969a597c8e7a9ec9ea6R28),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-b9a8822a64f1dc4a1f6071668ae9d721b23edd7df7663460fc936fb73bb9f7e8R19))
* Call the function returned by the hook before proceeding with the action logic and return early if the network is wrong ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517R654-R657),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-7977996b7f0dbc1f616a63dabbfd3cf4d7e894542863a65c8f492813fadecaebR273-R276),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-4240d7e3152a99edc7ce5b40d6f6b9025ba441e0cf8032de9ff6b8d093cc91f3R169-R172),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-4140e9fa5dba053d642a89f16e93d79a9b944b23e11e6f1746e3411ad9b0542aR100-R103),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-431256eec597b5a6fbe8bc86f1e0997372664195fb9bbbe33a35c56758b2a249R118-R121),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-aae51350297a3caa87f5b2cfa0307b6b207a4891cfb3be7074a340b9eb9b6df6R78-R81),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-7c93d329c665824b282d39c9a9a417223094b14938f2f1e27a541666a4c7b11fR50-R53),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-f812e30ce8d62ce0819c4ca5083bd62ced375837b120d5a757a1ee6b7f843934R124-R127),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L130-R142),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-cc605dc6510d575486ca4cc4d51a003ca10dfeb338fced8f413d3c60d1543c90R181-R184),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-cc605dc6510d575486ca4cc4d51a003ca10dfeb338fced8f413d3c60d1543c90L236-R251),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-13d4bceb37aa9a8fbfb289da32670451dffff4b1aa212cc07a4559e5bef0c3f2R142-R145),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-fa758c8e5e1075dcaa20885e8fbc002e5bb0d2c3425412bb26f90776aa8271b3R47),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-ea16fcefe5daf9bfbf6d18ab7dde87b5140ecfeb5999e72401c4c411322a4fb0R148-R151),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-c9dc50d00ae6e20957ce95b12e76c80b0548fc9743ca5969a597c8e7a9ec9ea6R164-R167),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-b9a8822a64f1dc4a1f6071668ae9d721b23edd7df7663460fc936fb73bb9f7e8R95-R98))
* Add optional chaining operators to `currentProfile` variable in `NewPublication` component to avoid potential errors ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L611-R605),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L618-R612),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L641-R635))
* Remove redundant checks for `currentProfile` and `walletClient` variables in `NewPublication` component ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-175403612af948ab5a9aed1b111d24448b156cc856927d47f556e01221a56517L594-L601))
* Add `onSwitch` prop to `SwitchNetwork` component to allow executing a function after switching the network ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-a773c12f3e3f2f922cd92857b126875d2b5678223c0c41c94b91789e1beca52aL13-R19),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-a773c12f3e3f2f922cd92857b126875d2b5678223c0c41c94b91789e1beca52aR29))
* Add `WrongNetwork` component to display a message and a `SwitchNetwork` component when the user is connected to the wrong network ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-51f96daeb1569972732ba7b19babe5a9892559cac9504eacb39ff90c3df7518fR1-R27))
* Add `showWrongNetworkModal` and `setShowWrongNetworkModal` variables to `GlobalModals` component to control the visibility of the wrong network modal ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-fdb706900e098449623e377a52b54f379ea7ae04d182358e10a6dccb233890c2R36-R37))
* Add a new `Modal` component to `GlobalModals` component that renders the `WrongNetwork` component when the `showWrongNetworkModal` variable is true ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-fdb706900e098449623e377a52b54f379ea7ae04d182358e10a6dccb233890c2R121-R128))
* Add `useHandleWrongNetwork` hook to `hooks` folder that returns a function that checks the current network chain id and shows the wrong network modal if it doesn't match ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-a95d61d1ae17f7a32fbdd7e94e504a5034bbb2a241e5292953ac903f575dcec6R1-R24))
* Move cropping logic inside try block in `Picture` and `Profile` components to avoid potential memory leak if the function returns early ([link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-e1d95068b7cec5b12e33c5d65d074c4ba6fc0717fb0c6239c17821998ff45526L130-R142),[link](https://github.com/lensterxyz/lenster/pull/3686/files?diff=unified&w=0#diff-cc605dc6510d575486ca4cc4d51a003ca10dfeb338fced8f413d3c60d1543c90L236-R251))

## Emoji

<!--
copilot:emoji
-->

🚫🔀🌐

<!--
1.  🚫 - This emoji represents the wrong network error and the modal that shows up to inform the user of the issue. It also conveys the idea of blocking or preventing an action that is not valid on the current network.
2.  🔀 - This emoji represents the switch network component and the functionality that allows the user to change their network connection. It also conveys the idea of switching or changing something.
3.  🌐 - This emoji represents the network connection and the validation logic that checks the network chain id. It also conveys the idea of the web or the internet.
-->
