### PR TITLE
feat: add pagination to algorithmic feed

### DIFF
--- a/apps/web/src/components/Home/AlgorithmicFeed.tsx
+++ b/apps/web/src/components/Home/AlgorithmicFeed.tsx
@@ -68,7 +68,7 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
     }
   });
 
-  if (displayedPublications.length == 0 && (algoLoading || loading)) {
+  if (publications.length == 0 && (algoLoading || loading)) {
     return <PublicationsShimmer />;
   }
 
@@ -81,7 +81,7 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
     );
   }
 
-  if (displayedPublications.length == 0 && (error || algoError)) {
+  if (publications.length == 0 && (error || algoError)) {
     return <ErrorMessage title={t`Failed to load for you`} error={error} />;
   }
 

--- a/apps/web/src/components/Home/AlgorithmicFeed.tsx
+++ b/apps/web/src/components/Home/AlgorithmicFeed.tsx
@@ -19,7 +19,6 @@ interface AlgorithmicFeedProps {
 
 const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
   const currentProfile = useAppStore((state) => state.currentProfile);
-
   const [displayedPublications, setDisplayedPublications] = useState<any[]>([]);
 
   const limit = 20;

--- a/apps/web/src/components/Home/AlgorithmicFeed.tsx
+++ b/apps/web/src/components/Home/AlgorithmicFeed.tsx
@@ -21,7 +21,6 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
   const currentProfile = useAppStore((state) => state.currentProfile);
 
   const [displayedPublications, setDisplayedPublications] = useState<any[]>([]);
-  const isFirstLoad = displayedPublications.length == 0;
 
   const limit = 20;
   const offset = displayedPublications.length;
@@ -69,7 +68,7 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
     }
   });
 
-  if (isFirstLoad && (algoLoading || loading)) {
+  if (displayedPublications.length == 0 && (algoLoading || loading)) {
     return <PublicationsShimmer />;
   }
 
@@ -82,7 +81,7 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
     );
   }
 
-  if (isFirstLoad && (error || algoError)) {
+  if (displayedPublications.length == 0 && (error || algoError)) {
     return <ErrorMessage title={t`Failed to load for you`} error={error} />;
   }
 

--- a/apps/web/src/components/Home/AlgorithmicFeed.tsx
+++ b/apps/web/src/components/Home/AlgorithmicFeed.tsx
@@ -9,7 +9,7 @@ import getAlgorithmicFeed from '@lib/getAlgorithmicFeed';
 import { t } from '@lingui/macro';
 import { useQuery } from '@tanstack/react-query';
 import type { FC } from 'react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useInView } from 'react-cool-inview';
 import { useAppStore } from 'src/store/app';
 
@@ -37,6 +37,10 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
     }
   );
 
+  useEffect(() => {
+    setDisplayedPublications([]);
+  }, [feedType, currentProfile?.id]);
+
   const request: PublicationsQueryRequest = { publicationIds, limit };
   const reactionRequest = currentProfile
     ? { profileId: currentProfile?.id }
@@ -53,14 +57,15 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
     ...displayedPublications,
     ...(data?.publications?.items || [])
   ];
-  const hasMore = true;
 
   const { observe } = useInView({
     onChange: async ({ inView }) => {
-      if (!inView || !hasMore) {
+      if (!inView) {
         return;
       }
-      setDisplayedPublications(publications);
+      if (publications.length != displayedPublications.length) {
+        setDisplayedPublications(publications);
+      }
     }
   });
 
@@ -91,7 +96,7 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
           publication={publication as Publication}
         />
       ))}
-      {hasMore ? <span ref={observe} /> : null}
+      <span ref={observe} />
     </Card>
   );
 };

