### PR TITLE
chore: remove network prop in zora worker

### DIFF
--- a/apps/web/src/components/Shared/OpenAction/Nft/index.tsx
+++ b/apps/web/src/components/Shared/OpenAction/Nft/index.tsx
@@ -61,7 +61,7 @@ interface NftProps {
 }
 
 const Nft: FC<NftProps> = ({ nftMetadata }) => {
-  const { chain, address, token, network } = nftMetadata;
+  const { chain, address, token } = nftMetadata;
   const [showMintModal, setShowMintModal] = useState(false);
   const isZoraMintEnabled = isFeatureEnabled(FeatureFlag.ZoraMint);
 
@@ -73,7 +73,6 @@ const Nft: FC<NftProps> = ({ nftMetadata }) => {
     chain,
     address,
     token: token,
-    network,
     enabled: Boolean(chain && address)
   });
 

--- a/apps/web/src/hooks/zora/useZoraNft.ts
+++ b/apps/web/src/hooks/zora/useZoraNft.ts
@@ -1,5 +1,5 @@
 import { ZORA_WORKER_URL } from '@lenster/data/constants';
-import type { ZoraNft, ZoraNftMetadata } from '@lenster/types/zora-nft';
+import type { ZoraNft } from '@lenster/types/zora-nft';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
@@ -7,7 +7,6 @@ interface UseZoraNftProps {
   chain: string;
   address: string;
   token: string;
-  network: ZoraNftMetadata['network'];
   enabled?: boolean;
 }
 
