### PR TITLE
feat: add testnet support

### DIFF
--- a/apps/web/src/components/Shared/OpenAction/Nft/index.tsx
+++ b/apps/web/src/components/Shared/OpenAction/Nft/index.tsx
@@ -57,7 +57,7 @@ interface NftProps {
 }
 
 const Nft: FC<NftProps> = ({ nftMetadata }) => {
-  const { chain, address, token } = nftMetadata;
+  const { chain, address, token, network } = nftMetadata;
   const [showMintModal, setShowMintModal] = useState(false);
   const isZoraMintEnabled = isFeatureEnabled(FeatureFlag.ZoraMint);
 
@@ -69,6 +69,7 @@ const Nft: FC<NftProps> = ({ nftMetadata }) => {
     chain,
     address,
     token: token,
+    network,
     enabled: Boolean(chain && address)
   });
 

--- a/apps/web/src/components/Shared/OpenAction/Nft/index.tsx
+++ b/apps/web/src/components/Shared/OpenAction/Nft/index.tsx
@@ -118,7 +118,7 @@ const Nft: FC<NftProps> = ({ nftMetadata }) => {
           </>
         ) : (
           <Link
-            href={'https://zora.co/collect/${chain}:${address}/${token}'}
+            href={`https://zora.co/collect/${chain}:${address}/${token}`}
             target="_blank"
             rel="noopener noreferrer"
             onClick={(event) => stopEventPropagation(event)}

--- a/apps/web/src/hooks/zora/useZoraNft.ts
+++ b/apps/web/src/hooks/zora/useZoraNft.ts
@@ -1,5 +1,5 @@
-import { IS_MAINNET, ZORA_WORKER_URL } from '@lenster/data/constants';
-import type { ZoraNft } from '@lenster/types/zora-nft';
+import { ZORA_WORKER_URL } from '@lenster/data/constants';
+import type { ZoraNft, ZoraNftMetadata } from '@lenster/types/zora-nft';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
@@ -7,6 +7,7 @@ interface UseZoraNftProps {
   chain: string;
   address: string;
   token: string;
+  network: ZoraNftMetadata['network'];
   enabled?: boolean;
 }
 
@@ -14,6 +15,7 @@ const useZoraNft = ({
   chain,
   address,
   token,
+  network,
   enabled
 }: UseZoraNftProps): {
   data: ZoraNft;
@@ -22,12 +24,7 @@ const useZoraNft = ({
 } => {
   const loadNftDetails = async () => {
     const response = await axios.get(`${ZORA_WORKER_URL}/nft`, {
-      params: {
-        chain,
-        address,
-        token,
-        network: IS_MAINNET ? 'mainnet' : 'testnet'
-      }
+      params: { chain, address, token, network }
     });
 
     return response.data?.nft;

--- a/packages/lib/nft/getNft.ts
+++ b/packages/lib/nft/getNft.ts
@@ -2,7 +2,7 @@ import type { ZoraNftMetadata } from '@lenster/types/zora-nft';
 
 import getZoraNFT from './getZoraNft';
 
-const knownSites = new Set(['zora.co']);
+const knownSites = new Set(['zora.co', 'testnet.zora.co']);
 
 /**
  * Get NFT metadata from a list of URLs
@@ -24,15 +24,7 @@ const getNft = (urls: string[]): ZoraNftMetadata | null => {
     return null;
   }
 
-  const url = knownUrls[0];
-  const parsedUrl = new URL(url);
-  const hostname = parsedUrl.hostname.replace('www.', '');
-
-  if (hostname === 'zora.co') {
-    return getZoraNFT(url);
-  }
-
-  return null;
+  return getZoraNFT(knownUrls[0]);
 };
 
 export default getNft;

--- a/packages/lib/nft/getZoraNft.ts
+++ b/packages/lib/nft/getZoraNft.ts
@@ -1,7 +1,8 @@
 import type { ZoraNftMetadata } from '@lenster/types/zora-nft';
 
+const mainnetChains = ['eth', 'zora', 'base'];
 export const regex =
-  /https:\/\/zora.co\/collect\/(eth|base|zora):(0x[\dA-Fa-f]{40})((?:\/(\d+))?|$)/;
+  /https:\/\/(?:testnet\.)?zora\.co\/collect\/(eth|base|zora|zgor):(0x[\dA-Fa-f]{40})((?:\/(\d+))?|$)/;
 
 /**
  * Get Zora NFT metadata from a URL
@@ -14,8 +15,9 @@ const getZoraNFT = (url: string): ZoraNftMetadata | null => {
     const chain = matches[1];
     const address = matches[2];
     const token = matches[4];
+    const network = mainnetChains.includes(chain) ? 'mainnet' : 'testnet';
 
-    return { chain, address, token };
+    return { chain, address, token, network };
   }
 
   return null;

--- a/packages/types/zora-nft.d.ts
+++ b/packages/types/zora-nft.d.ts
@@ -2,6 +2,7 @@ export interface ZoraNftMetadata {
   chain: string;
   address: string;
   token: string;
+  network: 'testnet' | 'mainnet';
 }
 
 export interface ZoraNft {


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 250ba78</samp>

Added and improved support for testnet Zora NFTs in the web app and the lib package. Refactored some functions and hooks to accept a `network` parameter and to handle different Zora NFT URL formats. Updated `apps/web/src/components/Shared/OpenAction/Nft/index.tsx` to use the `network` prop.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 250ba78</samp>

*  Add `network` prop to `Nft` component and pass it to `useZoraNft` hook ([link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-b0245d761eb1680291ece344e143661186d23a48466176bad89ab21c6e807f41L60-R60),[link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-b0245d761eb1680291ece344e143661186d23a48466176bad89ab21c6e807f41R72),[link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-c7706b3d375f9a6ffa92084e4a56bcbd8f8e76642262db3d13be0bf914685db8R10))
*  Update `useZoraNft` hook to fetch NFT details from Zora worker API based on `network` prop ([link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-c7706b3d375f9a6ffa92084e4a56bcbd8f8e76642262db3d13be0bf914685db8L1-R2),[link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-c7706b3d375f9a6ffa92084e4a56bcbd8f8e76642262db3d13be0bf914685db8R18),[link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-c7706b3d375f9a6ffa92084e4a56bcbd8f8e76642262db3d13be0bf914685db8L25-R27))
*  Update `getNft` and `getZoraNft` functions in `nft` library to support both mainnet and testnet Zora NFT URLs and return `network` property ([link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-bf37b1712419a21beaa11638f02b075ac17c49a0d5053cd767a73854e775ea51L5-R5),[link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-bf37b1712419a21beaa11638f02b075ac17c49a0d5053cd767a73854e775ea51L27-R27),[link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-574c7e2d175be07f3815a0d7b521ad507f17271d048bd84dc025acd6ff048654L3-R5),[link](https://github.com/lensterxyz/lenster/pull/3694/files?diff=unified&w=0#diff-574c7e2d175be07f3815a0d7b521ad507f17271d048bd84dc025acd6ff048654L17-R20))

## Emoji

<!--
copilot:emoji
-->

🧪🔄🌐

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of support for testnet NFTs, which are useful for testing and developing new features or integrations with Zora NFTs.
2.  🔄 - This emoji represents recycling, refreshing, or updating, and can be used to indicate the refactoring of the `useZoraNft` hook and the `loadNftDetails` function, which improves the code quality and performance by avoiding duplication and simplifying the logic.
3.  🌐 - This emoji represents the globe, the internet, or the world, and can be used to indicate the improvement of the `getZoraNFT` function, which handles different Zora NFT URL formats and provides network information, making the function more robust and compatible with different Zora NFT sources and networks.
-->