--- a/apps/web/src/components/Home/AlgorithmicFeed.tsx
+++ b/apps/web/src/components/Home/AlgorithmicFeed.tsx
@@ -30,15 +30,15 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
   } = useInfiniteQuery({
     queryKey: ['algorithmicFeed', feedType, currentProfile?.id],
     queryFn: ({ pageParam = 0 }) =>
-      getAlgorithmicFeed(feedType, currentProfile, limit, pageParam * limit),
+      getAlgorithmicFeed(feedType, currentProfile, 20, pageParam * 20),
 
     getNextPageParam: (lastPage, pages) =>
-      lastPage.length < limit ? null : pages.length
+      lastPage.length < 20 ? null : pages.length
   });
 
   const request: PublicationsQueryRequest = {
     publicationIds: publicationIds?.pages[publicationIds.pages.length - 1],
-    limit: limit
+    limit: 20
   };
   const reactionRequest = currentProfile
     ? { profileId: currentProfile?.id }

--- a/apps/web/src/components/Home/AlgorithmicFeed.tsx
+++ b/apps/web/src/components/Home/AlgorithmicFeed.tsx
@@ -30,15 +30,15 @@ const AlgorithmicFeed: FC<AlgorithmicFeedProps> = ({ feedType }) => {
   } = useInfiniteQuery({
     queryKey: ['algorithmicFeed', feedType, currentProfile?.id],
     queryFn: ({ pageParam = 0 }) =>
-      getAlgorithmicFeed(feedType, currentProfile, 20, pageParam * 20),
+      getAlgorithmicFeed(feedType, currentProfile, limit, pageParam * limit),
 
     getNextPageParam: (lastPage, pages) =>
-      lastPage.length < 20 ? null : pages.length
+      lastPage.length < limit ? null : pages.length
   });
 
   const request: PublicationsQueryRequest = {
     publicationIds: publicationIds?.pages[publicationIds.pages.length - 1],
-    limit: 20
+    limit: limit
   };
   const reactionRequest = currentProfile
     ? { profileId: currentProfile?.id }

--- a/apps/web/src/lib/getAlgorithmicFeed.ts
+++ b/apps/web/src/lib/getAlgorithmicFeed.ts
@@ -10,7 +10,9 @@ import getPublicationIds from '@lenster/lib/getPublicationIds';
  */
 const getAlgorithmicFeed = async (
   feedType: HomeFeedType,
-  profile: Profile | null
+  profile: Profile | null,
+  limit: number | null,
+  offset: number | null
 ) => {
   switch (feedType) {
     case HomeFeedType.K3L_RECOMMENDED:
@@ -19,19 +21,25 @@ const getAlgorithmicFeed = async (
     case HomeFeedType.K3L_CROWDSOURCED:
       return getPublicationIds(
         AlgorithmProvider.K3L,
-        feedType.replace('K3L_', '').toLowerCase()
+        feedType.replace('K3L_', '').toLowerCase(),
+        limit,
+        offset
       ).then((data) => data);
     case HomeFeedType.K3L_FOLLOWING:
       return getPublicationIds(
         AlgorithmProvider.K3L,
         feedType.replace('K3L_', '').toLowerCase(),
+        limit,
+        offset,
         profile?.handle
       ).then((data) => data);
     case HomeFeedType.LENSTER_MOSTVIEWED:
     case HomeFeedType.LENSTER_MOSTINTERACTED:
       return getPublicationIds(
         AlgorithmProvider.LENSTER,
-        feedType.replace('LENSTER_', '').toLowerCase()
+        feedType.replace('LENSTER_', '').toLowerCase(),
+        limit,
+        offset
       ).then((data) => data);
     default:
       return [];

--- a/packages/lib/getPublicationIds.ts
+++ b/packages/lib/getPublicationIds.ts
@@ -11,11 +11,19 @@ import axios from 'axios';
 const getPublicationIds = async (
   provider: string,
   strategy: string,
+  limit: number | null,
+  offset: number | null,
   profile?: string
 ) => {
   try {
     const response = await axios.get(`${FEEDS_WORKER_URL}/ids`, {
-      params: { provider, strategy, ...(profile ? { profile } : {}) }
+      params: {
+        provider,
+        strategy,
+        limit,
+        offset,
+        ...(profile ? { profile } : {})
+      }
     });
 
     return response.data.success ? response.data.ids : [];


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at de6bbab</samp>

This pull request adds infinite scrolling to the web app's algorithmic and profile feeds, using pagination of publication ids from different providers. It modifies the `getAlgorithmicFeed` function and the `getPublicationIds` function to handle the pagination logic, and updates the `AlgorithmicFeed` component to use the new hooks.


**After:**

https://github.com/lensterxyz/lenster/assets/667227/4d6ac392-da89-46f1-8fc8-0d2e96f3a355

## Related issues

Fixes #3483

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at de6bbab</samp>

*  Implement infinite scrolling for the algorithmic feed component ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-848e77e4a67d82015bfd1d335c5f39a9823d00b39c7ff95d97713992182113f0L10-R12), [link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-848e77e4a67d82015bfd1d335c5f39a9823d00b39c7ff95d97713992182113f0L21-R42), [link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-848e77e4a67d82015bfd1d335c5f39a9823d00b39c7ff95d97713992182113f0L35-R78), [link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-848e77e4a67d82015bfd1d335c5f39a9823d00b39c7ff95d97713992182113f0R106))
  - Update imports to use `useInfiniteQuery`, `useEffect`, and `useInView` hooks ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-848e77e4a67d82015bfd1d335c5f39a9823d00b39c7ff95d97713992182113f0L10-R12))
  - Replace `useQuery` with `useInfiniteQuery` and pass `limit` and `pageParam` arguments to `getAlgorithmicFeed` ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-848e77e4a67d82015bfd1d335c5f39a9823d00b39c7ff95d97713992182113f0L21-R42))
  - Update `useProfileFeedQuery` to use `fetchMore` and `refetch` functions and create an observer element with `useInView` ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-848e77e4a67d82015bfd1d335c5f39a9823d00b39c7ff95d97713992182113f0L35-R78))
  - Add observer element to the end of the publications list ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-848e77e4a67d82015bfd1d335c5f39a9823d00b39c7ff95d97713992182113f0R106))
