### PR TITLE
fix: preview list loading state

### DIFF
--- a/apps/web/src/components/Messages/Message.tsx
+++ b/apps/web/src/components/Messages/Message.tsx
@@ -22,7 +22,6 @@ import type {
 } from 'src/hooks/useSendOptimisticMessage';
 import useSendOptimisticMessage from 'src/hooks/useSendOptimisticMessage';
 import useStreamMessages from 'src/hooks/useStreamMessages';
-import Custom404 from 'src/pages/404';
 import { useAppStore } from 'src/store/app';
 import { useMessageStore } from 'src/store/message';
 import useResizeObserver from 'use-resize-observer';
@@ -238,16 +237,9 @@ const Message: FC<MessageProps> = ({}) => {
 };
 
 const MessagePage: NextPage = () => {
-  const currentProfileId = useAppStore((state) => state.currentProfile?.id);
-
   useEffectOnce(() => {
     Leafwatch.track(PAGEVIEW, { page: 'conversation' });
   });
-
-  // Need to have a login page for when there is no currentProfileId
-  if (!currentProfileId) {
-    return <Custom404 />;
-  }
 
   return <Message />;
 };

--- a/apps/web/src/components/Messages/Message.tsx
+++ b/apps/web/src/components/Messages/Message.tsx
@@ -149,10 +149,6 @@ const Message: FC<MessageProps> = ({}) => {
     }
   }, [conversationKey, hasMore, messages, endTime]);
 
-  if (!currentProfile) {
-    return <NotLoggedIn />;
-  }
-
   const showLoading = !missingXmtpAuth && !currentProfile;
 
   const userNameForTitle =
@@ -237,9 +233,16 @@ const Message: FC<MessageProps> = ({}) => {
 };
 
 const MessagePage: NextPage = () => {
+  const currentProfileId = useAppStore((state) => state.currentProfile?.id);
+
   useEffectOnce(() => {
     Leafwatch.track(PAGEVIEW, { page: 'conversation' });
   });
+
+  // Need to have a login page for when there is no currentProfileId
+  if (!currentProfileId) {
+    return <NotLoggedIn />;
+  }
 
   return <Message />;
 };

--- a/apps/web/src/components/Messages/MessageHeader.tsx
+++ b/apps/web/src/components/Messages/MessageHeader.tsx
@@ -4,7 +4,6 @@ import { ChevronLeftIcon } from '@heroicons/react/outline';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import formatAddress from '@lenster/lib/formatAddress';
-import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
 import getStampFyiURL from '@lenster/lib/getStampFyiURL';
 import { Image } from '@lenster/ui';
@@ -63,17 +62,17 @@ const MessageHeader: FC<MessageHeaderProps> = ({
         {profile ? (
           <UserProfile profile={profile} />
         ) : (
-          <>
+          <div className="flex min-h-[48px] items-center space-x-3">
             <Image
               src={ensName ? url : getAvatar(profile)}
               loading="lazy"
-              className="mr-4 h-10 w-10 rounded-full border bg-gray-200 dark:border-gray-700"
+              className="h-10 min-h-[40px] w-10 min-w-[40px] rounded-full border bg-gray-200 dark:border-gray-700"
               height={40}
               width={40}
-              alt={formatHandle('')}
+              alt={ensName ?? formatAddress(conversationKey ?? '')}
             />
-            {ensName ?? formatAddress(conversationKey ?? '')}
-          </>
+            <div>{ensName ?? formatAddress(conversationKey ?? '')}</div>
+          </div>
         )}
       </div>
       {profile ? (

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -74,7 +74,8 @@ const PreviewList: FC<PreviewListProps> = ({
 
   const showAuthenticating = currentProfile && authenticating;
 
-  const showLoading = loading || previewsLoading;
+  const showLoading =
+    loading && (messages.size === 0 || profilesToShow.size === 0);
 
   const newMessageClick = () => {
     setShowSearchModal(true);

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -8,7 +8,6 @@ import { MESSAGES } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import {
   Card,
-  EmptyState,
   ErrorMessage,
   GridItemFour,
   Modal,
@@ -188,11 +187,12 @@ const PreviewList: FC<PreviewListProps> = ({
               onClick={newMessageClick}
               type="button"
             >
-              <EmptyState
-                message={t`Start messaging your Lens frens`}
-                icon={<MailIcon className="text-brand h-8 w-8" />}
-                hideCard
-              />
+              <div className="grid justify-items-center space-y-2 p-5">
+                <div>
+                  <MailIcon className="text-brand h-8 w-8" />
+                </div>
+                <div>{t`Start messaging your Lens frens`}</div>
+              </div>
             </button>
           ) : (
             <Virtuoso


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aec44ac</samp>

Improved loading indicator logic in `PreviewList` component. The component now only shows the loading indicator when there is no data to display, instead of showing it whenever any data is being fetched.

## Related issues

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aec44ac</samp>

* Improve loading indicator logic for message previews ([link](https://github.com/lensterxyz/lenster/pull/3763/files?diff=unified&w=0#diff-eda1f4100c8fae29a041adb14d95c174c2313e7056d3922bd0c0b1b77d634778L77-R78))

## Emoji

<!--
copilot:emoji
-->

🔄🚫🙌

<!--
1.  🔄 - This emoji represents the change from using `loading` or `previewsLoading` to using `!messages.length && !profiles.length` as the condition for showing the loading indicator. The emoji suggests a switch or a change of logic.
2.  🚫 - This emoji represents the removal of the unnecessary loading states and flickering that occurred when the loading indicator was shown even when there were messages or profiles to display. The emoji suggests a negation or a prevention of something unwanted.
3.  🙌 - This emoji represents the improvement of the user experience by showing the loading indicator only when there is nothing else to show. The emoji suggests a celebration or a praise of something positive.
-->
