### PR TITLE
chore: add text highlighting for mention node

### DIFF
--- a/apps/web/src/components/Shared/Lexical/Nodes/MentionsNode.tsx
+++ b/apps/web/src/components/Shared/Lexical/Nodes/MentionsNode.tsx
@@ -53,7 +53,7 @@ export class MentionNode extends TextNode {
   createDOM(config: EditorConfig): HTMLElement {
     const dom = super.createDOM(config);
     dom.style.cssText = '';
-    dom.className = '';
+    dom.className = 'text-brand';
 
     return dom;
   }


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8119a6f</samp>

Added a blue color to mention nodes in the text editor. This improves the visibility and consistency of mentions in the app.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8119a6f</samp>

*  Add `text-brand` class to mention nodes to make them more visible and consistent ([link](https://github.com/lensterxyz/lenster/pull/3735/files?diff=unified&w=0#diff-4cc2decf3f145e0ba2064b6c5f21a11199cc0e5562e6a2a9b90f0e11630ef136L56-R56))

## Emoji

<!--
copilot:emoji
-->

👥🎨🆕

<!--
1.  👥 - This emoji represents the concept of mentioning users and groups, which is the main feature of the `MentionNode` class. It also conveys the idea of collaboration and communication, which are the goals of the app.
2.  🎨 - This emoji represents the change in the appearance of the mention node, which is to add a blue color to the text. It also conveys the idea of design and creativity, which are relevant to the app's domain of writing.
3.  🆕 - This emoji represents the fact that the change is a new addition to the codebase, which implies that it is not a bug fix or a refactoring. It also conveys the idea of innovation and improvement, which are desirable qualities for the app.
-->