* Update `getAlgorithmicFeed` function to accept `limit` and `offset` arguments and pass them to the feeds worker ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-333daf307173c12ef1d04da090879f9496fc8b08e9ce3d727707138675920a41L13-R15), [link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-333daf307173c12ef1d04da090879f9496fc8b08e9ce3d727707138675920a41L22-R26), [link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-333daf307173c12ef1d04da090879f9496fc8b08e9ce3d727707138675920a41R32-R33), [link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-333daf307173c12ef1d04da090879f9496fc8b08e9ce3d727707138675920a41L34-R42))
  - Add `limit` and `offset` arguments to the function signature ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-333daf307173c12ef1d04da090879f9496fc8b08e9ce3d727707138675920a41L13-R15))
  - Add `limit` and `offset` arguments to the `getPublicationIds` function calls for each provider ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-333daf307173c12ef1d04da090879f9496fc8b08e9ce3d727707138675920a41L22-R26), [link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-333daf307173c12ef1d04da090879f9496fc8b08e9ce3d727707138675920a41R32-R33), [link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-333daf307173c12ef1d04da090879f9496fc8b08e9ce3d727707138675920a41L34-R42))
* Update `getPublicationIds` function to accept `limit` and `offset` arguments and pass them to the feeds worker as query parameters ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-28f5c9275ef67db786ab872ef3a1d4428cb8a305c7562af613d7ac7ef8eab736L14-R26))
  - Add `limit` and `offset` arguments to the function signature and the worker URL ([link](https://github.com/lensterxyz/lenster/pull/3739/files?diff=unified&w=0#diff-28f5c9275ef67db786ab872ef3a1d4428cb8a305c7562af613d7ac7ef8eab736L14-R26))

## Emoji

<!--
copilot:emoji
-->

📄🚀🔀

<!--
1.  📄 for adding the `limit` and `offset` arguments to the `getPublicationIds` function and passing them to the feeds worker.
2.  🚀 for adding infinite scrolling functionality to the algorithmic feed and the profile feed components, using different hooks and query parameters.
3.  🔀 for modifying the `getAlgorithmicFeed` function and its sub-functions to support pagination of publication ids from different providers.
-->
