### PR TITLE
fix: crop oembed images to constant aspect ratio

### DIFF
--- a/apps/web/src/components/Shared/Oembed/Embed.tsx
+++ b/apps/web/src/components/Shared/Oembed/Embed.tsx
@@ -34,7 +34,7 @@ const Embed: FC<EmbedProps> = ({ og, publicationId }) => {
         <Card forceRounded>
           {og.isLarge && og.image ? (
             <Image
-              className="divider w-full rounded-t-xl"
+              className="divider aspect-2 w-full rounded-t-xl object-cover"
               onError={({ currentTarget }) => {
                 currentTarget.src = og.image as string;
               }}


### PR DESCRIPTION
## What does this PR do?

@bigint Not sure if i understood the desired behavior. But here's something to start with

Fixes #3084

### Before:
![Screenshot_2023-09-12_15-30-43](https://github.com/lensterxyz/lenster/assets/667227/d1f33cae-ca6c-4a7d-8971-e4034c826413)

### After:
![Screenshot_2023-09-12_15-32-26](https://github.com/lensterxyz/lenster/assets/667227/052bfca7-d964-430f-b3d1-7ddca98b1161)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d217ad8</samp>

Added classes to `Image` component to fix aspect ratio and stretching of oembed images in `Embed.tsx`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d217ad8</samp>

* Preserve aspect ratio and avoid stretching of embedded images in oembed component ([link](https://github.com/lensterxyz/lenster/pull/3764/files?diff=unified&w=0#diff-8c4edf59668cb216096d225df3729857825195df650e04d9ebd8d6f6358bfaebL37-R37))

## Emoji

<!--
copilot:emoji
-->

🖼️🧑‍🎨🔗

<!--
1.  🖼️ - This emoji can be used to represent the `Image` component or the aspect ratio feature, as it depicts a framed picture.
2.  🧑‍🎨 - This emoji can be used to represent the `object-cover` class or the visual improvement of the oembed component, as it depicts an artist or a designer.
3.  🔗 - This emoji can be used to represent the oembed feature, as it depicts a link or an embedded content.
-->