@@ -15,7 +14,6 @@ const useZoraNft = ({
   chain,
   address,
   token,
-  network,
   enabled
 }: UseZoraNftProps): {
   data: ZoraNft;
@@ -24,7 +22,7 @@ const useZoraNft = ({
 } => {
   const loadNftDetails = async () => {
     const response = await axios.get(`${ZORA_WORKER_URL}/nft`, {
-      params: { chain, address, token, network }
+      params: { chain, address, token }
     });
 
     return response.data?.nft;

--- a/packages/lib/nft/getZoraNft.ts
+++ b/packages/lib/nft/getZoraNft.ts
@@ -1,6 +1,5 @@
 import type { ZoraNftMetadata } from '@lenster/types/zora-nft';
 
-const mainnetChains = ['eth', 'oeth', 'base', 'zora'];
 export const regex =
   /https:\/\/(?:testnet\.)?zora\.co\/collect\/(eth|oeth|base|zora|gor|ogor|basegor|zgor):(0x[\dA-Fa-f]{40})((?:\/(\d+))?|$)/;
 
@@ -15,9 +14,8 @@ const getZoraNFT = (url: string): ZoraNftMetadata | null => {
     const chain = matches[1];
     const address = matches[2];
     const token = matches[4];
-    const network = mainnetChains.includes(chain) ? 'mainnet' : 'testnet';
 
-    return { chain, address, token, network };
+    return { chain, address, token };
   }
 
   return null;

--- a/packages/types/zora-nft.d.ts
+++ b/packages/types/zora-nft.d.ts
@@ -2,7 +2,6 @@ export interface ZoraNftMetadata {
   chain: string;
   address: string;
   token: string;
-  network: 'testnet' | 'mainnet';
 }
 
 export interface ZoraNft {

--- a/packages/workers/zora/src/handlers/getNft.spec.ts
+++ b/packages/workers/zora/src/handlers/getNft.spec.ts
@@ -3,13 +3,23 @@ import { describe, expect, test } from 'vitest';
 import { TEST_URL } from '../constants';
 
 describe('getNft', () => {
-  test('should return valid nft response if chain and address is provided', async () => {
+  test('should return valid mainnet nft response if chain and address is provided', async () => {
     const getRequest = await fetch(
-      `${TEST_URL}/nft?chain=zora&address=0x4ad3cd57a68149a5c5d8a41919dc8ac02d00a366&network=mainnet`
+      `${TEST_URL}/nft?chain=zora&address=0x4ad3cd57a68149a5c5d8a41919dc8ac02d00a366`
     );
     const response: any = await getRequest.json();
 
     expect(response.success).toBeTruthy();
     expect(response.nft.name).toBe('Guild on Zora');
+  });
+
+  test('should return valid testnet nft response if chain and address is provided', async () => {
+    const getRequest = await fetch(
+      `${TEST_URL}/nft?chain=zgor&address=0x276d3a444f2fe1a7d43c6716a630f3a2760ad1c9`
+    );
+    const response: any = await getRequest.json();
+
+    expect(response.success).toBeTruthy();
+    expect(response.nft.name).toBe('VİKİNG');
   });
 });

--- a/packages/workers/zora/src/handlers/getNft.ts
+++ b/packages/workers/zora/src/handlers/getNft.ts
@@ -9,20 +9,21 @@ export default async (request: WorkerRequest) => {
     name: '@lenster/zora/getNft'
   });
 
-  const { network, chain, address } = request.query;
+  const { chain, address } = request.query;
 
-  if (!network || !chain || !address) {
+  if (!chain || !address) {
     return response({
       success: false,
-      error: 'No network, chain and address provided'
+      error: 'No chain and address provided'
     });
   }
 
   try {
+    const mainnetChains = ['eth', 'oeth', 'base', 'zora'];
+    const network = mainnetChains.includes(chain as string) ? '' : 'testnet.';
+
     const zoraResponse = await fetch(
-      `https://${
-        network === 'testnet' ? 'testnet.' : ''
-      }zora.co/api/personalize/collection/${chain}:${address}`
+      `https://${network}zora.co/api/personalize/collection/${chain}:${address}`
     );
     const nft: { collection: any } = await zoraResponse.json();
 


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d2201d5</samp>

Removed the `network` parameter from the Zora NFT fetching logic across the web app, the lib package, and the workers package. This simplifies the code and avoids unnecessary network switching, as the network can be derived from the chain ID.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d2201d5</samp>

*  Remove `network` property from `nftMetadata` object and `useZoraNft` hook call in `Nft` component ([link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-b0245d761eb1680291ece344e143661186d23a48466176bad89ab21c6e807f41L64-R64), [link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-b0245d761eb1680291ece344e143661186d23a48466176bad89ab21c6e807f41L76))
*  Remove `network` property from `useZoraNft` hook interface and implementation in `useZoraNft.ts` ([link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-c7706b3d375f9a6ffa92084e4a56bcbd8f8e76642262db3d13be0bf914685db8L2-R2), [link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-c7706b3d375f9a6ffa92084e4a56bcbd8f8e76642262db3d13be0bf914685db8L10), [link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-c7706b3d375f9a6ffa92084e4a56bcbd8f8e76642262db3d13be0bf914685db8L18), [link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-c7706b3d375f9a6ffa92084e4a56bcbd8f8e76642262db3d13be0bf914685db8L27-R25))
*  Remove `network` property from return value of `getZoraNft` function in `getZoraNft.ts` ([link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-574c7e2d175be07f3815a0d7b521ad507f17271d048bd84dc025acd6ff048654L3), [link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-574c7e2d175be07f3815a0d7b521ad507f17271d048bd84dc025acd6ff048654L18-R18))
*  Remove `network` property from query validation and fetch URL in `getNft` handler in `getNft.ts` and define `network` based on `chain` and `mainnetChains` ([link](https://github.com/lensterxyz/lenster/pull/3698/files?diff=unified&w=0#diff-6e25113ecdaca0cf80dc49d7b9d58879ad653cb749b3991773e1b29dcaa55341L12-R26))

## Emoji

<!--
copilot:emoji
-->

🔥🌐🎨

<!--
1.  🔥 - This emoji represents the removal of the `network` property and parameter from various files and functions, as well as the simplification of the code and logic. It conveys the idea of burning or deleting something that is no longer needed or useful.
2.  🌐 - This emoji represents the network switching logic that was removed from the Zora NFT fetching function. It conveys the idea of the global or internet network, and the different chains or protocols that can be used to access it.
3.  🎨 - This emoji represents the Zora NFT metadata and content that are fetched by the `getZoraNft` function. It conveys the idea of art or creativity, which are the main features of the Zora platform and its NFTs.
-->
