### PR TITLE
fix: preview profile img size

### DIFF
--- a/apps/web/src/components/Messages/Preview.tsx
+++ b/apps/web/src/components/Messages/Preview.tsx
@@ -80,7 +80,7 @@ const Preview: FC<PreviewProps> = ({
                 : getAvatar('')
             }
             loading="lazy"
-            className="h-10 w-10 rounded-full border bg-gray-200 dark:border-gray-700"
+            className="h-10 min-h-[40px] w-10 min-w-[40px] rounded-full border bg-gray-200 dark:border-gray-700"
             height={40}
             width={40}
             alt={formatHandle(profile?.handle)}


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8596a7e</samp>

Improved the image size and layout of the message preview component in `apps/web/src/components/Messages/Preview.tsx` by adding Tailwind CSS classes.

## Related issues

Fixes #3741 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8596a7e</samp>

* Ensure message preview images have a minimum size of 40 pixels ([link](https://github.com/lensterxyz/lenster/pull/3762/files?diff=unified&w=0#diff-86a42fd57d0cd5557caf0ba432c3f36f048b7f3098460771c3f65de779dd14a4L83-R83))

## Emoji

🚀 
