### PR TITLE
fix: edit profile save btn disabled on no change

### DIFF
--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -350,7 +350,7 @@ const ProfileSettingsForm: FC<ProfileSettingsFormProps> = ({ profile }) => {
           <Button
             className="ml-auto"
             type="submit"
-            disabled={isLoading}
+            disabled={isLoading || (!form.formState.isDirty && !imageSrc)}
             icon={
               isLoading ? (
                 <Spinner size="xs" />


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af7dba5</samp>

Improved the logic of the submit button in the profile settings component. It now only enables when the user changes the form values or the avatar image.

## Related issues

Fixes ENG-60

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af7dba5</samp>

* Enable users to update their profile settings and avatar by submitting a form with validation and feedback ([link](https://github.com/lensterxyz/lenster/pull/3769/files?diff=unified&w=0#diff-cc605dc6510d575486ca4cc4d51a003ca10dfeb338fced8f413d3c60d1543c90L353-R353),                            

## Emoji

<!--
copilot:emoji
-->

🛠️🆕🔄

<!--
1.  🛠️ - This emoji represents a tool or a fix, and it could be used to indicate that the `disabled` prop was modified to improve the functionality or logic of the submit button.
2.  🆕 - This emoji represents something new or added, and it could be used to indicate that the new condition of checking the form or the image source was introduced to the `disabled` prop.
3.  🔄 - This emoji represents a refresh or a change, and it could be used to indicate that the `disabled` prop was updated to reflect the current state of the form or the image source.
-->
