### PR TITLE
chore: update heroicons to v2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/sortable": "^7.0.2",
     "@headlessui/react": "^1.7.17",
-    "@heroicons/react": "v1",
+    "@heroicons/react": "^2.0.18",
     "@lens-protocol/sdk-gated": "^1.2.0",
     "@lenster/abis": "workspace:*",
     "@lenster/data": "workspace:*",

--- a/apps/web/src/components/Bookmarks/Feed.tsx
+++ b/apps/web/src/components/Bookmarks/Feed.tsx
@@ -1,6 +1,6 @@
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { BookmarkIcon } from '@heroicons/react/outline';
+import { BookmarkIcon } from '@heroicons/react/24/outline';
 import type {
   Publication,
   PublicationMainFocus,

--- a/apps/web/src/components/Channel/Details.tsx
+++ b/apps/web/src/components/Channel/Details.tsx
@@ -1,7 +1,7 @@
 import Markup from '@components/Shared/Markup';
 import Slug from '@components/Shared/Slug';
-import { ClockIcon } from '@heroicons/react/outline';
-import { FireIcon } from '@heroicons/react/solid';
+import { ClockIcon } from '@heroicons/react/24/outline';
+import { FireIcon } from '@heroicons/react/24/solid';
 import { STATIC_IMAGES_URL } from '@lenster/data/constants';
 import formatHandle from '@lenster/lib/formatHandle';
 import type { Channel } from '@lenster/types/lenster';

--- a/apps/web/src/components/Channel/Feed.tsx
+++ b/apps/web/src/components/Channel/Feed.tsx
@@ -1,6 +1,6 @@
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { CollectionIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import type { ExplorePublicationRequest, Publication } from '@lenster/lens';
 import {
   PublicationSortCriteria,
@@ -70,7 +70,7 @@ const Feed: FC<FeedProps> = ({ channel }) => {
             <span>{t`don't have any publications yet`}</span>
           </div>
         }
-        icon={<CollectionIcon className="text-brand h-8 w-8" />}
+        icon={<RectangleStackIcon className="text-brand h-8 w-8" />}
       />
     );
   }

--- a/apps/web/src/components/Comment/Feed.tsx
+++ b/apps/web/src/components/Comment/Feed.tsx
@@ -1,7 +1,7 @@
 import QueuedPublication from '@components/Publication/QueuedPublication';
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { ChatAlt2Icon } from '@heroicons/react/outline';
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import type {
   Comment,
   Publication,
@@ -94,7 +94,7 @@ const Feed: FC<FeedProps> = ({ publication }) => {
     return (
       <EmptyState
         message={t`Be the first one to comment!`}
-        icon={<ChatAlt2Icon className="text-brand h-8 w-8" />}
+        icon={<ChatBubbleLeftRightIcon className="text-brand h-8 w-8" />}
       />
     );
   }

--- a/apps/web/src/components/Composer/Actions/AccessSettings/BasicSettings.tsx
+++ b/apps/web/src/components/Composer/Actions/AccessSettings/BasicSettings.tsx
@@ -1,5 +1,5 @@
 import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
-import { CollectionIcon, UsersIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon, UsersIcon } from '@heroicons/react/24/outline';
 import { CollectModules } from '@lenster/lens';
 import { Button, Card } from '@lenster/ui';
 import { t, Trans } from '@lingui/macro';
@@ -64,7 +64,7 @@ const BasicSettings: FC<BasicSettingsProps> = ({ setShowModal }) => {
               }}
               heading={t`Collectors can view`}
               description={t`People need to collect it first to be able to view it`}
-              icon={<CollectionIcon className="h-4 w-4" />}
+              icon={<RectangleStackIcon className="h-4 w-4" />}
             />
           </Card>
           <Card className="mt-5 p-5">

--- a/apps/web/src/components/Composer/Actions/AccessSettings/index.tsx
+++ b/apps/web/src/components/Composer/Actions/AccessSettings/index.tsx
@@ -1,4 +1,4 @@
-import { LockClosedIcon } from '@heroicons/react/outline';
+import { LockClosedIcon } from '@heroicons/react/24/outline';
 import { HelpTooltip, Modal, Tooltip } from '@lenster/ui';
 import cn from '@lenster/ui/cn';
 import { t, Trans } from '@lingui/macro';

--- a/apps/web/src/components/Composer/Actions/Attachment.tsx
+++ b/apps/web/src/components/Composer/Actions/Attachment.tsx
@@ -1,10 +1,10 @@
 import MenuTransition from '@components/Shared/MenuTransition';
 import { Menu } from '@headlessui/react';
 import {
-  MusicNoteIcon,
-  PhotographIcon,
+  MusicalNoteIcon,
+  PhotoIcon,
   VideoCameraIcon
-} from '@heroicons/react/outline';
+} from '@heroicons/react/24/outline';
 import {
   ALLOWED_AUDIO_TYPES,
   ALLOWED_IMAGE_TYPES,
@@ -85,7 +85,7 @@ const Attachment: FC = () => {
             <Spinner size="sm" />
           ) : (
             <Tooltip placement="top" content={t`Media`}>
-              <PhotographIcon className="text-brand h-5 w-5" />
+              <PhotoIcon className="text-brand h-5 w-5" />
             </Tooltip>
           )}
         </button>
@@ -107,7 +107,7 @@ const Attachment: FC = () => {
             }
             htmlFor={`image_${id}`}
           >
-            <PhotographIcon className="text-brand h-4 w-4" />
+            <PhotoIcon className="text-brand h-4 w-4" />
             <span className="text-sm">Upload image(s)</span>
             <input
               id={`image_${id}`}
@@ -152,7 +152,7 @@ const Attachment: FC = () => {
             }
             htmlFor={`audio_${id}`}
           >
-            <MusicNoteIcon className="text-brand h-4 w-4" />
+            <MusicalNoteIcon className="text-brand h-4 w-4" />
             <span className="text-sm">Upload audio</span>
             <input
               id={`audio_${id}`}

--- a/apps/web/src/components/Composer/Actions/CollectSettings/AmountConfig.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/AmountConfig.tsx
@@ -1,5 +1,5 @@
 import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
-import { CurrencyDollarIcon } from '@heroicons/react/outline';
+import { CurrencyDollarIcon } from '@heroicons/react/24/outline';
 import { DEFAULT_COLLECT_TOKEN } from '@lenster/data/constants';
 import type { Erc20 } from '@lenster/lens';
 import { CollectModules } from '@lenster/lens';

--- a/apps/web/src/components/Composer/Actions/CollectSettings/CollectLimitConfig.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/CollectLimitConfig.tsx
@@ -1,5 +1,5 @@
 import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
-import { StarIcon } from '@heroicons/react/outline';
+import { StarIcon } from '@heroicons/react/24/outline';
 import { Input } from '@lenster/ui';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';

--- a/apps/web/src/components/Composer/Actions/CollectSettings/FollowersConfig.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/FollowersConfig.tsx
@@ -1,5 +1,5 @@
 import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
-import { UserGroupIcon } from '@heroicons/react/outline';
+import { UserGroupIcon } from '@heroicons/react/24/outline';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';
 import { useCollectModuleStore } from 'src/store/collect-module';

--- a/apps/web/src/components/Composer/Actions/CollectSettings/ReferralConfig.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/ReferralConfig.tsx
@@ -1,5 +1,5 @@
 import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
-import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import { CollectModules } from '@lenster/lens';
 import { Input } from '@lenster/ui';
 import { t } from '@lingui/macro';
@@ -27,7 +27,7 @@ const ReferralConfig: FC<ReferralConfigProps> = ({ setCollectType }) => {
         }
         heading={t`Mirror referral reward`}
         description={t`Share your fee with people who amplify your content`}
-        icon={<SwitchHorizontalIcon className="h-4 w-4" />}
+        icon={<ArrowsRightLeftIcon className="h-4 w-4" />}
       />
       {collectModule.referralFee ? (
         <div className="flex space-x-2 pt-4 text-sm">

--- a/apps/web/src/components/Composer/Actions/CollectSettings/SplitConfig.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/SplitConfig.tsx
@@ -1,11 +1,11 @@
 import Beta from '@components/Shared/Badges/Beta';
 import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
 import {
+  ArrowsRightLeftIcon,
   PlusIcon,
-  SwitchHorizontalIcon,
   UsersIcon,
   XCircleIcon
-} from '@heroicons/react/outline';
+} from '@heroicons/react/24/outline';
 import { HANDLE_SUFFIX, LENSPROTOCOL_HANDLE } from '@lenster/data/constants';
 import { CollectModules, useProfileLazyQuery } from '@lenster/lens';
 import isValidEthAddress from '@lenster/lib/isValidEthAddress';
@@ -182,7 +182,7 @@ const SplitConfig: FC<SplitConfigProps> = ({
             <Button
               size="sm"
               outline
-              icon={<SwitchHorizontalIcon className="h-3 w-3" />}
+              icon={<ArrowsRightLeftIcon className="h-3 w-3" />}
               onClick={splitEvenly}
             >
               Split evenly

--- a/apps/web/src/components/Composer/Actions/CollectSettings/TimeLimitConfig.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/TimeLimitConfig.tsx
@@ -1,5 +1,5 @@
 import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
-import { ClockIcon } from '@heroicons/react/outline';
+import { ClockIcon } from '@heroicons/react/24/outline';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';
 import { useCollectModuleStore } from 'src/store/collect-module';

--- a/apps/web/src/components/Composer/Actions/CollectSettings/index.tsx
+++ b/apps/web/src/components/Composer/Actions/CollectSettings/index.tsx
@@ -1,4 +1,4 @@
-import { CollectionIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import { Modal, Tooltip } from '@lenster/ui';
 import { t } from '@lingui/macro';
 import { motion } from 'framer-motion';
@@ -21,12 +21,12 @@ const CollectSettings: FC = () => {
           onClick={() => setShowModal(!showModal)}
           aria-label="Choose Collect Module"
         >
-          <CollectionIcon className="text-brand h-5 w-5" />
+          <RectangleStackIcon className="text-brand h-5 w-5" />
         </motion.button>
       </Tooltip>
       <Modal
         title={t`Collect settings`}
-        icon={<CollectionIcon className="text-brand h-5 w-5" />}
+        icon={<RectangleStackIcon className="text-brand h-5 w-5" />}
         show={showModal}
         onClose={() => {
           setShowModal(false);

--- a/apps/web/src/components/Composer/Actions/Gif/index.tsx
+++ b/apps/web/src/components/Composer/Actions/Gif/index.tsx
@@ -1,5 +1,5 @@
 import Loader from '@components/Shared/Loader';
-import { PhotographIcon } from '@heroicons/react/outline';
+import { PhotoIcon } from '@heroicons/react/24/outline';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type { IGif } from '@lenster/types/giphy';
 import { Modal, Tooltip } from '@lenster/ui';
@@ -48,7 +48,7 @@ const Gif: FC<GiphyProps> = ({ setGifAttachment }) => {
       </Tooltip>
       <Modal
         title={t`Select GIF`}
-        icon={<PhotographIcon className="text-brand h-5 w-5" />}
+        icon={<PhotoIcon className="text-brand h-5 w-5" />}
         show={showModal}
         onClose={() => setShowModal(false)}
       >

--- a/apps/web/src/components/Composer/Actions/PollSettings/PollEditor.tsx
+++ b/apps/web/src/components/Composer/Actions/PollSettings/PollEditor.tsx
@@ -1,5 +1,5 @@
-import { ClockIcon, PlusIcon, XIcon } from '@heroicons/react/outline';
-import { MenuAlt2Icon, XCircleIcon } from '@heroicons/react/solid';
+import { ClockIcon, PlusIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Bars3BottomLeftIcon, XCircleIcon } from '@heroicons/react/24/solid';
 import { Button, Card, Input, Modal, Tooltip } from '@lenster/ui';
 import { Plural, t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
@@ -19,7 +19,7 @@ const PollEditor: FC = () => {
     <Card className="m-5 px-5 py-3" forceRounded>
       <div className="flex items-center justify-between">
         <div className="flex items-center space-x-2 text-sm">
-          <MenuAlt2Icon className="text-brand h-4 w-4" />
+          <Bars3BottomLeftIcon className="text-brand h-4 w-4" />
           <b>Poll</b>
         </div>
         <div className="flex items-center space-x-3">
@@ -114,7 +114,7 @@ const PollEditor: FC = () => {
                       setPollConfig({ ...pollConfig, choices: newChoices });
                     }}
                   >
-                    <XIcon className="h-5 w-5 text-red-500" />
+                    <XMarkIcon className="h-5 w-5 text-red-500" />
                   </button>
                 ) : null
               }

--- a/apps/web/src/components/Composer/Actions/PollSettings/index.tsx
+++ b/apps/web/src/components/Composer/Actions/PollSettings/index.tsx
@@ -1,4 +1,4 @@
-import { MenuAlt2Icon } from '@heroicons/react/solid';
+import { Bars3BottomLeftIcon } from '@heroicons/react/24/solid';
 import { Tooltip } from '@lenster/ui';
 import { t } from '@lingui/macro';
 import { motion } from 'framer-motion';
@@ -23,7 +23,7 @@ const PollSettings: FC = () => {
         }}
         aria-label="Poll"
       >
-        <MenuAlt2Icon className="text-brand h-5 w-5" />
+        <Bars3BottomLeftIcon className="text-brand h-5 w-5" />
       </motion.button>
     </Tooltip>
   );

--- a/apps/web/src/components/Composer/Actions/ReferenceSettings/index.tsx
+++ b/apps/web/src/components/Composer/Actions/ReferenceSettings/index.tsx
@@ -2,11 +2,11 @@ import MenuTransition from '@components/Shared/MenuTransition';
 import { Menu } from '@headlessui/react';
 import {
   GlobeAltIcon,
-  UserAddIcon,
   UserGroupIcon,
+  UserPlusIcon,
   UsersIcon
-} from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+} from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { ReferenceModules } from '@lenster/lens';
 import { Tooltip } from '@lenster/ui';
 import cn from '@lenster/ui/cn';
@@ -95,7 +95,7 @@ const ReferenceSettings: FC = () => {
           <div className="text-brand">
             {isEveryone ? <GlobeAltIcon className="w-5" /> : null}
             {isMyFollowers ? <UsersIcon className="w-5" /> : null}
-            {isMyFollows ? <UserAddIcon className="w-5" /> : null}
+            {isMyFollows ? <UserPlusIcon className="w-5" /> : null}
             {isFriendsOfFriends ? <UserGroupIcon className="w-5" /> : null}
           </div>
         </Menu.Button>
@@ -130,7 +130,7 @@ const ReferenceSettings: FC = () => {
           <Module
             title={MY_FOLLOWS}
             selected={isMyFollows}
-            icon={<UserAddIcon className="h-4 w-4" />}
+            icon={<UserPlusIcon className="h-4 w-4" />}
             onClick={() => {
               setSelectedReferenceModule(
                 ReferenceModules.DegreesOfSeparationReferenceModule

--- a/apps/web/src/components/Composer/ChooseThumbnail.tsx
+++ b/apps/web/src/components/Composer/ChooseThumbnail.tsx
@@ -1,5 +1,5 @@
 import ThumbnailsShimmer from '@components/Shared/Shimmer/ThumbnailsShimmer';
-import { CheckCircleIcon, PhotographIcon } from '@heroicons/react/outline';
+import { CheckCircleIcon, PhotoIcon } from '@heroicons/react/24/outline';
 import { generateVideoThumbnails } from '@lenster/lib/generateVideoThumbnails';
 import getFileFromDataURL from '@lenster/lib/getFileFromDataURL';
 import type { MediaSetWithoutOnChain } from '@lenster/types/misc';
@@ -160,7 +160,7 @@ const ChooseThumbnail: FC = () => {
             <Spinner size="sm" />
           ) : (
             <>
-              <PhotographIcon className="mb-1 h-5 w-5" />
+              <PhotoIcon className="mb-1 h-5 w-5" />
               <span className="text-sm">
                 <Trans>Upload</Trans>
               </span>

--- a/apps/web/src/components/Composer/NewPublication.tsx
+++ b/apps/web/src/components/Composer/NewPublication.tsx
@@ -4,7 +4,10 @@ import { AudioPublicationSchema } from '@components/Shared/Audio';
 import Wrapper from '@components/Shared/Embed/Wrapper';
 import EmojiPicker from '@components/Shared/EmojiPicker';
 import withLexicalContext from '@components/Shared/Lexical/withLexicalContext';
-import { ChatAlt2Icon, PencilAltIcon } from '@heroicons/react/outline';
+import {
+  ChatBubbleLeftRightIcon,
+  PencilSquareIcon
+} from '@heroicons/react/24/outline';
 import type {
   CollectCondition,
   EncryptedMetadata,
@@ -952,9 +955,9 @@ const NewPublication: FC<NewPublicationProps> = ({ publication }) => {
               isLoading ? (
                 <Spinner size="xs" />
               ) : isComment ? (
-                <ChatAlt2Icon className="h-4 w-4" />
+                <ChatBubbleLeftRightIcon className="h-4 w-4" />
               ) : (
-                <PencilAltIcon className="h-4 w-4" />
+                <PencilSquareIcon className="h-4 w-4" />
               )
             }
             onClick={createPublication}

--- a/apps/web/src/components/Composer/Post/New.tsx
+++ b/apps/web/src/components/Composer/Post/New.tsx
@@ -1,4 +1,4 @@
-import { PencilAltIcon } from '@heroicons/react/outline';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
 import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
 import { Card, Image } from '@lenster/ui';
@@ -59,7 +59,7 @@ const NewPost: FC = () => {
           type="button"
           onClick={() => openModal()}
         >
-          <PencilAltIcon className="h-5 w-5" />
+          <PencilSquareIcon className="h-5 w-5" />
           <span>
             <Trans>What's happening?</Trans>
           </span>

--- a/apps/web/src/components/Explore/Feed.tsx
+++ b/apps/web/src/components/Explore/Feed.tsx
@@ -1,6 +1,6 @@
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { CollectionIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import type {
   ExplorePublicationRequest,
   Publication,
@@ -78,7 +78,7 @@ const Feed: FC<FeedProps> = ({
     return (
       <EmptyState
         message={t`No posts yet!`}
-        icon={<CollectionIcon className="text-brand h-8 w-8" />}
+        icon={<RectangleStackIcon className="text-brand h-8 w-8" />}
       />
     );
   }

--- a/apps/web/src/components/Home/AlgorithmicFeed.tsx
+++ b/apps/web/src/components/Home/AlgorithmicFeed.tsx
@@ -1,6 +1,6 @@
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { SparklesIcon } from '@heroicons/react/outline';
+import { SparklesIcon } from '@heroicons/react/24/outline';
 import type { HomeFeedType } from '@lenster/data/enums';
 import type { Publication, PublicationsQueryRequest } from '@lenster/lens';
 import { useProfileFeedQuery } from '@lenster/lens';

--- a/apps/web/src/components/Home/Algorithms/List.tsx
+++ b/apps/web/src/components/Home/Algorithms/List.tsx
@@ -1,4 +1,4 @@
-import { GlobeIcon, UserCircleIcon } from '@heroicons/react/outline';
+import { GlobeAmericasIcon, UserCircleIcon } from '@heroicons/react/24/outline';
 import { algorithms } from '@lenster/data/algorithms';
 import { HOME } from '@lenster/data/tracking';
 import { Toggle, Tooltip } from '@lenster/ui';
@@ -45,7 +45,7 @@ const List: FC = () => {
                       {algorithm.isPersonalized ? (
                         <UserCircleIcon className="h-4 w-4" />
                       ) : (
-                        <GlobeIcon className="h-4 w-4" />
+                        <GlobeAmericasIcon className="h-4 w-4" />
                       )}
                     </div>
                   </Tooltip>

--- a/apps/web/src/components/Home/Algorithms/index.tsx
+++ b/apps/web/src/components/Home/Algorithms/index.tsx
@@ -1,4 +1,4 @@
-import { SparklesIcon } from '@heroicons/react/outline';
+import { SparklesIcon } from '@heroicons/react/24/outline';
 import { HOME } from '@lenster/data/tracking';
 import { Modal, Tooltip } from '@lenster/ui';
 import { Leafwatch } from '@lib/leafwatch';

--- a/apps/web/src/components/Home/EnableDispatcher.tsx
+++ b/apps/web/src/components/Home/EnableDispatcher.tsx
@@ -1,5 +1,5 @@
 import ToggleDispatcher from '@components/Settings/Dispatcher/ToggleDispatcher';
-import { HandIcon } from '@heroicons/react/outline';
+import { HandRaisedIcon } from '@heroicons/react/24/outline';
 import { APP_NAME, OLD_LENS_RELAYER_ADDRESS } from '@lenster/data/constants';
 import getIsDispatcherEnabled from '@lenster/lib/getIsDispatcherEnabled';
 import { Card } from '@lenster/ui';
@@ -48,7 +48,7 @@ const EnableDispatcher: FC = () => {
       className="border-brand-400 !bg-brand-300/20 text-brand-600 mb-4 space-y-2.5 p-5"
     >
       <div className="flex items-center space-x-2 font-bold">
-        <HandIcon className="h-5 w-5" />
+        <HandRaisedIcon className="h-5 w-5" />
         <p>{getTitle()}</p>
       </div>
       <p className="text-sm leading-[22px]">{getDescription()}</p>

--- a/apps/web/src/components/Home/EnableMessages.tsx
+++ b/apps/web/src/components/Home/EnableMessages.tsx
@@ -1,4 +1,4 @@
-import { MailIcon, MailOpenIcon } from '@heroicons/react/solid';
+import { EnvelopeIcon, EnvelopeOpenIcon } from '@heroicons/react/24/solid';
 import { XMTP_ENV } from '@lenster/data/constants';
 import { Button, Card } from '@lenster/ui';
 import cn from '@lenster/ui/cn';
@@ -42,7 +42,7 @@ const EnableMessages: FC = () => {
       className="mb-4 space-y-2.5 border-green-400 !bg-green-300/20 p-5 text-green-600"
     >
       <div className="flex items-center space-x-2 font-bold">
-        <MailOpenIcon className="h-5 w-5" />
+        <EnvelopeOpenIcon className="h-5 w-5" />
         <p>
           <Trans>Direct messages are here!</Trans>
         </p>
@@ -55,7 +55,7 @@ const EnableMessages: FC = () => {
       </p>
       <Button
         className={cn({ 'text-sm': true }, 'mr-auto')}
-        icon={<MailIcon className="h-4 w-4" />}
+        icon={<EnvelopeIcon className="h-4 w-4" />}
         onClick={onConversationSelected}
       >
         <Trans>Enable DMs</Trans>

--- a/apps/web/src/components/Home/FeedEventFilters.tsx
+++ b/apps/web/src/components/Home/FeedEventFilters.tsx
@@ -1,6 +1,6 @@
 import MenuTransition from '@components/Shared/MenuTransition';
 import { Menu } from '@headlessui/react';
-import { AdjustmentsIcon } from '@heroicons/react/outline';
+import { AdjustmentsVerticalIcon } from '@heroicons/react/24/outline';
 import { Checkbox, Tooltip } from '@lenster/ui';
 import cn from '@lenster/ui/cn';
 import { t } from '@lingui/macro';
@@ -26,7 +26,7 @@ const FeedEventFilters: FC = () => {
     <Menu as="div" className="relative">
       <Menu.Button className="rounded-md p-1 hover:bg-gray-300/20">
         <Tooltip placement="top" content={t`Filter`}>
-          <AdjustmentsIcon className="text-brand h-5 w-5" />
+          <AdjustmentsVerticalIcon className="text-brand h-5 w-5" />
         </Tooltip>
       </Menu.Button>
       <MenuTransition>

--- a/apps/web/src/components/Home/FeedType.tsx
+++ b/apps/web/src/components/Home/FeedType.tsx
@@ -2,7 +2,7 @@ import {
   LightBulbIcon,
   SparklesIcon,
   UserGroupIcon
-} from '@heroicons/react/outline';
+} from '@heroicons/react/24/outline';
 import { IS_MAINNET } from '@lenster/data/constants';
 import { HomeFeedType } from '@lenster/data/enums';
 import { HOME } from '@lenster/data/tracking';

--- a/apps/web/src/components/Home/ForYou.tsx
+++ b/apps/web/src/components/Home/ForYou.tsx
@@ -1,7 +1,7 @@
 import QueuedPublication from '@components/Publication/QueuedPublication';
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { SparklesIcon } from '@heroicons/react/outline';
+import { SparklesIcon } from '@heroicons/react/24/outline';
 import type { Publication, PublicationForYouRequest } from '@lenster/lens';
 import { useForYouQuery } from '@lenster/lens';
 import { Card, EmptyState, ErrorMessage } from '@lenster/ui';

--- a/apps/web/src/components/Home/Highlights.tsx
+++ b/apps/web/src/components/Home/Highlights.tsx
@@ -1,7 +1,7 @@
 import QueuedPublication from '@components/Publication/QueuedPublication';
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { LightBulbIcon } from '@heroicons/react/outline';
+import { LightBulbIcon } from '@heroicons/react/24/outline';
 import type { FeedHighlightsRequest, Publication } from '@lenster/lens';
 import { useFeedHighlightsQuery } from '@lenster/lens';
 import { Card, EmptyState, ErrorMessage } from '@lenster/ui';

--- a/apps/web/src/components/Home/RecommendedProfiles.tsx
+++ b/apps/web/src/components/Home/RecommendedProfiles.tsx
@@ -1,8 +1,11 @@
 import DismissRecommendedProfile from '@components/Shared/DismissRecommendedProfile';
 import UserProfileShimmer from '@components/Shared/Shimmer/UserProfileShimmer';
 import UserProfile from '@components/Shared/UserProfile';
-import { DotsCircleHorizontalIcon, UsersIcon } from '@heroicons/react/outline';
-import { SparklesIcon } from '@heroicons/react/solid';
+import {
+  EllipsisHorizontalCircleIcon,
+  UsersIcon
+} from '@heroicons/react/24/outline';
+import { SparklesIcon } from '@heroicons/react/24/solid';
 import { FollowUnfollowSource, MISCELLANEOUS } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import { useRecommendedProfilesQuery } from '@lenster/lens';
@@ -120,7 +123,7 @@ const RecommendedProfiles: FC = () => {
             Leafwatch.track(MISCELLANEOUS.OPEN_RECOMMENDED_PROFILES);
           }}
         >
-          <DotsCircleHorizontalIcon className="h-4 w-4" />
+          <EllipsisHorizontalCircleIcon className="h-4 w-4" />
           <span>
             <Trans>Show more</Trans>
           </span>

--- a/apps/web/src/components/Home/SeeThroughLens.tsx
+++ b/apps/web/src/components/Home/SeeThroughLens.tsx
@@ -1,8 +1,8 @@
 import MenuTransition from '@components/Shared/MenuTransition';
 import UserProfile from '@components/Shared/UserProfile';
 import { Menu } from '@headlessui/react';
-import { XIcon } from '@heroicons/react/outline';
-import { ChevronDownIcon } from '@heroicons/react/solid';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { ChevronDownIcon } from '@heroicons/react/24/solid';
 import { HOME } from '@lenster/data/tracking';
 import type {
   FeedItem,
@@ -136,7 +136,7 @@ const SeeThroughLens: FC = () => {
               value={searchText}
               autoComplete="off"
               iconRight={
-                <XIcon
+                <XMarkIcon
                   className={cn(
                     'cursor-pointer',
                     searchText ? 'visible' : 'invisible'

--- a/apps/web/src/components/Home/SetDefaultProfile.tsx
+++ b/apps/web/src/components/Home/SetDefaultProfile.tsx
@@ -1,4 +1,7 @@
-import { CurrencyDollarIcon, UserCircleIcon } from '@heroicons/react/outline';
+import {
+  CurrencyDollarIcon,
+  UserCircleIcon
+} from '@heroicons/react/24/outline';
 import { Card } from '@lenster/ui';
 import { Trans } from '@lingui/macro';
 import Link from 'next/link';

--- a/apps/web/src/components/Home/SetProfile.tsx
+++ b/apps/web/src/components/Home/SetProfile.tsx
@@ -1,10 +1,10 @@
 import New from '@components/Shared/Badges/New';
 import {
   MinusCircleIcon,
-  PencilAltIcon,
-  PhotographIcon
-} from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+  PencilSquareIcon,
+  PhotoIcon
+} from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { APP_NAME } from '@lenster/data/constants';
 import { ONBOARDING } from '@lenster/data/tracking';
 import { Card } from '@lenster/ui';
@@ -53,7 +53,7 @@ const SetProfile: FC = () => {
       className="mb-4 space-y-4 !border-green-600 !bg-green-50 p-5 text-green-600 dark:bg-green-900"
     >
       <div className="flex items-center space-x-2 font-bold">
-        <PhotographIcon className="h-5 w-5" />
+        <PhotoIcon className="h-5 w-5" />
         <p>
           <Trans>Setup your {APP_NAME} profile</Trans>
         </p>
@@ -88,7 +88,7 @@ const SetProfile: FC = () => {
         </div>
       </div>
       <div className="flex items-center space-x-1.5 text-sm font-bold">
-        <PencilAltIcon className="h-4 w-4" />
+        <PencilSquareIcon className="h-4 w-4" />
         <Link
           onClick={() => Leafwatch.track(ONBOARDING.NAVIGATE_UPDATE_PROFILE)}
           href="/settings"

--- a/apps/web/src/components/Home/Suggested.tsx
+++ b/apps/web/src/components/Home/Suggested.tsx
@@ -1,7 +1,7 @@
 import DismissRecommendedProfile from '@components/Shared/DismissRecommendedProfile';
 import Loader from '@components/Shared/Loader';
 import UserProfile from '@components/Shared/UserProfile';
-import { UsersIcon } from '@heroicons/react/outline';
+import { UsersIcon } from '@heroicons/react/24/outline';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import { useRecommendedProfilesQuery } from '@lenster/lens';

--- a/apps/web/src/components/Home/Tags.tsx
+++ b/apps/web/src/components/Home/Tags.tsx
@@ -1,5 +1,5 @@
 import Alpha from '@components/Shared/Badges/Alpha';
-import { TagIcon } from '@heroicons/react/outline';
+import { TagIcon } from '@heroicons/react/24/outline';
 import { Card } from '@lenster/ui';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';

--- a/apps/web/src/components/Home/Timeline/EventType/Collected.tsx
+++ b/apps/web/src/components/Home/Timeline/EventType/Collected.tsx
@@ -1,5 +1,5 @@
 import Profiles from '@components/Shared/Profiles';
-import { CollectionIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import type { CollectedEvent } from '@lenster/lens';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';
@@ -20,7 +20,7 @@ const Collected: FC<CollectedProps> = ({ collects }) => {
 
   return (
     <div className="lt-text-gray-500 flex items-center space-x-1 pb-4 text-[13px]">
-      <CollectionIcon className="h-4 w-4" />
+      <RectangleStackIcon className="h-4 w-4" />
       <Profiles profiles={getCollectedProfiles()} context={t`collected`} />
     </div>
   );

--- a/apps/web/src/components/Home/Timeline/EventType/Combined.tsx
+++ b/apps/web/src/components/Home/Timeline/EventType/Combined.tsx
@@ -1,5 +1,5 @@
 import Profiles from '@components/Shared/Profiles';
-import { SparklesIcon } from '@heroicons/react/outline';
+import { SparklesIcon } from '@heroicons/react/24/outline';
 import type { FeedItem } from '@lenster/lens';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';

--- a/apps/web/src/components/Home/Timeline/EventType/Liked.tsx
+++ b/apps/web/src/components/Home/Timeline/EventType/Liked.tsx
@@ -1,5 +1,5 @@
 import Profiles from '@components/Shared/Profiles';
-import { HeartIcon } from '@heroicons/react/outline';
+import { HeartIcon } from '@heroicons/react/24/outline';
 import type { ReactionEvent } from '@lenster/lens';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';

--- a/apps/web/src/components/Home/Timeline/EventType/Mirrored.tsx
+++ b/apps/web/src/components/Home/Timeline/EventType/Mirrored.tsx
@@ -1,5 +1,5 @@
 import Profiles from '@components/Shared/Profiles';
-import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import type { MirrorEvent } from '@lenster/lens';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';
@@ -20,7 +20,7 @@ const Mirrored: FC<MirroredProps> = ({ mirrors }) => {
 
   return (
     <div className="lt-text-gray-500 flex items-center space-x-1 pb-4 text-[13px]">
-      <SwitchHorizontalIcon className="h-4 w-4" />
+      <ArrowsRightLeftIcon className="h-4 w-4" />
       <Profiles profiles={getMirroredProfiles()} context={t`mirrored`} />
     </div>
   );

--- a/apps/web/src/components/Home/Timeline/index.tsx
+++ b/apps/web/src/components/Home/Timeline/index.tsx
@@ -1,7 +1,7 @@
 import QueuedPublication from '@components/Publication/QueuedPublication';
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { UserGroupIcon } from '@heroicons/react/outline';
+import { UserGroupIcon } from '@heroicons/react/24/outline';
 import type { FeedItem, FeedRequest, Publication } from '@lenster/lens';
 import { FeedEventItemType, useTimelineQuery } from '@lenster/lens';
 import { Card, EmptyState, ErrorMessage } from '@lenster/ui';

--- a/apps/web/src/components/Home/Trending.tsx
+++ b/apps/web/src/components/Home/Trending.tsx
@@ -1,5 +1,5 @@
 import TrendingTagShimmer from '@components/Shared/Shimmer/TrendingTagShimmer';
-import { TrendingUpIcon } from '@heroicons/react/solid';
+import { ArrowTrendingUpIcon } from '@heroicons/react/24/solid';
 import { MISCELLANEOUS } from '@lenster/data/tracking';
 import type { TagResult } from '@lenster/lens';
 import { TagSortCriteria, useTrendingQuery } from '@lenster/lens';
@@ -13,7 +13,7 @@ import type { FC } from 'react';
 const Title = () => {
   return (
     <div className="mb-2 flex items-center gap-2 px-5 sm:px-0">
-      <TrendingUpIcon className="h-4 w-4 text-green-500" />
+      <ArrowTrendingUpIcon className="h-4 w-4 text-green-500" />
       <div>
         <Trans>Trending</Trans>
       </div>

--- a/apps/web/src/components/Home/Waitlist.tsx
+++ b/apps/web/src/components/Home/Waitlist.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon } from '@heroicons/react/outline';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
 import { STATIC_IMAGES_URL } from '@lenster/data/constants';
 import { MISCELLANEOUS } from '@lenster/data/tracking';
 import { Button, Card } from '@lenster/ui';

--- a/apps/web/src/components/Messages/Composer.tsx
+++ b/apps/web/src/components/Messages/Composer.tsx
@@ -1,5 +1,5 @@
-import { ArrowRightIcon, PhotographIcon } from '@heroicons/react/outline';
-import { XIcon } from '@heroicons/react/solid';
+import { ArrowRightIcon, PhotoIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon } from '@heroicons/react/24/solid';
 import { MIN_WIDTH_DESKTOP } from '@lenster/data/constants';
 import { MESSAGES } from '@lenster/data/tracking';
 import sanitizeDStorageUrl from '@lenster/lib/sanitizeDStorageUrl';
@@ -65,7 +65,7 @@ const AttachmentPreview: FC<AttachmentPreviewProps> = ({
         className="absolute top-2 rounded-full bg-gray-900 p-1.5 opacity-75"
         onClick={onDismiss}
       >
-        <XIcon className="h-4 w-4 text-white" />
+        <XMarkIcon className="h-4 w-4 text-white" />
       </button>
       <Attachment attachment={attachment} />
     </div>
@@ -268,7 +268,7 @@ const Composer: FC<ComposerProps> = ({
       ) : null}
       <div className="flex space-x-4 p-4">
         <label className="flex cursor-pointer items-center">
-          <PhotographIcon className="text-brand-500 h-6 w-5" />
+          <PhotoIcon className="text-brand-500 h-6 w-5" />
           <input
             ref={fileInputRef}
             type="file"

--- a/apps/web/src/components/Messages/MessageHeader.tsx
+++ b/apps/web/src/components/Messages/MessageHeader.tsx
@@ -1,6 +1,6 @@
 import Unfollow from '@components/Shared/Unfollow';
 import UserProfile from '@components/Shared/UserProfile';
-import { ChevronLeftIcon } from '@heroicons/react/outline';
+import { ChevronLeftIcon } from '@heroicons/react/24/outline';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import formatAddress from '@lenster/lib/formatAddress';

--- a/apps/web/src/components/Messages/MessageIcon.tsx
+++ b/apps/web/src/components/Messages/MessageIcon.tsx
@@ -1,4 +1,4 @@
-import { MailIcon } from '@heroicons/react/outline';
+import { EnvelopeIcon } from '@heroicons/react/24/outline';
 import type { DecodedMessage } from '@xmtp/xmtp-js';
 import { fromNanoString, SortDirection } from '@xmtp/xmtp-js';
 import Link from 'next/link';
@@ -137,7 +137,7 @@ const MessageIcon: FC = () => {
         currentProfile && clearMessagesBadge(currentProfile.id);
       }}
     >
-      <MailIcon className="h-5 w-5 sm:h-6 sm:w-6" />
+      <EnvelopeIcon className="h-5 w-5 sm:h-6 sm:w-6" />
       {showMessagesBadge.get(currentProfile?.id) ? (
         <span className="h-2 w-2 rounded-full bg-red-500" />
       ) : null}

--- a/apps/web/src/components/Messages/MessagesList.tsx
+++ b/apps/web/src/components/Messages/MessagesList.tsx
@@ -1,5 +1,5 @@
-import { ClockIcon, EmojiSadIcon } from '@heroicons/react/outline';
-import { CheckIcon, ExclamationIcon } from '@heroicons/react/solid';
+import { ClockIcon, FaceFrownIcon } from '@heroicons/react/24/outline';
+import { CheckIcon, ExclamationTriangleIcon } from '@heroicons/react/24/solid';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
@@ -46,7 +46,7 @@ const MessageTile: FC<MessageTileProps> = ({
   if (isQueuedMessage(message)) {
     switch (message.status) {
       case 'failed':
-        statusIcon = <ExclamationIcon width={14} height={14} />;
+        statusIcon = <ExclamationTriangleIcon width={14} height={14} />;
         break;
       case 'pending':
         statusIcon = <ClockIcon width={14} height={14} />;
@@ -165,7 +165,7 @@ const MissingXmtpAuth: FC = () => (
     className="mb-2 mr-4 space-y-2.5 border-gray-400 !bg-gray-300/20 p-5"
   >
     <div className="flex items-center space-x-2 font-bold">
-      <EmojiSadIcon className="h-5 w-5" />
+      <FaceFrownIcon className="h-5 w-5" />
       <p>
         <Trans>This fren hasn't enabled DMs yet</Trans>
       </p>

--- a/apps/web/src/components/Messages/Preview.tsx
+++ b/apps/web/src/components/Messages/Preview.tsx
@@ -1,4 +1,7 @@
-import { BadgeCheckIcon, ExclamationCircleIcon } from '@heroicons/react/solid';
+import {
+  CheckBadgeIcon,
+  ExclamationCircleIcon
+} from '@heroicons/react/24/solid';
 import type { Profile } from '@lenster/lens';
 import formatAddress from '@lenster/lib/formatAddress';
 import formatHandle from '@lenster/lib/formatHandle';
@@ -95,7 +98,7 @@ const Preview: FC<PreviewProps> = ({
                     : ensName || formatAddress(conversationKey?.split('/')[0])}
                 </div>
                 {isVerified(profile?.id) ? (
-                  <BadgeCheckIcon className="text-brand h-4 w-4 min-w-fit" />
+                  <CheckBadgeIcon className="text-brand h-4 w-4 min-w-fit" />
                 ) : null}
                 {hasMisused(profile?.id) ? (
                   <ExclamationCircleIcon className="h-4 w-4 min-w-fit text-red-500" />

--- a/apps/web/src/components/Messages/PreviewList.tsx
+++ b/apps/web/src/components/Messages/PreviewList.tsx
@@ -2,7 +2,7 @@ import Preview from '@components/Messages/Preview';
 import Following from '@components/Profile/Following';
 import Loader from '@components/Shared/Loader';
 import Search from '@components/Shared/Navbar/Search';
-import { MailIcon, PlusCircleIcon } from '@heroicons/react/outline';
+import { EnvelopeIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
 import { Errors } from '@lenster/data/errors';
 import { MESSAGES } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
@@ -190,7 +190,7 @@ const PreviewList: FC<PreviewListProps> = ({
             >
               <div className="grid justify-items-center space-y-2 p-5">
                 <div>
-                  <MailIcon className="text-brand h-8 w-8" />
+                  <EnvelopeIcon className="text-brand h-8 w-8" />
                 </div>
                 <div>{t`Start messaging your Lens frens`}</div>
               </div>
@@ -218,7 +218,7 @@ const PreviewList: FC<PreviewListProps> = ({
       </Card>
       <Modal
         title={t`New message`}
-        icon={<MailIcon className="text-brand h-5 w-5" />}
+        icon={<EnvelopeIcon className="text-brand h-5 w-5" />}
         size="sm"
         show={showSearchModal}
         onClose={() => setShowSearchModal(false)}

--- a/apps/web/src/components/Mod/Feed.tsx
+++ b/apps/web/src/components/Mod/Feed.tsx
@@ -1,6 +1,6 @@
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { CollectionIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import type {
   CustomFiltersTypes,
   ExplorePublicationRequest,
@@ -87,7 +87,7 @@ const Feed: FC<FeedProps> = ({
     return (
       <EmptyState
         message={t`No posts yet!`}
-        icon={<CollectionIcon className="text-brand h-8 w-8" />}
+        icon={<RectangleStackIcon className="text-brand h-8 w-8" />}
       />
     );
   }

--- a/apps/web/src/components/Nft/Details/Title.tsx
+++ b/apps/web/src/components/Nft/Details/Title.tsx
@@ -1,5 +1,5 @@
 import Slug from '@components/Shared/Slug';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import type { OpenSeaNft } from '@lenster/types/opensea-nft';
 import { Card } from '@lenster/ui';
 import type { FC } from 'react';

--- a/apps/web/src/components/Notification/FeedType.tsx
+++ b/apps/web/src/components/Notification/FeedType.tsx
@@ -1,10 +1,10 @@
 import {
   AtSymbolIcon,
   BellIcon,
-  ChatAlt2Icon,
-  CollectionIcon,
-  HeartIcon
-} from '@heroicons/react/outline';
+  ChatBubbleLeftRightIcon,
+  HeartIcon,
+  RectangleStackIcon
+} from '@heroicons/react/24/outline';
 import { NOTIFICATION } from '@lenster/data/tracking';
 import { TabButton } from '@lenster/ui';
 import { Leafwatch } from '@lib/leafwatch';
@@ -44,7 +44,7 @@ const FeedType: FC<FeedTypeProps> = ({ setFeedType, feedType }) => {
         />
         <TabButton
           name={t`Comments`}
-          icon={<ChatAlt2Icon className="h-4 w-4" />}
+          icon={<ChatBubbleLeftRightIcon className="h-4 w-4" />}
           active={feedType === NotificationType.Comments}
           type={NotificationType.Comments.toLowerCase()}
           onClick={() => switchTab(NotificationType.Comments)}
@@ -58,7 +58,7 @@ const FeedType: FC<FeedTypeProps> = ({ setFeedType, feedType }) => {
         />
         <TabButton
           name={t`Collects`}
-          icon={<CollectionIcon className="h-4 w-4" />}
+          icon={<RectangleStackIcon className="h-4 w-4" />}
           active={feedType === NotificationType.Collects}
           type={NotificationType.Collects.toLowerCase()}
           onClick={() => switchTab(NotificationType.Collects)}

--- a/apps/web/src/components/Notification/List.tsx
+++ b/apps/web/src/components/Notification/List.tsx
@@ -1,4 +1,4 @@
-import { BellIcon } from '@heroicons/react/outline';
+import { BellIcon } from '@heroicons/react/24/outline';
 import type {
   NewCollectNotification,
   NewCommentNotification,

--- a/apps/web/src/components/Notification/NotificationIcon.tsx
+++ b/apps/web/src/components/Notification/NotificationIcon.tsx
@@ -1,4 +1,4 @@
-import { BellIcon } from '@heroicons/react/outline';
+import { BellIcon } from '@heroicons/react/24/outline';
 import { CustomFiltersTypes, useNotificationCountQuery } from '@lenster/lens';
 import Link from 'next/link';
 import type { FC } from 'react';

--- a/apps/web/src/components/Notification/Profile.tsx
+++ b/apps/web/src/components/Notification/Profile.tsx
@@ -1,4 +1,7 @@
-import { BadgeCheckIcon, ExclamationCircleIcon } from '@heroicons/react/solid';
+import {
+  CheckBadgeIcon,
+  ExclamationCircleIcon
+} from '@heroicons/react/24/solid';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
@@ -41,7 +44,7 @@ export const NotificationProfileName: FC<NotificationProfileProps> = ({
         {sanitizeDisplayName(profile?.name) ?? formatHandle(profile?.handle)}
       </div>
       {isVerified(profile.id) ? (
-        <BadgeCheckIcon className="text-brand h-4 w-4" />
+        <CheckBadgeIcon className="text-brand h-4 w-4" />
       ) : null}
       {hasMisused(profile.id) ? (
         <ExclamationCircleIcon className="h-4 w-4 text-red-500" />

--- a/apps/web/src/components/Notification/Settings.tsx
+++ b/apps/web/src/components/Notification/Settings.tsx
@@ -1,5 +1,5 @@
 import HighSignalNotificationFilter from '@components/Settings/Preferences/HighSignalNotificationFilter';
-import { BellIcon, CogIcon } from '@heroicons/react/outline';
+import { BellIcon, Cog6ToothIcon } from '@heroicons/react/24/outline';
 import { Modal, Tooltip } from '@lenster/ui';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';
@@ -16,7 +16,7 @@ const Settings: FC = () => {
         onClick={() => setShowNotificationSettings(true)}
       >
         <Tooltip placement="top" content={t`Notification settings`}>
-          <CogIcon className="lt-text-gray-500 h-5 w-5" />
+          <Cog6ToothIcon className="lt-text-gray-500 h-5 w-5" />
         </Tooltip>
       </button>
       <Modal

--- a/apps/web/src/components/Notification/Type/CollectNotification/Amount.tsx
+++ b/apps/web/src/components/Notification/Type/CollectNotification/Amount.tsx
@@ -1,4 +1,4 @@
-import { CurrencyDollarIcon } from '@heroicons/react/outline';
+import { CurrencyDollarIcon } from '@heroicons/react/24/outline';
 import type { NewCollectNotification } from '@lenster/lens';
 import getTokenImage from '@lenster/lib/getTokenImage';
 import humanize from '@lenster/lib/humanize';

--- a/apps/web/src/components/Notification/Type/CollectNotification/index.tsx
+++ b/apps/web/src/components/Notification/Type/CollectNotification/index.tsx
@@ -7,7 +7,7 @@ import {
   NotificationWalletProfileName
 } from '@components/Notification/WalletProfile';
 import UserPreview from '@components/Shared/UserPreview';
-import { CollectionIcon } from '@heroicons/react/solid';
+import { RectangleStackIcon } from '@heroicons/react/24/solid';
 import type { NewCollectNotification } from '@lenster/lens';
 import type { MessageDescriptor } from '@lenster/types/misc';
 import { formatTime, getTimeFromNow } from '@lib/formatTime';
@@ -50,7 +50,7 @@ const CollectNotification: FC<CollectNotificationProps> = ({
       <div className="flex-1 space-y-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <CollectionIcon className="h-6 w-6 text-pink-500/70" />
+            <RectangleStackIcon className="h-6 w-6 text-pink-500/70" />
             {notification?.wallet?.defaultProfile ? (
               <UserPreview
                 isBig={false}

--- a/apps/web/src/components/Notification/Type/CommentNotification.tsx
+++ b/apps/web/src/components/Notification/Type/CommentNotification.tsx
@@ -1,6 +1,6 @@
 import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
-import { ChatAlt2Icon } from '@heroicons/react/solid';
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/solid';
 import type { NewCommentNotification } from '@lenster/lens';
 import type { MessageDescriptor } from '@lenster/types/misc';
 import { formatTime, getTimeFromNow } from '@lib/formatTime';
@@ -42,7 +42,7 @@ const CommentNotification: FC<CommentNotificationProps> = ({
       <div className="flex-1 space-y-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <ChatAlt2Icon className="h-6 w-6 text-blue-500/70" />
+            <ChatBubbleLeftRightIcon className="h-6 w-6 text-blue-500/70" />
             <UserPreview profile={notification?.profile}>
               <NotificationProfileAvatar profile={notification?.profile} />
             </UserPreview>

--- a/apps/web/src/components/Notification/Type/FollowerNotification.tsx
+++ b/apps/web/src/components/Notification/Type/FollowerNotification.tsx
@@ -1,5 +1,5 @@
 import UserPreview from '@components/Shared/UserPreview';
-import { UserAddIcon } from '@heroicons/react/solid';
+import { UserPlusIcon } from '@heroicons/react/24/solid';
 import type { NewFollowerNotification } from '@lenster/lens';
 import { formatTime, getTimeFromNow } from '@lib/formatTime';
 import { defineMessage } from '@lingui/macro';
@@ -39,9 +39,9 @@ const FollowerNotification: FC<FollowerNotificationProps> = ({
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             {isSuperFollow ? (
-              <UserAddIcon className="h-6 w-6 text-pink-500/70" />
+              <UserPlusIcon className="h-6 w-6 text-pink-500/70" />
             ) : (
-              <UserAddIcon className="h-6 w-6 text-green-500/70" />
+              <UserPlusIcon className="h-6 w-6 text-green-500/70" />
             )}
             {notification?.wallet?.defaultProfile ? (
               <UserPreview profile={notification?.wallet?.defaultProfile}>

--- a/apps/web/src/components/Notification/Type/LikeNotification.tsx
+++ b/apps/web/src/components/Notification/Type/LikeNotification.tsx
@@ -1,6 +1,6 @@
 import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
-import { HeartIcon } from '@heroicons/react/solid';
+import { HeartIcon } from '@heroicons/react/24/solid';
 import type { NewReactionNotification } from '@lenster/lens';
 import type { MessageDescriptor } from '@lenster/types/misc';
 import { formatTime, getTimeFromNow } from '@lib/formatTime';

--- a/apps/web/src/components/Notification/Type/MentionNotification.tsx
+++ b/apps/web/src/components/Notification/Type/MentionNotification.tsx
@@ -1,6 +1,6 @@
 import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
-import { AtSymbolIcon } from '@heroicons/react/solid';
+import { AtSymbolIcon } from '@heroicons/react/24/solid';
 import type { NewMentionNotification } from '@lenster/lens';
 import type { MessageDescriptor } from '@lenster/types/misc';
 import { formatTime, getTimeFromNow } from '@lib/formatTime';

--- a/apps/web/src/components/Notification/Type/MirrorNotification.tsx
+++ b/apps/web/src/components/Notification/Type/MirrorNotification.tsx
@@ -1,6 +1,6 @@
 import Markup from '@components/Shared/Markup';
 import UserPreview from '@components/Shared/UserPreview';
-import { SwitchHorizontalIcon } from '@heroicons/react/solid';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/solid';
 import type { NewMirrorNotification } from '@lenster/lens';
 import type { MessageDescriptor } from '@lenster/types/misc';
 import { formatTime, getTimeFromNow } from '@lib/formatTime';
@@ -39,7 +39,7 @@ const MirrorNotification: FC<MirrorNotificationProps> = ({ notification }) => {
       <div className="flex-1 space-y-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <SwitchHorizontalIcon className="text-brand-500/70 h-6 w-6" />
+            <ArrowsRightLeftIcon className="text-brand-500/70 h-6 w-6" />
             <UserPreview profile={notification?.profile}>
               <NotificationProfileAvatar profile={notification?.profile} />
             </UserPreview>

--- a/apps/web/src/components/Pages/Contact.tsx
+++ b/apps/web/src/components/Pages/Contact.tsx
@@ -1,7 +1,7 @@
 import MetaTags from '@components/Common/MetaTags';
 import SettingsHelper from '@components/Shared/SettingsHelper';
-import { PencilAltIcon } from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { APP_NAME, FRESHDESK_WORKER_URL } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
 import { PAGEVIEW } from '@lenster/data/tracking';
@@ -147,7 +147,7 @@ const Contact: FC = () => {
                     submitting ? (
                       <Spinner size="xs" />
                     ) : (
-                      <PencilAltIcon className="h-5 w-5" />
+                      <PencilSquareIcon className="h-5 w-5" />
                     )
                   }
                 >

--- a/apps/web/src/components/Pages/Thanks.tsx
+++ b/apps/web/src/components/Pages/Thanks.tsx
@@ -1,6 +1,6 @@
 import MetaTags from '@components/Common/MetaTags';
 import Footer from '@components/Shared/Footer';
-import { HeartIcon } from '@heroicons/react/outline';
+import { HeartIcon } from '@heroicons/react/24/outline';
 import { APP_NAME, STATIC_IMAGES_URL } from '@lenster/data/constants';
 import { PAGEVIEW } from '@lenster/data/tracking';
 import { Leafwatch } from '@lib/leafwatch';

--- a/apps/web/src/components/Profile/Achievements/StreaksList.tsx
+++ b/apps/web/src/components/Profile/Achievements/StreaksList.tsx
@@ -1,13 +1,13 @@
 import {
-  ChatAlt2Icon,
+  ArrowsRightLeftIcon,
+  ChatBubbleLeftRightIcon,
   CheckCircleIcon,
-  CollectionIcon,
   HeartIcon,
-  PencilAltIcon,
-  SwitchHorizontalIcon,
-  UserAddIcon
-} from '@heroicons/react/outline';
-import { CalendarIcon } from '@heroicons/react/solid';
+  PencilSquareIcon,
+  RectangleStackIcon,
+  UserPlusIcon
+} from '@heroicons/react/24/outline';
+import { CalendarIcon } from '@heroicons/react/24/solid';
 import { ACHIEVEMENTS_WORKER_URL } from '@lenster/data/constants';
 import { PROFILE, PUBLICATION } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
@@ -42,17 +42,17 @@ const StreaksList: FC<StreaksListProps> = ({ profile }) => {
     switch (event) {
       case PROFILE.FOLLOW:
       case PROFILE.SUPER_FOLLOW:
-        return <UserAddIcon className="h-5 w-5 text-green-500" />;
+        return <UserPlusIcon className="h-5 w-5 text-green-500" />;
       case PUBLICATION.LIKE:
         return <HeartIcon className="h-5 w-5 text-red-500" />;
       case PUBLICATION.NEW_POST:
-        return <PencilAltIcon className="text-brand h-5 w-5" />;
+        return <PencilSquareIcon className="text-brand h-5 w-5" />;
       case PUBLICATION.NEW_COMMENT:
-        return <ChatAlt2Icon className="text-brand h-5 w-5" />;
+        return <ChatBubbleLeftRightIcon className="text-brand h-5 w-5" />;
       case PUBLICATION.MIRROR:
-        return <SwitchHorizontalIcon className="h-5 w-5 text-green-500" />;
+        return <ArrowsRightLeftIcon className="h-5 w-5 text-green-500" />;
       case PUBLICATION.COLLECT_MODULE.COLLECT:
-        return <CollectionIcon className="h-5 w-5 text-pink-500" />;
+        return <RectangleStackIcon className="h-5 w-5 text-pink-500" />;
       case PUBLICATION.WIDGET.SNAPSHOT.VOTE:
         return <CheckCircleIcon className="h-5 w-5 text-green-500" />;
       default:

--- a/apps/web/src/components/Profile/Badges/ProofOfHumanity.tsx
+++ b/apps/web/src/components/Profile/Badges/ProofOfHumanity.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { STATIC_IMAGES_URL } from '@lenster/data/constants';
 import type { Profile } from '@lenster/lens';
 import { Tooltip } from '@lenster/ui';

--- a/apps/web/src/components/Profile/Badges/Sybil.tsx
+++ b/apps/web/src/components/Profile/Badges/Sybil.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { STATIC_IMAGES_URL } from '@lenster/data/constants';
 import type { Profile } from '@lenster/lens';
 import { Tooltip } from '@lenster/ui';

--- a/apps/web/src/components/Profile/Badges/Worldcoin.tsx
+++ b/apps/web/src/components/Profile/Badges/Worldcoin.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { STATIC_IMAGES_URL } from '@lenster/data/constants';
 import type { Profile } from '@lenster/lens';
 import { Tooltip } from '@lenster/ui';

--- a/apps/web/src/components/Profile/Details.tsx
+++ b/apps/web/src/components/Profile/Details.tsx
@@ -6,12 +6,15 @@ import SuperFollow from '@components/Shared/SuperFollow';
 import Unfollow from '@components/Shared/Unfollow';
 import ProfileStaffTool from '@components/StaffTools/Panels/Profile';
 import {
-  CogIcon,
+  Cog6ToothIcon,
   HashtagIcon,
-  LocationMarkerIcon,
+  MapPinIcon,
   UsersIcon
-} from '@heroicons/react/outline';
-import { BadgeCheckIcon, ExclamationCircleIcon } from '@heroicons/react/solid';
+} from '@heroicons/react/24/outline';
+import {
+  CheckBadgeIcon,
+  ExclamationCircleIcon
+} from '@heroicons/react/24/solid';
 import {
   EXPANDED_AVATAR,
   RARIBLE_URL,
@@ -126,7 +129,7 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
           </div>
           {isVerified(profile.id) ? (
             <Tooltip content={t`Verified`}>
-              <BadgeCheckIcon
+              <CheckBadgeIcon
                 className="text-brand h-6 w-6"
                 data-testid="profile-verified-badge"
               />
@@ -182,7 +185,7 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
             <Link href="/settings">
               <Button
                 variant="secondary"
-                icon={<CogIcon className="h-5 w-5" />}
+                icon={<Cog6ToothIcon className="h-5 w-5" />}
                 outline
               >
                 <Trans>Edit Profile</Trans>
@@ -259,7 +262,7 @@ const Details: FC<DetailsProps> = ({ profile, following, setFollowing }) => {
           </MetaDetails>
           {getProfileAttribute(profile?.attributes, 'location') ? (
             <MetaDetails
-              icon={<LocationMarkerIcon className="h-4 w-4" />}
+              icon={<MapPinIcon className="h-4 w-4" />}
               dataTestId="profile-meta-location"
             >
               {getProfileAttribute(profile?.attributes, 'location')}

--- a/apps/web/src/components/Profile/Feed.tsx
+++ b/apps/web/src/components/Profile/Feed.tsx
@@ -1,6 +1,6 @@
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { CollectionIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import type {
   Profile,
   Publication,
@@ -132,7 +132,7 @@ const Feed: FC<FeedProps> = ({ profile, type }) => {
             <span>{emptyMessage}</span>
           </div>
         }
-        icon={<CollectionIcon className="text-brand h-8 w-8" />}
+        icon={<RectangleStackIcon className="text-brand h-8 w-8" />}
       />
     );
   }

--- a/apps/web/src/components/Profile/FeedType.tsx
+++ b/apps/web/src/components/Profile/FeedType.tsx
@@ -1,11 +1,11 @@
 import {
   ChartBarIcon,
-  ChatAlt2Icon,
-  CollectionIcon,
+  ChatBubbleLeftRightIcon,
   FilmIcon,
-  PencilAltIcon,
-  PhotographIcon
-} from '@heroicons/react/outline';
+  PencilSquareIcon,
+  PhotoIcon,
+  RectangleStackIcon
+} from '@heroicons/react/24/outline';
 import { IS_MAINNET } from '@lenster/data/constants';
 import { PROFILE } from '@lenster/data/tracking';
 import { TabButton } from '@lenster/ui';
@@ -38,14 +38,14 @@ const FeedType: FC<FeedTypeProps> = ({ setFeedType, feedType }) => {
       <div className="mt-3 flex gap-3 overflow-x-auto px-5 pb-2 sm:mt-0 sm:px-0 md:pb-0">
         <TabButton
           name={t`Feed`}
-          icon={<PencilAltIcon className="h-4 w-4" />}
+          icon={<PencilSquareIcon className="h-4 w-4" />}
           active={feedType === ProfileFeedType.Feed}
           type={ProfileFeedType.Feed.toLowerCase()}
           onClick={() => switchTab(ProfileFeedType.Feed)}
         />
         <TabButton
           name={t`Replies`}
-          icon={<ChatAlt2Icon className="h-4 w-4" />}
+          icon={<ChatBubbleLeftRightIcon className="h-4 w-4" />}
           active={feedType === ProfileFeedType.Replies}
           type={ProfileFeedType.Replies.toLowerCase()}
           onClick={() => switchTab(ProfileFeedType.Replies)}
@@ -59,14 +59,14 @@ const FeedType: FC<FeedTypeProps> = ({ setFeedType, feedType }) => {
         />
         <TabButton
           name={t`Collected`}
-          icon={<CollectionIcon className="h-4 w-4" />}
+          icon={<RectangleStackIcon className="h-4 w-4" />}
           active={feedType === ProfileFeedType.Collects}
           type={ProfileFeedType.Collects.toLowerCase()}
           onClick={() => switchTab(ProfileFeedType.Collects)}
         />
         <TabButton
           name={t`NFTs`}
-          icon={<PhotographIcon className="h-4 w-4" />}
+          icon={<PhotoIcon className="h-4 w-4" />}
           active={feedType === ProfileFeedType.Nft}
           type={ProfileFeedType.Nft.toLowerCase()}
           onClick={() => switchTab(ProfileFeedType.Nft)}

--- a/apps/web/src/components/Profile/Filters/MediaFilter.tsx
+++ b/apps/web/src/components/Profile/Filters/MediaFilter.tsx
@@ -1,6 +1,6 @@
 import MenuTransition from '@components/Shared/MenuTransition';
 import { Menu } from '@headlessui/react';
-import { AdjustmentsIcon } from '@heroicons/react/outline';
+import { AdjustmentsVerticalIcon } from '@heroicons/react/24/outline';
 import { Checkbox, Tooltip } from '@lenster/ui';
 import cn from '@lenster/ui/cn';
 import { t } from '@lingui/macro';
@@ -26,7 +26,7 @@ const MediaFilter = () => {
     <Menu as="div" className="relative">
       <Menu.Button className="rounded-md hover:bg-gray-300/20">
         <Tooltip placement="top" content={t`Filter`}>
-          <AdjustmentsIcon className="text-brand h-5 w-5" />
+          <AdjustmentsVerticalIcon className="text-brand h-5 w-5" />
         </Tooltip>
       </Menu.Button>
       <MenuTransition>

--- a/apps/web/src/components/Profile/Followerings.tsx
+++ b/apps/web/src/components/Profile/Followerings.tsx
@@ -1,4 +1,4 @@
-import { UsersIcon } from '@heroicons/react/outline';
+import { UsersIcon } from '@heroicons/react/24/outline';
 import { PROFILE } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import humanize from '@lenster/lib/humanize';

--- a/apps/web/src/components/Profile/Followers.tsx
+++ b/apps/web/src/components/Profile/Followers.tsx
@@ -1,7 +1,7 @@
 import Loader from '@components/Shared/Loader';
 import UserProfile from '@components/Shared/UserProfile';
 import WalletProfile from '@components/Shared/WalletProfile';
-import { UsersIcon } from '@heroicons/react/outline';
+import { UsersIcon } from '@heroicons/react/24/outline';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type { FollowersRequest, Profile, Wallet } from '@lenster/lens';
 import { useFollowersQuery } from '@lenster/lens';

--- a/apps/web/src/components/Profile/Following.tsx
+++ b/apps/web/src/components/Profile/Following.tsx
@@ -1,6 +1,6 @@
 import Loader from '@components/Shared/Loader';
 import UserProfile from '@components/Shared/UserProfile';
-import { UsersIcon } from '@heroicons/react/outline';
+import { UsersIcon } from '@heroicons/react/24/outline';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type { FollowingRequest, Profile } from '@lenster/lens';
 import { useFollowingQuery } from '@lenster/lens';

--- a/apps/web/src/components/Profile/Menu/Report.tsx
+++ b/apps/web/src/components/Profile/Menu/Report.tsx
@@ -1,4 +1,4 @@
-import { FlagIcon } from '@heroicons/react/outline';
+import { FlagIcon } from '@heroicons/react/24/outline';
 import type { Profile } from '@lenster/lens';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';

--- a/apps/web/src/components/Profile/Menu/Share.tsx
+++ b/apps/web/src/components/Profile/Menu/Share.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { ClipboardCopyIcon } from '@heroicons/react/outline';
+import { ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import { PROFILE } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
@@ -36,7 +36,7 @@ const Share: FC<ShareProps> = ({ profile }) => {
       }}
     >
       <div className="flex items-center space-x-2">
-        <ClipboardCopyIcon className="h-4 w-4" />
+        <ClipboardDocumentIcon className="h-4 w-4" />
         <div>
           <Trans>Copy link</Trans>
         </div>

--- a/apps/web/src/components/Profile/Menu/index.tsx
+++ b/apps/web/src/components/Profile/Menu/index.tsx
@@ -1,6 +1,6 @@
 import MenuTransition from '@components/Shared/MenuTransition';
 import { Menu } from '@headlessui/react';
-import { DotsVerticalIcon } from '@heroicons/react/outline';
+import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 import type { Profile } from '@lenster/lens';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import type { FC } from 'react';
@@ -26,7 +26,7 @@ const ProfileMenu: FC<ProfileMenuProps> = ({ profile }) => {
           aria-label="More"
           data-testid={`profile-${profile.id}-menu`}
         >
-          <DotsVerticalIcon className="lt-text-gray-500 h-5 w-5" />
+          <EllipsisVerticalIcon className="lt-text-gray-500 h-5 w-5" />
         </button>
       </Menu.Button>
       <MenuTransition>

--- a/apps/web/src/components/Profile/Message.tsx
+++ b/apps/web/src/components/Profile/Message.tsx
@@ -1,4 +1,4 @@
-import { MailIcon } from '@heroicons/react/outline';
+import { EnvelopeIcon } from '@heroicons/react/24/outline';
 import { Button } from '@lenster/ui';
 import type { FC } from 'react';
 
@@ -10,7 +10,7 @@ const Message: FC<MessageProps> = ({ onClick }) => {
   return (
     <Button
       className="!px-3 !py-1.5 text-sm"
-      icon={<MailIcon className="h-5 w-5" />}
+      icon={<EnvelopeIcon className="h-5 w-5" />}
       outline
       onClick={onClick}
       aria-label="Message"

--- a/apps/web/src/components/Profile/NftGallery/Create.tsx
+++ b/apps/web/src/components/Profile/NftGallery/Create.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeftIcon } from '@heroicons/react/outline';
+import { ChevronLeftIcon } from '@heroicons/react/24/outline';
 import { Errors } from '@lenster/data/errors';
 import type { NftGallery } from '@lenster/lens';
 import {

--- a/apps/web/src/components/Profile/NftGallery/Gallery.tsx
+++ b/apps/web/src/components/Profile/NftGallery/Gallery.tsx
@@ -1,11 +1,11 @@
 import MenuTransition from '@components/Shared/MenuTransition';
 import { Menu } from '@headlessui/react';
 import {
-  ArrowsExpandIcon,
-  DotsVerticalIcon,
-  PencilAltIcon,
+  ArrowsPointingOutIcon,
+  EllipsisVerticalIcon,
+  PencilSquareIcon,
   TrashIcon
-} from '@heroicons/react/outline';
+} from '@heroicons/react/24/outline';
 import { Errors } from '@lenster/data/errors';
 import type { Nft, NftGallery } from '@lenster/lens';
 import {
@@ -175,7 +175,7 @@ const Gallery: FC<GalleryProps> = ({ galleries }) => {
         ) : currentProfile && currentProfile?.id === gallery.profileId ? (
           <Menu as="div" className="relative">
             <Menu.Button className="rounded-md p-1 hover:bg-gray-300/20">
-              <DotsVerticalIcon className="h-4 w-4" />
+              <EllipsisVerticalIcon className="h-4 w-4" />
             </Menu.Button>
             <MenuTransition>
               <Menu.Items
@@ -193,7 +193,7 @@ const Gallery: FC<GalleryProps> = ({ galleries }) => {
                   }
                 >
                   <div className="flex items-center space-x-2">
-                    <PencilAltIcon className="h-4 w-4" />
+                    <PencilSquareIcon className="h-4 w-4" />
                     <div>
                       <Trans>Edit</Trans>
                     </div>
@@ -210,7 +210,7 @@ const Gallery: FC<GalleryProps> = ({ galleries }) => {
                   }
                 >
                   <div className="flex items-center space-x-2">
-                    <ArrowsExpandIcon className="h-4 w-4" />
+                    <ArrowsPointingOutIcon className="h-4 w-4" />
                     <div>
                       <Trans>Rearrrange</Trans>
                     </div>

--- a/apps/web/src/components/Profile/NftGallery/Picker.tsx
+++ b/apps/web/src/components/Profile/NftGallery/Picker.tsx
@@ -1,6 +1,6 @@
 import NftsShimmer from '@components/Shared/Shimmer/NftsShimmer';
 import SingleNft from '@components/Shared/SingleNft';
-import { CheckIcon, CollectionIcon } from '@heroicons/react/outline';
+import { CheckIcon, RectangleStackIcon } from '@heroicons/react/24/outline';
 import { IS_MAINNET } from '@lenster/data/constants';
 import type { Nft, NfTsRequest } from '@lenster/lens';
 import { useNftFeedQuery } from '@lenster/lens';
@@ -62,7 +62,7 @@ const Picker: FC<PickerProps> = ({ onlyAllowOne }) => {
     return (
       <div className="flex flex-1 flex-col items-center justify-center justify-items-center space-y-2 p-5">
         <div>
-          <CollectionIcon className="text-brand h-8 w-8" />
+          <RectangleStackIcon className="text-brand h-8 w-8" />
         </div>
         <div>
           <div>

--- a/apps/web/src/components/Profile/NftGallery/ReviewSelection.tsx
+++ b/apps/web/src/components/Profile/NftGallery/ReviewSelection.tsx
@@ -1,5 +1,5 @@
 import SingleNft from '@components/Shared/SingleNft';
-import { CollectionIcon, XIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import type { Nft } from '@lenster/lens';
 import { EmptyState } from '@lenster/ui';
 import { t } from '@lingui/macro';
@@ -52,7 +52,7 @@ const ReviewSelection = () => {
         <EmptyState
           hideCard
           message={t`No collectables selected!`}
-          icon={<CollectionIcon className="text-brand h-8 w-8" />}
+          icon={<RectangleStackIcon className="text-brand h-8 w-8" />}
         />
       </div>
     );
@@ -67,7 +67,7 @@ const ReviewSelection = () => {
               onClick={() => onRemoveItem(item)}
               className="bg-brand-500 absolute right-2 top-2 rounded-full"
             >
-              <XIcon className="h-6 w-6 rounded-full bg-white p-1 text-black" />
+              <XMarkIcon className="h-6 w-6 rounded-full bg-white p-1 text-black" />
             </button>
             <SingleNft nft={item as Nft} linkToDetail={false} />
           </div>

--- a/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
+++ b/apps/web/src/components/Publication/Actions/Collect/CollectModule.tsx
@@ -6,14 +6,14 @@ import Collectors from '@components/Shared/Modal/Collectors';
 import ReferralAlert from '@components/Shared/ReferralAlert';
 import Uniswap from '@components/Shared/Uniswap';
 import {
-  CashIcon,
+  BanknotesIcon,
   ClockIcon,
-  CollectionIcon,
-  PhotographIcon,
-  PuzzleIcon,
+  PhotoIcon,
+  PuzzlePieceIcon,
+  RectangleStackIcon,
   UsersIcon
-} from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+} from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { LensHub } from '@lenster/abis';
 import { LENSHUB_PROXY, POLYGONSCAN_URL } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
@@ -398,7 +398,7 @@ const CollectModule: FC<CollectModuleProps> = ({
               </button>
               <Modal
                 title={t`Collected by`}
-                icon={<CollectionIcon className="text-brand h-5 w-5" />}
+                icon={<RectangleStackIcon className="text-brand h-5 w-5" />}
                 show={showCollectorsModal}
                 onClose={() => setShowCollectorsModal(false)}
               >
@@ -413,7 +413,7 @@ const CollectModule: FC<CollectModuleProps> = ({
             </div>
             {collectLimit ? (
               <div className="flex items-center space-x-2">
-                <PhotographIcon className="lt-text-gray-500 h-4 w-4" />
+                <PhotoIcon className="lt-text-gray-500 h-4 w-4" />
                 <div className="font-bold">
                   <Trans>{parseInt(collectLimit) - count} available</Trans>
                 </div>
@@ -421,7 +421,7 @@ const CollectModule: FC<CollectModuleProps> = ({
             ) : null}
             {referralFee ? (
               <div className="flex items-center space-x-2">
-                <CashIcon className="lt-text-gray-500 h-4 w-4" />
+                <BanknotesIcon className="lt-text-gray-500 h-4 w-4" />
                 <div className="font-bold">
                   <Trans>{referralFee}% referral fee</Trans>
                 </div>
@@ -430,7 +430,7 @@ const CollectModule: FC<CollectModuleProps> = ({
           </div>
           {revenueData?.publicationRevenue ? (
             <div className="flex items-center space-x-2">
-              <CashIcon className="lt-text-gray-500 h-4 w-4" />
+              <BanknotesIcon className="lt-text-gray-500 h-4 w-4" />
               <div className="flex items-center space-x-1.5">
                 <span>
                   <Trans>Revenue:</Trans>
@@ -479,7 +479,7 @@ const CollectModule: FC<CollectModuleProps> = ({
           ) : null}
           {data?.publication?.collectNftAddress ? (
             <div className="flex items-center space-x-2">
-              <PuzzleIcon className="lt-text-gray-500 h-4 w-4" />
+              <PuzzlePieceIcon className="lt-text-gray-500 h-4 w-4" />
               <div className="space-x-1.5">
                 <span>
                   <Trans>Token:</Trans>
@@ -516,7 +516,7 @@ const CollectModule: FC<CollectModuleProps> = ({
                       isLoading ? (
                         <Spinner size="xs" />
                       ) : (
-                        <CollectionIcon className="h-4 w-4" />
+                        <RectangleStackIcon className="h-4 w-4" />
                       )
                     }
                   >

--- a/apps/web/src/components/Publication/Actions/Collect/index.tsx
+++ b/apps/web/src/components/Publication/Actions/Collect/index.tsx
@@ -1,6 +1,6 @@
 import Loader from '@components/Shared/Loader';
-import { CollectionIcon } from '@heroicons/react/outline';
-import { CollectionIcon as CollectionIconSolid } from '@heroicons/react/solid';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
+import { RectangleStackIcon as RectangleStackIconSolid } from '@heroicons/react/24/solid';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type { ElectedMirror, Publication } from '@lenster/lens';
 import humanize from '@lenster/lib/humanize';
@@ -76,9 +76,9 @@ const Collect: FC<CollectProps> = ({
               withDelay
             >
               {hasCollected ? (
-                <CollectionIconSolid className={iconClassName} />
+                <RectangleStackIconSolid className={iconClassName} />
               ) : (
-                <CollectionIcon className={iconClassName} />
+                <RectangleStackIcon className={iconClassName} />
               )}
             </Tooltip>
           </div>
@@ -89,7 +89,7 @@ const Collect: FC<CollectProps> = ({
       </div>
       <Modal
         title={t`Collect`}
-        icon={<CollectionIcon className="text-brand h-5 w-5" />}
+        icon={<RectangleStackIcon className="text-brand h-5 w-5" />}
         show={showCollectModal}
         onClose={() => setShowCollectModal(false)}
       >

--- a/apps/web/src/components/Publication/Actions/Comment.tsx
+++ b/apps/web/src/components/Publication/Actions/Comment.tsx
@@ -1,4 +1,4 @@
-import { ChatAlt2Icon } from '@heroicons/react/outline';
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import type { Publication } from '@lenster/lens';
 import humanize from '@lenster/lib/humanize';
 import nFormatter from '@lenster/lib/nFormatter';
@@ -32,7 +32,7 @@ const Comment: FC<CommentProps> = ({ publication, showCount }) => {
               content={count > 0 ? t`${humanize(count)} Comments` : t`Comment`}
               withDelay
             >
-              <ChatAlt2Icon className={iconClassName} />
+              <ChatBubbleLeftRightIcon className={iconClassName} />
             </Tooltip>
           </div>
         </Link>

--- a/apps/web/src/components/Publication/Actions/Like.tsx
+++ b/apps/web/src/components/Publication/Actions/Like.tsx
@@ -1,5 +1,5 @@
-import { HeartIcon } from '@heroicons/react/outline';
-import { HeartIcon as HeartIconSolid } from '@heroicons/react/solid';
+import { HeartIcon } from '@heroicons/react/24/outline';
+import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid';
 import { Errors } from '@lenster/data/errors';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type { Publication } from '@lenster/lens';

--- a/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Bookmark.tsx
@@ -1,6 +1,6 @@
 import { Menu } from '@headlessui/react';
-import { BookmarkIcon as BookmarkIconOutline } from '@heroicons/react/outline';
-import { BookmarkIcon as BookmarkIconSolid } from '@heroicons/react/solid';
+import { BookmarkIcon as BookmarkIconOutline } from '@heroicons/react/24/outline';
+import { BookmarkIcon as BookmarkIconSolid } from '@heroicons/react/24/solid';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type {
   Publication,

--- a/apps/web/src/components/Publication/Actions/Menu/CopyPostText.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/CopyPostText.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { ClipboardCopyIcon } from '@heroicons/react/outline';
+import { ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type { Publication } from '@lenster/lens';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
@@ -40,7 +40,7 @@ const CopyPostText: FC<CopyPostTextProps> = ({ publication }) => {
       }}
     >
       <div className="flex items-center space-x-2">
-        <ClipboardCopyIcon className="h-4 w-4" />
+        <ClipboardDocumentIcon className="h-4 w-4" />
         <div>
           {publicationType === 'Comment' ? (
             <Trans>Copy comment text</Trans>

--- a/apps/web/src/components/Publication/Actions/Menu/Delete.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Delete.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { TrashIcon } from '@heroicons/react/outline';
+import { TrashIcon } from '@heroicons/react/24/outline';
 import type { Publication } from '@lenster/lens';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import cn from '@lenster/ui/cn';

--- a/apps/web/src/components/Publication/Actions/Menu/NotInterested.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/NotInterested.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { EyeIcon, EyeOffIcon } from '@heroicons/react/outline';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type {
   Publication,
@@ -104,7 +104,7 @@ const NotInterested: FC<NotInterestedProps> = ({ publication }) => {
           </>
         ) : (
           <>
-            <EyeOffIcon className="h-4 w-4" />
+            <EyeSlashIcon className="h-4 w-4" />
             <div>Not interested</div>
           </>
         )}

--- a/apps/web/src/components/Publication/Actions/Menu/Report.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Report.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { ShieldExclamationIcon } from '@heroicons/react/outline';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import type { Publication } from '@lenster/lens';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import cn from '@lenster/ui/cn';
@@ -30,7 +30,7 @@ const Report: FC<ReportProps> = ({ publication }) => {
       }}
     >
       <div className="flex items-center space-x-2">
-        <ShieldExclamationIcon className="h-4 w-4" />
+        <ExclamationTriangleIcon className="h-4 w-4" />
         <div>Report post</div>
       </div>
     </Menu.Item>

--- a/apps/web/src/components/Publication/Actions/Menu/Share.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Share.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { ClipboardCopyIcon } from '@heroicons/react/outline';
+import { ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type { Publication } from '@lenster/lens';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
@@ -35,7 +35,7 @@ const Share: FC<ShareProps> = ({ publication }) => {
       }}
     >
       <div className="flex items-center space-x-2">
-        <ClipboardCopyIcon className="h-4 w-4" />
+        <ClipboardDocumentIcon className="h-4 w-4" />
         <div>
           <Trans>Share</Trans>
         </div>

--- a/apps/web/src/components/Publication/Actions/Menu/Translate.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/Translate.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { TranslateIcon } from '@heroicons/react/outline';
+import { LanguageIcon } from '@heroicons/react/24/outline';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type { Publication } from '@lenster/lens';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
@@ -39,7 +39,7 @@ const Translate: FC<TranslateProps> = ({ publication }) => {
       target="_blank"
     >
       <div className="flex items-center space-x-2">
-        <TranslateIcon className="h-4 w-4" />
+        <LanguageIcon className="h-4 w-4" />
         <div>
           <Trans>Translate</Trans>
         </div>

--- a/apps/web/src/components/Publication/Actions/Menu/index.tsx
+++ b/apps/web/src/components/Publication/Actions/Menu/index.tsx
@@ -1,6 +1,6 @@
 import MenuTransition from '@components/Shared/MenuTransition';
 import { Menu } from '@headlessui/react';
-import { DotsVerticalIcon } from '@heroicons/react/outline';
+import { EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 import type { Publication } from '@lenster/lens';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import cn from '@lenster/ui/cn';
@@ -33,7 +33,9 @@ const PublicationMenu: FC<PublicationMenuProps> = ({ publication }) => {
           aria-label="More"
           data-testid={`publication-${publication.id}-menu`}
         >
-          <DotsVerticalIcon className={cn('lt-text-gray-500', iconClassName)} />
+          <EllipsisVerticalIcon
+            className={cn('lt-text-gray-500', iconClassName)}
+          />
         </button>
       </Menu.Button>
       <MenuTransition>

--- a/apps/web/src/components/Publication/Actions/Mod.tsx
+++ b/apps/web/src/components/Publication/Actions/Mod.tsx
@@ -1,4 +1,4 @@
-import { ShieldCheckIcon } from '@heroicons/react/outline';
+import { ShieldCheckIcon } from '@heroicons/react/24/outline';
 import type { Publication } from '@lenster/lens';
 import { Tooltip } from '@lenster/ui';
 import { t } from '@lingui/macro';

--- a/apps/web/src/components/Publication/Actions/ModAction/index.tsx
+++ b/apps/web/src/components/Publication/Actions/ModAction/index.tsx
@@ -1,4 +1,4 @@
-import { CashIcon, DocumentTextIcon } from '@heroicons/react/outline';
+import { BanknotesIcon, DocumentTextIcon } from '@heroicons/react/24/outline';
 import { GARDENER } from '@lenster/data/tracking';
 import type { Publication } from '@lenster/lens';
 import {
@@ -113,7 +113,7 @@ const ModAction: FC<ModActionProps> = ({ publication, className = '' }) => {
             subreason: PublicationReportingSpamSubreason.LowSignal
           }
         ]}
-        icon={<CashIcon className="h-4 w-4" />}
+        icon={<BanknotesIcon className="h-4 w-4" />}
         label={t`Stop Sponsor`}
       />
       <ReportButton
@@ -127,7 +127,7 @@ const ModAction: FC<ModActionProps> = ({ publication, className = '' }) => {
             subreason: PublicationReportingSpamSubreason.LowSignal
           }
         ]}
-        icon={<CashIcon className="h-4 w-4" />}
+        icon={<BanknotesIcon className="h-4 w-4" />}
         label={t`Poor content & Stop Sponsor`}
       />
     </span>

--- a/apps/web/src/components/Publication/Actions/Share/Mirror.tsx
+++ b/apps/web/src/components/Publication/Actions/Share/Mirror.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { LENSHUB_PROXY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
@@ -227,7 +227,7 @@ const Mirror: FC<MirrorProps> = ({ publication, setIsLoading, isLoading }) => {
       disabled={isLoading}
     >
       <div className="flex items-center space-x-2">
-        <SwitchHorizontalIcon className="h-4 w-4" />
+        <ArrowsRightLeftIcon className="h-4 w-4" />
         <div>{mirrored ? <Trans>Unmirror</Trans> : <Trans>Mirror</Trans>}</div>
       </div>
     </Menu.Item>

--- a/apps/web/src/components/Publication/Actions/Share/Quote.tsx
+++ b/apps/web/src/components/Publication/Actions/Share/Quote.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { AnnotationIcon } from '@heroicons/react/outline';
+import { ChatBubbleBottomCenterTextIcon } from '@heroicons/react/24/outline';
 import type { Publication } from '@lenster/lens';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
@@ -39,7 +39,7 @@ const Quote: FC<QuoteProps> = ({ publication }) => {
       }}
     >
       <div className="flex items-center space-x-2">
-        <AnnotationIcon className="h-4 w-4" />
+        <ChatBubbleBottomCenterTextIcon className="h-4 w-4" />
         <div>
           {publicationType === 'Comment' ? (
             <Trans>Quote comment</Trans>

--- a/apps/web/src/components/Publication/Actions/Share/index.tsx
+++ b/apps/web/src/components/Publication/Actions/Share/index.tsx
@@ -1,6 +1,6 @@
 import MenuTransition from '@components/Shared/MenuTransition';
 import { Menu } from '@headlessui/react';
-import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import type { Publication } from '@lenster/lens';
 import humanize from '@lenster/lib/humanize';
 import nFormatter from '@lenster/lib/nFormatter';
@@ -56,7 +56,7 @@ const ShareMenu: FC<PublicationMenuProps> = ({ publication, showCount }) => {
                 content={count > 0 ? t`${humanize(count)} Mirrors` : t`Mirror`}
                 withDelay
               >
-                <SwitchHorizontalIcon className={iconClassName} />
+                <ArrowsRightLeftIcon className={iconClassName} />
               </Tooltip>
             )}
           </button>

--- a/apps/web/src/components/Publication/DecryptedPublicationBody.tsx
+++ b/apps/web/src/components/Publication/DecryptedPublicationBody.tsx
@@ -2,15 +2,15 @@ import Attachments from '@components/Shared/Attachments';
 import Markup from '@components/Shared/Markup';
 import Oembed from '@components/Shared/Oembed';
 import {
-  CollectionIcon,
-  DatabaseIcon,
+  ArrowRightOnRectangleIcon,
+  CircleStackIcon,
   EyeIcon,
   FingerPrintIcon,
-  LogoutIcon,
-  PhotographIcon,
-  UserAddIcon
-} from '@heroicons/react/outline';
-import { LockClosedIcon } from '@heroicons/react/solid';
+  PhotoIcon,
+  RectangleStackIcon,
+  UserPlusIcon
+} from '@heroicons/react/24/outline';
+import { LockClosedIcon } from '@heroicons/react/24/solid';
 import type { LensEnvironment } from '@lens-protocol/sdk-gated';
 import { LensGatedSDK } from '@lens-protocol/sdk-gated';
 import type {
@@ -199,7 +199,7 @@ const DecryptedPublicationBody: FC<DecryptedPublicationBodyProps> = ({
         }}
       >
         <div className="flex items-center space-x-1 font-bold text-white">
-          <LogoutIcon className="h-5 w-5" />
+          <ArrowRightOnRectangleIcon className="h-5 w-5" />
           <span>Login to decrypt</span>
         </div>
       </Card>
@@ -221,7 +221,7 @@ const DecryptedPublicationBody: FC<DecryptedPublicationBodyProps> = ({
         <div className="space-y-2 pt-3.5 text-white">
           {/* Collect checks */}
           {hasNotCollectedPublication ? (
-            <DecryptMessage icon={<CollectionIcon className="h-4 w-4" />}>
+            <DecryptMessage icon={<RectangleStackIcon className="h-4 w-4" />}>
               Collect the{' '}
               <Link
                 href={`/posts/${collectCondition?.publicationId}`}
@@ -238,7 +238,7 @@ const DecryptedPublicationBody: FC<DecryptedPublicationBodyProps> = ({
           ) : null}
           {collectNotFinalisedOnChain ? (
             <DecryptMessage
-              icon={<CollectionIcon className="h-4 w-4 animate-pulse" />}
+              icon={<RectangleStackIcon className="h-4 w-4 animate-pulse" />}
             >
               <Trans>Collect finalizing on chain...</Trans>
             </DecryptMessage>
@@ -246,7 +246,7 @@ const DecryptedPublicationBody: FC<DecryptedPublicationBodyProps> = ({
 
           {/* Follow checks */}
           {doesNotFollowProfile ? (
-            <DecryptMessage icon={<UserAddIcon className="h-4 w-4" />}>
+            <DecryptMessage icon={<UserPlusIcon className="h-4 w-4" />}>
               Follow{' '}
               <Link
                 href={`/u/${formatHandle(
@@ -260,7 +260,7 @@ const DecryptedPublicationBody: FC<DecryptedPublicationBodyProps> = ({
           ) : null}
           {followNotFinalisedOnChain ? (
             <DecryptMessage
-              icon={<UserAddIcon className="h-4 w-4 animate-pulse" />}
+              icon={<UserPlusIcon className="h-4 w-4 animate-pulse" />}
             >
               <Trans>Follow finalizing on chain...</Trans>
             </DecryptMessage>
@@ -268,7 +268,7 @@ const DecryptedPublicationBody: FC<DecryptedPublicationBodyProps> = ({
 
           {/* Token check */}
           {unauthorizedBalance ? (
-            <DecryptMessage icon={<DatabaseIcon className="h-4 w-4" />}>
+            <DecryptMessage icon={<CircleStackIcon className="h-4 w-4" />}>
               You need{' '}
               <Link
                 href={`${POLYGONSCAN_URL}/token/${tokenCondition.contractAddress}`}
@@ -289,7 +289,7 @@ const DecryptedPublicationBody: FC<DecryptedPublicationBodyProps> = ({
 
           {/* NFT check */}
           {doesNotOwnNft ? (
-            <DecryptMessage icon={<PhotographIcon className="h-4 w-4" />}>
+            <DecryptMessage icon={<PhotoIcon className="h-4 w-4" />}>
               You need{' '}
               <Tooltip content={contractMetadata?.name} placement="top">
                 <Link

--- a/apps/web/src/components/Publication/OnchainMeta.tsx
+++ b/apps/web/src/components/Publication/OnchainMeta.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon } from '@heroicons/react/outline';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { IPFS_GATEWAY, POLYGONSCAN_URL } from '@lenster/data/constants';
 import type { Publication } from '@lenster/lens';
 import { Card } from '@lenster/ui';
@@ -22,7 +22,7 @@ const Meta: FC<MetaProps> = ({ name, uri, hash }) => (
     >
       <div className="flex items-center space-x-1">
         <div className="text-[10px]">{name}</div>
-        <ExternalLinkIcon className="h-4 w-4" />
+        <ArrowTopRightOnSquareIcon className="h-4 w-4" />
       </div>
       <div className="truncate text-xs">{hash}</div>
     </Link>

--- a/apps/web/src/components/Publication/OpenActions/Nft/Mint/Metadata.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Nft/Mint/Metadata.tsx
@@ -1,9 +1,9 @@
 import {
-  ExternalLinkIcon,
-  PuzzleIcon,
+  ArrowTopRightOnSquareIcon,
+  PuzzlePieceIcon,
   ShoppingBagIcon,
   UsersIcon
-} from '@heroicons/react/outline';
+} from '@heroicons/react/24/outline';
 import humanize from '@lenster/lib/humanize';
 import type { ZoraNft } from '@lenster/types/zora-nft';
 import { Trans } from '@lingui/macro';
@@ -19,7 +19,7 @@ const Metadata: FC<MetadataProps> = ({ nft, zoraLink }) => {
   return (
     <div className="space-y-1.5">
       <div className="flex items-center space-x-2">
-        <PuzzleIcon className="lt-text-gray-500 h-4 w-4" />
+        <PuzzlePieceIcon className="lt-text-gray-500 h-4 w-4" />
         <div className="space-x-1.5">
           <span>
             <Trans>Type:</Trans>
@@ -49,7 +49,7 @@ const Metadata: FC<MetadataProps> = ({ nft, zoraLink }) => {
         target="_blank"
         rel="noopener noreferrer"
       >
-        <ExternalLinkIcon className="lt-text-gray-500 h-4 w-4" />
+        <ArrowTopRightOnSquareIcon className="lt-text-gray-500 h-4 w-4" />
         <b>
           <Trans>Open in Zora</Trans>
         </b>

--- a/apps/web/src/components/Publication/OpenActions/Nft/Mint/MintAction.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Nft/Mint/MintAction.tsx
@@ -1,6 +1,9 @@
 import SwitchNetwork from '@components/Shared/SwitchNetwork';
-import { CurrencyDollarIcon, CursorClickIcon } from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import {
+  CurrencyDollarIcon,
+  CursorArrowRaysIcon
+} from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { ZoraCreator1155Impl, ZoraERC721Drop } from '@lenster/abis';
 import { ADMIN_ADDRESS } from '@lenster/data/constants';
 import type { ZoraNft } from '@lenster/types/zora-nft';
@@ -133,7 +136,7 @@ const MintAction: FC<MintActionProps> = ({ nft, zoraLink }) => {
           >
             <Button
               className="mt-5 w-full justify-center"
-              icon={<CursorClickIcon className="h-5 w-5" />}
+              icon={<CursorArrowRaysIcon className="h-5 w-5" />}
               size="md"
             >
               <Trans>Mint on Zora</Trans>
@@ -149,7 +152,7 @@ const MintAction: FC<MintActionProps> = ({ nft, zoraLink }) => {
             isContractWriteLoading ? (
               <Spinner className="mr-1" size="xs" />
             ) : (
-              <CursorClickIcon className="h-5 w-5" />
+              <CursorArrowRaysIcon className="h-5 w-5" />
             )
           }
         >

--- a/apps/web/src/components/Publication/OpenActions/Nft/Mint/Price.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Nft/Mint/Price.tsx
@@ -1,4 +1,4 @@
-import { MinusIcon, PlusIcon } from '@heroicons/react/outline';
+import { MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
 import type { ZoraNft } from '@lenster/types/zora-nft';
 import { HelpTooltip } from '@lenster/ui';
 import getRedstonePrice from '@lib/getRedstonePrice';

--- a/apps/web/src/components/Publication/OpenActions/Nft/index.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Nft/index.tsx
@@ -1,5 +1,8 @@
 import Alpha from '@components/Shared/Badges/Alpha';
-import { CollectionIcon, CursorClickIcon } from '@heroicons/react/outline';
+import {
+  CursorArrowRaysIcon,
+  RectangleStackIcon
+} from '@heroicons/react/24/outline';
 import getZoraChainIsMainnet from '@lenster/lib/nft/getZoraChainIsMainnet';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import type { ZoraNftMetadata } from '@lenster/types/zora-nft';
@@ -77,7 +80,7 @@ const Nft: FC<NftProps> = ({ nftMetadata }) => {
           <div className="text-sm font-bold">{nft.name}</div>
           {nft.contractType === 'ERC1155_COLLECTION' ? (
             <Tooltip placement="right" content={t`ERC-1155 Collection`}>
-              <CollectionIcon className="h-4 w-4" />
+              <RectangleStackIcon className="h-4 w-4" />
             </Tooltip>
           ) : null}
         </div>
@@ -85,7 +88,7 @@ const Nft: FC<NftProps> = ({ nftMetadata }) => {
           <>
             <Button
               className="text-sm"
-              icon={<CursorClickIcon className="h-4 w-4" />}
+              icon={<CursorArrowRaysIcon className="h-4 w-4" />}
               size="md"
               onClick={() => {
                 setQuantity(1);
@@ -105,7 +108,7 @@ const Nft: FC<NftProps> = ({ nftMetadata }) => {
                 </div>
               }
               show={showMintModal}
-              icon={<CursorClickIcon className="text-brand h-5 w-5" />}
+              icon={<CursorArrowRaysIcon className="text-brand h-5 w-5" />}
               onClose={() => setShowMintModal(false)}
             >
               <Mint nft={nft} zoraLink={zoraLink} />
@@ -115,7 +118,7 @@ const Nft: FC<NftProps> = ({ nftMetadata }) => {
           <Link href={zoraLink} target="_blank" rel="noopener noreferrer">
             <Button
               className="text-sm"
-              icon={<CursorClickIcon className="h-4 w-4" />}
+              icon={<CursorArrowRaysIcon className="h-4 w-4" />}
               size="md"
             >
               {nft.contractType === 'ERC1155_COLLECTION' ? (

--- a/apps/web/src/components/Publication/OpenActions/Snapshot/Choices.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Snapshot/Choices.tsx
@@ -1,5 +1,8 @@
-import { CheckCircleIcon as CheckCircleIconOutline } from '@heroicons/react/outline';
-import { CheckCircleIcon, MenuAlt2Icon } from '@heroicons/react/solid';
+import { CheckCircleIcon as CheckCircleIconOutline } from '@heroicons/react/24/outline';
+import {
+  Bars3BottomLeftIcon,
+  CheckCircleIcon
+} from '@heroicons/react/24/solid';
 import { APP_NAME, SNAPSHOT_SEQUNECER_URL } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
 import { PUBLICATION } from '@lenster/data/tracking';
@@ -134,7 +137,7 @@ const Choices: FC<ChoicesProps> = ({
         {!isLensterPoll ? (
           <div className="divider flex items-center justify-between px-5 py-3 ">
             <div className="flex items-center space-x-2 text-sm">
-              <MenuAlt2Icon className="h-4 w-4" />
+              <Bars3BottomLeftIcon className="h-4 w-4" />
               <b>{state === 'active' ? t`Current results` : t`Results`}</b>
             </div>
             <New />
@@ -195,7 +198,7 @@ const Choices: FC<ChoicesProps> = ({
         {isLensterPoll ? (
           <div className="flex items-center justify-between border-t px-5 py-3 dark:border-gray-700 ">
             <div className="flex items-center space-x-2 text-xs text-gray-500">
-              <MenuAlt2Icon className="h-4 w-4" />
+              <Bars3BottomLeftIcon className="h-4 w-4" />
               <b>
                 <Trans>Poll</Trans>
               </b>

--- a/apps/web/src/components/Publication/OpenActions/Snapshot/VoteProposal.tsx
+++ b/apps/web/src/components/Publication/OpenActions/Snapshot/VoteProposal.tsx
@@ -1,5 +1,5 @@
-import { ExclamationIcon } from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { SNAPSHOT_SEQUNECER_URL } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
 import { PUBLICATION } from '@lenster/data/tracking';
@@ -123,7 +123,7 @@ const VoteProposal: FC<VoteProposalProps> = ({
             {isLoading ? (
               <Spinner size="xs" />
             ) : error ? (
-              <ExclamationIcon className="h-5 w-5 text-yellow-500" />
+              <ExclamationTriangleIcon className="h-5 w-5 text-yellow-500" />
             ) : (
               <>
                 {humanize(totalVotingPower)} {symbol}

--- a/apps/web/src/components/Publication/PublicationBody.tsx
+++ b/apps/web/src/components/Publication/PublicationBody.tsx
@@ -4,7 +4,7 @@ import Attachments from '@components/Shared/Attachments';
 import Quote from '@components/Shared/Embed/Quote';
 import Markup from '@components/Shared/Markup';
 import Oembed from '@components/Shared/Oembed';
-import { EyeIcon } from '@heroicons/react/outline';
+import { EyeIcon } from '@heroicons/react/24/outline';
 import type { Publication } from '@lenster/lens';
 import getPublicationAttribute from '@lenster/lib/getPublicationAttribute';
 import getSnapshotProposalId from '@lenster/lib/getSnapshotProposalId';

--- a/apps/web/src/components/Publication/PublicationHeader.tsx
+++ b/apps/web/src/components/Publication/PublicationHeader.tsx
@@ -1,6 +1,6 @@
 import SmallUserProfile from '@components/Shared/SmallUserProfile';
 import UserProfile from '@components/Shared/UserProfile';
-import { XIcon } from '@heroicons/react/outline';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import type { FeedItem, Publication } from '@lenster/lens';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import cn from '@lenster/ui/cn';
@@ -79,7 +79,7 @@ const PublicationHeader: FC<PublicationHeaderProps> = ({
             }}
             aria-label="Remove Quote"
           >
-            <XIcon className="lt-text-gray-500 w-[15px] sm:w-[18px]" />
+            <XMarkIcon className="lt-text-gray-500 w-[15px] sm:w-[18px]" />
           </button>
         ) : null}
       </div>

--- a/apps/web/src/components/Publication/PublicationStats.tsx
+++ b/apps/web/src/components/Publication/PublicationStats.tsx
@@ -2,10 +2,10 @@ import Collectors from '@components/Shared/Modal/Collectors';
 import Likes from '@components/Shared/Modal/Likes';
 import Mirrors from '@components/Shared/Modal/Mirrors';
 import {
-  CollectionIcon,
+  ArrowsRightLeftIcon,
   HeartIcon,
-  SwitchHorizontalIcon
-} from '@heroicons/react/outline';
+  RectangleStackIcon
+} from '@heroicons/react/24/outline';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type { Publication } from '@lenster/lens';
 import nFormatter from '@lenster/lib/nFormatter';
@@ -81,7 +81,7 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
           </button>
           <Modal
             title={t`Mirrored by`}
-            icon={<SwitchHorizontalIcon className="text-brand h-5 w-5" />}
+            icon={<ArrowsRightLeftIcon className="text-brand h-5 w-5" />}
             show={showMirrorsModal}
             onClose={() => setShowMirrorsModal(false)}
           >
@@ -145,7 +145,7 @@ const PublicationStats: FC<PublicationStatsProps> = ({ publication }) => {
           </button>
           <Modal
             title={t`Collected by`}
-            icon={<CollectionIcon className="text-brand h-5 w-5" />}
+            icon={<RectangleStackIcon className="text-brand h-5 w-5" />}
             show={showCollectorsModal}
             onClose={() => setShowCollectorsModal(false)}
           >

--- a/apps/web/src/components/Publication/Type/Mirrored.tsx
+++ b/apps/web/src/components/Publication/Type/Mirrored.tsx
@@ -1,5 +1,5 @@
 import Profiles from '@components/Shared/Profiles';
-import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import type { Mirror } from '@lenster/lens';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';
@@ -11,7 +11,7 @@ interface MirroredProps {
 const Mirrored: FC<MirroredProps> = ({ publication }) => {
   return (
     <div className="lt-text-gray-500 flex items-center space-x-1 pb-4 text-[13px]">
-      <SwitchHorizontalIcon className="h-4 w-4" />
+      <ArrowsRightLeftIcon className="h-4 w-4" />
       <Profiles profiles={[publication.profile]} context={t`mirrored`} />
     </div>
   );

--- a/apps/web/src/components/Search/Profiles.tsx
+++ b/apps/web/src/components/Search/Profiles.tsx
@@ -1,6 +1,6 @@
 import UserProfilesShimmer from '@components/Shared/Shimmer/UserProfilesShimmer';
 import UserProfile from '@components/Shared/UserProfile';
-import { UsersIcon } from '@heroicons/react/outline';
+import { UsersIcon } from '@heroicons/react/24/outline';
 import type { ProfileSearchResult, SearchQueryRequest } from '@lenster/lens';
 import {
   CustomFiltersTypes,

--- a/apps/web/src/components/Search/Publications.tsx
+++ b/apps/web/src/components/Search/Publications.tsx
@@ -1,6 +1,6 @@
 import SinglePublication from '@components/Publication/SinglePublication';
 import PublicationsShimmer from '@components/Shared/Shimmer/PublicationsShimmer';
-import { CollectionIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import type {
   Publication,
   PublicationSearchResult,
@@ -73,7 +73,7 @@ const Publications: FC<PublicationsProps> = ({ query }) => {
             No publications for <b>&ldquo;{query}&rdquo;</b>
           </Trans>
         }
-        icon={<CollectionIcon className="text-brand h-8 w-8" />}
+        icon={<RectangleStackIcon className="text-brand h-8 w-8" />}
       />
     );
   }

--- a/apps/web/src/components/Search/index.tsx
+++ b/apps/web/src/components/Search/index.tsx
@@ -1,6 +1,6 @@
 import MetaTags from '@components/Common/MetaTags';
 import Sidebar from '@components/Shared/Sidebar';
-import { PencilAltIcon, UsersIcon } from '@heroicons/react/outline';
+import { PencilSquareIcon, UsersIcon } from '@heroicons/react/24/outline';
 import { PAGEVIEW } from '@lenster/data/tracking';
 import { GridItemEight, GridItemFour, GridLayout } from '@lenster/ui';
 import { Leafwatch } from '@lib/leafwatch';
@@ -36,7 +36,7 @@ const Search: NextPage = () => {
             items={[
               {
                 title: t`Publications`,
-                icon: <PencilAltIcon className="h-4 w-4" />,
+                icon: <PencilSquareIcon className="h-4 w-4" />,
                 url: `/search?q=${searchText}&type=pubs`,
                 active: query.type === 'pubs'
               },

--- a/apps/web/src/components/Settings/Account/SetProfile.tsx
+++ b/apps/web/src/components/Settings/Account/SetProfile.tsx
@@ -1,6 +1,9 @@
 import NotLoggedIn from '@components/Shared/NotLoggedIn';
 import UserProfile from '@components/Shared/UserProfile';
-import { ExclamationIcon, PencilIcon } from '@heroicons/react/outline';
+import {
+  ExclamationTriangleIcon,
+  PencilIcon
+} from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { APP_NAME, LENSHUB_PROXY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
@@ -135,7 +138,7 @@ const SetProfile: FC = () => {
         </>
       ) : (
         <div className="flex items-center space-x-1.5 font-bold text-yellow-500">
-          <ExclamationIcon className="h-5 w-5" />
+          <ExclamationTriangleIcon className="h-5 w-5" />
           <div>
             <Trans>You don't have any default profile set!</Trans>
           </div>

--- a/apps/web/src/components/Settings/Account/SuperFollow.tsx
+++ b/apps/web/src/components/Settings/Account/SuperFollow.tsx
@@ -1,4 +1,4 @@
-import { StarIcon, XIcon } from '@heroicons/react/outline';
+import { StarIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { DEFAULT_COLLECT_TOKEN, LENSHUB_PROXY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
@@ -231,7 +231,7 @@ const SuperFollow: FC = () => {
                 outline
                 onClick={() => setSuperFollow(null, null)}
                 disabled={isLoading}
-                icon={<XIcon className="h-4 w-4" />}
+                icon={<XMarkIcon className="h-4 w-4" />}
               >
                 <Trans>Disable Super follow</Trans>
               </Button>

--- a/apps/web/src/components/Settings/Account/Verification.tsx
+++ b/apps/web/src/components/Settings/Account/Verification.tsx
@@ -1,4 +1,4 @@
-import { BadgeCheckIcon } from '@heroicons/react/solid';
+import { CheckBadgeIcon } from '@heroicons/react/24/solid';
 import { Card } from '@lenster/ui';
 import isVerified from '@lib/isVerified';
 import { Trans } from '@lingui/macro';
@@ -16,7 +16,7 @@ const Verification: FC = () => {
       {isVerified(currentProfile?.id) ? (
         <div className="flex items-center space-x-1.5">
           <span>Believe it. Yes, you're really verified.</span>
-          <BadgeCheckIcon className="text-brand h-5 w-5" />
+          <CheckBadgeIcon className="text-brand h-5 w-5" />
         </div>
       ) : (
         <div>

--- a/apps/web/src/components/Settings/Allowance/Button.tsx
+++ b/apps/web/src/components/Settings/Allowance/Button.tsx
@@ -1,4 +1,8 @@
-import { ExclamationIcon, MinusIcon, PlusIcon } from '@heroicons/react/outline';
+import {
+  ExclamationTriangleIcon,
+  MinusIcon,
+  PlusIcon
+} from '@heroicons/react/24/outline';
 import { SETTINGS } from '@lenster/data/tracking';
 import type { ApprovedAllowanceAmount } from '@lenster/lens';
 import { useGenerateModuleCurrencyApprovalDataLazyQuery } from '@lenster/lens';
@@ -107,7 +111,7 @@ const AllowanceButton: FC<AllowanceButtonProps> = ({
       </Button>
       <Modal
         title={t`Warning`}
-        icon={<ExclamationIcon className="h-5 w-5 text-yellow-500" />}
+        icon={<ExclamationTriangleIcon className="h-5 w-5 text-yellow-500" />}
         show={showWarningModal}
         onClose={() => setShowWarningModal(false)}
       >

--- a/apps/web/src/components/Settings/Danger/Delete.tsx
+++ b/apps/web/src/components/Settings/Danger/Delete.tsx
@@ -1,5 +1,8 @@
 import UserProfile from '@components/Shared/UserProfile';
-import { ExclamationIcon, TrashIcon } from '@heroicons/react/outline';
+import {
+  ExclamationTriangleIcon,
+  TrashIcon
+} from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { LENSHUB_PROXY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
@@ -143,7 +146,7 @@ const DeleteSettings: FC = () => {
       </Button>
       <Modal
         title={t`Danger zone`}
-        icon={<ExclamationIcon className="h-5 w-5 text-red-500" />}
+        icon={<ExclamationTriangleIcon className="h-5 w-5 text-red-500" />}
         show={showWarningModal}
         onClose={() => setShowWarningModal(false)}
       >

--- a/apps/web/src/components/Settings/Danger/Guardian.tsx
+++ b/apps/web/src/components/Settings/Danger/Guardian.tsx
@@ -1,5 +1,8 @@
 import IndexStatus from '@components/Shared/IndexStatus';
-import { ExclamationIcon, LockOpenIcon } from '@heroicons/react/outline';
+import {
+  ExclamationTriangleIcon,
+  LockOpenIcon
+} from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { LENSHUB_PROXY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
@@ -111,7 +114,7 @@ const GuardianSettings: FC = () => {
       )}
       <Modal
         title={t`Danger zone`}
-        icon={<ExclamationIcon className="h-5 w-5 text-red-500" />}
+        icon={<ExclamationTriangleIcon className="h-5 w-5 text-red-500" />}
         show={showWarningModal}
         onClose={() => setShowWarningModal(false)}
       >

--- a/apps/web/src/components/Settings/Dispatcher/ToggleDispatcher.tsx
+++ b/apps/web/src/components/Settings/Dispatcher/ToggleDispatcher.tsx
@@ -1,5 +1,5 @@
 import IndexStatus from '@components/Shared/IndexStatus';
-import { CheckCircleIcon, XIcon } from '@heroicons/react/outline';
+import { CheckCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import {
   LENSHUB_PROXY,
@@ -136,7 +136,7 @@ const ToggleDispatcher: FC<ToggleDispatcherProps> = ({ buttonSize = 'md' }) => {
         isLoading ? (
           <Spinner variant={canUseRelay ? 'danger' : 'primary'} size="xs" />
         ) : canUseRelay ? (
-          <XIcon className="h-4 w-4" />
+          <XMarkIcon className="h-4 w-4" />
         ) : (
           <CheckCircleIcon className="h-4 w-4" />
         )

--- a/apps/web/src/components/Settings/Interests/Interests.tsx
+++ b/apps/web/src/components/Settings/Interests/Interests.tsx
@@ -1,5 +1,5 @@
-import { PlusCircleIcon } from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { PlusCircleIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { SETTINGS } from '@lenster/data/tracking';
 import {
   useAddProfileInterestMutation,

--- a/apps/web/src/components/Settings/Preferences/HighSignalNotificationFilter.tsx
+++ b/apps/web/src/components/Settings/Preferences/HighSignalNotificationFilter.tsx
@@ -1,5 +1,5 @@
 import ToggleWithHelper from '@components/Shared/ToggleWithHelper';
-import { ColorSwatchIcon } from '@heroicons/react/outline';
+import { SwatchIcon } from '@heroicons/react/24/outline';
 import { PREFERENCES_WORKER_URL } from '@lenster/data/constants';
 import { Localstorage } from '@lenster/data/storage';
 import { SETTINGS } from '@lenster/data/tracking';
@@ -58,7 +58,7 @@ const HighSignalNotificationFilter: FC = () => {
       setOn={toggleHighSignalNotificationFilter}
       heading={t`Notification Signal filter`}
       description={t`Turn on high-signal notification filter`}
-      icon={<ColorSwatchIcon className="h-4 w-4" />}
+      icon={<SwatchIcon className="h-4 w-4" />}
     />
   );
 };

--- a/apps/web/src/components/Settings/Profile/NftAvatarModal.tsx
+++ b/apps/web/src/components/Settings/Profile/NftAvatarModal.tsx
@@ -1,5 +1,5 @@
 import Picker from '@components/Profile/NftGallery/Picker';
-import { PencilIcon } from '@heroicons/react/outline';
+import { PencilIcon } from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { LENSHUB_PROXY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';

--- a/apps/web/src/components/Settings/Profile/NftPicture.tsx
+++ b/apps/web/src/components/Settings/Profile/NftPicture.tsx
@@ -1,4 +1,4 @@
-import { PhotographIcon } from '@heroicons/react/outline';
+import { PhotoIcon } from '@heroicons/react/24/outline';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
@@ -25,7 +25,7 @@ const NftPicture: FC<NftPictureProps> = ({ profile }) => {
         alt={formatHandle(profile?.handle)}
       />
       <Button
-        icon={<PhotographIcon className="h-4 w-4" />}
+        icon={<PhotoIcon className="h-4 w-4" />}
         onClick={() => setShowNftAvatarModal(true)}
       >
         <Trans>Choose NFT avatar</Trans>

--- a/apps/web/src/components/Settings/Profile/Picture.tsx
+++ b/apps/web/src/components/Settings/Profile/Picture.tsx
@@ -1,6 +1,6 @@
 import ChooseFile from '@components/Shared/ChooseFile';
 import ImageCropperController from '@components/Shared/ImageCropperController';
-import { PencilIcon } from '@heroicons/react/outline';
+import { PencilIcon } from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { AVATAR, LENSHUB_PROXY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';

--- a/apps/web/src/components/Settings/Profile/Profile.tsx
+++ b/apps/web/src/components/Settings/Profile/Profile.tsx
@@ -1,6 +1,6 @@
 import ChooseFile from '@components/Shared/ChooseFile';
 import ImageCropperController from '@components/Shared/ImageCropperController';
-import { PencilIcon } from '@heroicons/react/outline';
+import { PencilIcon } from '@heroicons/react/24/outline';
 import { LensPeriphery } from '@lenster/abis';
 import { COVER, LENS_PERIPHERY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';

--- a/apps/web/src/components/Settings/Profile/index.tsx
+++ b/apps/web/src/components/Settings/Profile/index.tsx
@@ -1,6 +1,6 @@
 import MetaTags from '@components/Common/MetaTags';
 import NotLoggedIn from '@components/Shared/NotLoggedIn';
-import { CubeIcon, PhotographIcon } from '@heroicons/react/outline';
+import { CubeIcon, PhotoIcon } from '@heroicons/react/24/outline';
 import { APP_NAME } from '@lenster/data/constants';
 import { PAGEVIEW } from '@lenster/data/tracking';
 import { useProfileSettingsQuery } from '@lenster/lens';
@@ -68,7 +68,7 @@ const ProfileSettings: NextPage = () => {
           <div className="flex items-center space-x-2">
             <TabButton
               name="Upload avatar"
-              icon={<PhotographIcon className="h-5 w-5" />}
+              icon={<PhotoIcon className="h-5 w-5" />}
               active={settingsType === 'AVATAR'}
               onClick={() => setSettingsType('AVATAR')}
             />

--- a/apps/web/src/components/Settings/Sidebar.tsx
+++ b/apps/web/src/components/Settings/Sidebar.tsx
@@ -1,16 +1,16 @@
 import Sidebar from '@components/Shared/Sidebar';
 import UserProfile from '@components/Shared/UserProfile';
 import {
-  AdjustmentsIcon,
+  AdjustmentsVerticalIcon,
   BookmarkIcon,
-  ChipIcon,
-  DatabaseIcon,
-  ExclamationIcon,
+  CircleStackIcon,
+  CpuChipIcon,
+  ExclamationTriangleIcon,
   FingerPrintIcon,
   ShareIcon,
   SparklesIcon,
   UserIcon
-} from '@heroicons/react/outline';
+} from '@heroicons/react/24/outline';
 import type { Profile } from '@lenster/lens';
 import { t, Trans } from '@lingui/macro';
 import type { FC } from 'react';
@@ -36,12 +36,12 @@ const SettingsSidebar: FC = () => {
           },
           {
             title: t`Account`,
-            icon: <ChipIcon className="h-4 w-4" />,
+            icon: <CpuChipIcon className="h-4 w-4" />,
             url: '/settings/account'
           },
           {
             title: t`Preferences`,
-            icon: <AdjustmentsIcon className="h-4 w-4" />,
+            icon: <AdjustmentsVerticalIcon className="h-4 w-4" />,
             url: '/settings/preferences'
           },
           {
@@ -66,7 +66,7 @@ const SettingsSidebar: FC = () => {
           },
           {
             title: t`Export`,
-            icon: <DatabaseIcon className="h-4 w-4" />,
+            icon: <CircleStackIcon className="h-4 w-4" />,
             url: '/settings/export'
           },
           {
@@ -75,7 +75,7 @@ const SettingsSidebar: FC = () => {
                 <Trans>Danger zone</Trans>
               </div>
             ),
-            icon: <ExclamationIcon className="h-4 w-4 text-red-500" />,
+            icon: <ExclamationTriangleIcon className="h-4 w-4 text-red-500" />,
             url: '/settings/danger'
           }
         ]}

--- a/apps/web/src/components/Shared/Attachments.tsx
+++ b/apps/web/src/components/Shared/Attachments.tsx
@@ -1,5 +1,8 @@
 import ChooseThumbnail from '@components/Composer/ChooseThumbnail';
-import { ExternalLinkIcon, XIcon } from '@heroicons/react/outline';
+import {
+  ArrowTopRightOnSquareIcon,
+  XMarkIcon
+} from '@heroicons/react/24/outline';
 import {
   ALLOWED_AUDIO_TYPES,
   ALLOWED_VIDEO_TYPES,
@@ -130,7 +133,7 @@ const Attachments: FC<AttachmentsProps> = ({
                   <Button
                     className="text-sm"
                     variant="primary"
-                    icon={<ExternalLinkIcon className="h-4 w-4" />}
+                    icon={<ArrowTopRightOnSquareIcon className="h-4 w-4" />}
                     onClick={() => window.open(url, '_blank')}
                   >
                     <span>
@@ -192,7 +195,7 @@ const Attachments: FC<AttachmentsProps> = ({
                       className="mt-3"
                       variant="danger"
                       size="sm"
-                      icon={<XIcon className="h-4 w-4" />}
+                      icon={<XMarkIcon className="h-4 w-4" />}
                       onClick={() => removeAttachment(attachment)}
                       outline
                     >
@@ -207,7 +210,7 @@ const Attachments: FC<AttachmentsProps> = ({
                         className="rounded-full bg-gray-900 p-1.5 opacity-75"
                         onClick={() => removeAttachment(attachment)}
                       >
-                        <XIcon className="h-4 w-4 text-white" />
+                        <XMarkIcon className="h-4 w-4 text-white" />
                       </button>
                     </div>
                   ))}

--- a/apps/web/src/components/Shared/Audio/CoverImage.tsx
+++ b/apps/web/src/components/Shared/Audio/CoverImage.tsx
@@ -1,4 +1,4 @@
-import { PhotographIcon } from '@heroicons/react/outline';
+import { PhotoIcon } from '@heroicons/react/24/outline';
 import { ATTACHMENT } from '@lenster/data/constants';
 import imageKit from '@lenster/lib/imageKit';
 import sanitizeDStorageUrl from '@lenster/lib/sanitizeDStorageUrl';
@@ -73,7 +73,7 @@ const CoverImage: FC<CoverImageProps> = ({
             <Spinner size="sm" />
           ) : (
             <div className="flex flex-col items-center text-sm text-black opacity-60 dark:text-white">
-              <PhotographIcon className="h-5 w-5" />
+              <PhotoIcon className="h-5 w-5" />
               <span>Add cover</span>
             </div>
           )}

--- a/apps/web/src/components/Shared/Audio/index.tsx
+++ b/apps/web/src/components/Shared/Audio/index.tsx
@@ -1,4 +1,4 @@
-import { PauseIcon, PlayIcon } from '@heroicons/react/solid';
+import { PauseIcon, PlayIcon } from '@heroicons/react/24/solid';
 import { PUBLICATION } from '@lenster/data/tracking';
 import type { Publication } from '@lenster/lens';
 import getPublicationAttribute from '@lenster/lib/getPublicationAttribute';

--- a/apps/web/src/components/Shared/Badges/Alpha.tsx
+++ b/apps/web/src/components/Shared/Badges/Alpha.tsx
@@ -1,11 +1,11 @@
-import { PuzzleIcon } from '@heroicons/react/outline';
+import { PuzzlePieceIcon } from '@heroicons/react/24/outline';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';
 
 const Alpha: FC = () => {
   return (
     <div className="flex items-center space-x-1 rounded-md border border-red-600 bg-red-500 px-1.5 text-xs text-white shadow-sm">
-      <PuzzleIcon className="h-3 w-3" />
+      <PuzzlePieceIcon className="h-3 w-3" />
       <div>
         <Trans>Alpha 🤫</Trans>
       </div>

--- a/apps/web/src/components/Shared/Badges/Beta.tsx
+++ b/apps/web/src/components/Shared/Badges/Beta.tsx
@@ -1,4 +1,4 @@
-import { StarIcon } from '@heroicons/react/solid';
+import { StarIcon } from '@heroicons/react/24/solid';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';
 

--- a/apps/web/src/components/Shared/Badges/New.tsx
+++ b/apps/web/src/components/Shared/Badges/New.tsx
@@ -1,4 +1,4 @@
-import { SparklesIcon } from '@heroicons/react/solid';
+import { SparklesIcon } from '@heroicons/react/24/solid';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';
 

--- a/apps/web/src/components/Shared/CollectWarning.tsx
+++ b/apps/web/src/components/Shared/CollectWarning.tsx
@@ -1,5 +1,5 @@
 import Slug from '@components/Shared/Slug';
-import { StarIcon, UsersIcon } from '@heroicons/react/outline';
+import { StarIcon, UsersIcon } from '@heroicons/react/24/outline';
 import { Card } from '@lenster/ui';
 import cn from '@lenster/ui/cn';
 import type { FC } from 'react';

--- a/apps/web/src/components/Shared/CommentWarning.tsx
+++ b/apps/web/src/components/Shared/CommentWarning.tsx
@@ -1,4 +1,4 @@
-import { ChatAlt2Icon } from '@heroicons/react/outline';
+import { ChatBubbleLeftRightIcon } from '@heroicons/react/24/outline';
 import { Card } from '@lenster/ui';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';
@@ -6,7 +6,7 @@ import type { FC } from 'react';
 const CommentWarning: FC = () => {
   return (
     <Card className="flex items-center space-x-1.5 border-blue-300 !bg-blue-100 p-5 text-sm font-bold text-gray-500">
-      <ChatAlt2Icon className="h-4 w-4 text-blue-500" />
+      <ChatBubbleLeftRightIcon className="h-4 w-4 text-blue-500" />
       <span>
         <Trans>You can't reply to this post</Trans>
       </span>

--- a/apps/web/src/components/Shared/DismissRecommendedProfile.tsx
+++ b/apps/web/src/components/Shared/DismissRecommendedProfile.tsx
@@ -1,4 +1,4 @@
-import { XIcon } from '@heroicons/react/outline';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import { PROFILE } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import { useDismissRecommendedProfilesMutation } from '@lenster/lens';
@@ -34,7 +34,7 @@ const DismissRecommendedProfile: FC<DismissRecommendedProfileProps> = ({
 
   return (
     <button onClick={handleDismiss}>
-      <XIcon className="h-4 w-4 text-gray-500" />
+      <XMarkIcon className="h-4 w-4 text-gray-500" />
     </button>
   );
 };

--- a/apps/web/src/components/Shared/EmojiPicker/List.tsx
+++ b/apps/web/src/components/Shared/EmojiPicker/List.tsx
@@ -1,4 +1,4 @@
-import { SearchIcon, XIcon } from '@heroicons/react/outline';
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { STATIC_ASSETS_URL } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
@@ -71,9 +71,9 @@ const List: FC<ListProps> = ({ setEmoji }) => {
           className="px-3 py-2 text-sm"
           placeholder={'Search...'}
           value={searchText}
-          iconLeft={<SearchIcon />}
+          iconLeft={<MagnifyingGlassIcon />}
           iconRight={
-            <XIcon
+            <XMarkIcon
               className={cn(
                 'cursor-pointer',
                 searchText ? 'visible' : 'invisible'

--- a/apps/web/src/components/Shared/EmojiPicker/index.tsx
+++ b/apps/web/src/components/Shared/EmojiPicker/index.tsx
@@ -1,4 +1,4 @@
-import { EmojiHappyIcon } from '@heroicons/react/outline';
+import { FaceSmileIcon } from '@heroicons/react/24/outline';
 import stopEventPropagation from '@lenster/lib/stopEventPropagation';
 import { Tooltip } from '@lenster/ui';
 import cn from '@lenster/ui/cn';
@@ -41,7 +41,7 @@ const EmojiPicker: FC<EmojiPickerProps> = ({
           <span>{emoji}</span>
         ) : (
           <Tooltip placement="top" content={t`Emoji`}>
-            <EmojiHappyIcon className={cn('h-5 w-5', emojiClassName)} />
+            <FaceSmileIcon className={cn('h-5 w-5', emojiClassName)} />
           </Tooltip>
         )}
       </button>

--- a/apps/web/src/components/Shared/Follow.tsx
+++ b/apps/web/src/components/Shared/Follow.tsx
@@ -1,4 +1,4 @@
-import { UserAddIcon } from '@heroicons/react/outline';
+import { UserPlusIcon } from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { LENSHUB_PROXY } from '@lenster/data/constants';
 import { PROFILE } from '@lenster/data/tracking';
@@ -185,7 +185,7 @@ const Follow: FC<FollowProps> = ({
       aria-label="Follow"
       disabled={isLoading}
       icon={
-        isLoading ? <Spinner size="xs" /> : <UserAddIcon className="h-4 w-4" />
+        isLoading ? <Spinner size="xs" /> : <UserPlusIcon className="h-4 w-4" />
       }
     >
       {showText ? t`Follow` : null}

--- a/apps/web/src/components/Shared/Footer/Locale.tsx
+++ b/apps/web/src/components/Shared/Footer/Locale.tsx
@@ -1,5 +1,5 @@
 import { Menu } from '@headlessui/react';
-import { GlobeAltIcon } from '@heroicons/react/outline';
+import { GlobeAltIcon } from '@heroicons/react/24/outline';
 import { Localstorage } from '@lenster/data/storage';
 import { MISCELLANEOUS } from '@lenster/data/tracking';
 import cn from '@lenster/ui/cn';

--- a/apps/web/src/components/Shared/GlobalModals.tsx
+++ b/apps/web/src/components/Shared/GlobalModals.tsx
@@ -1,11 +1,11 @@
 import NewPublication from '@components/Composer/NewPublication';
 import ReportPublication from '@components/Shared/Modal/ReportPublication';
 import {
-  ArrowCircleRightIcon,
-  EmojiHappyIcon,
+  ArrowRightCircleIcon,
+  FaceSmileIcon,
   ShieldCheckIcon,
   TicketIcon
-} from '@heroicons/react/outline';
+} from '@heroicons/react/24/outline';
 import { Modal } from '@lenster/ui';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';
@@ -94,7 +94,7 @@ const GlobalModals: FC = () => {
       </Modal>
       <Modal
         title={t`Set status`}
-        icon={<EmojiHappyIcon className="text-brand h-5 w-5" />}
+        icon={<FaceSmileIcon className="text-brand h-5 w-5" />}
         show={showStatusModal}
         onClose={() => setShowStatusModal(false)}
       >
@@ -110,7 +110,7 @@ const GlobalModals: FC = () => {
       </Modal>
       <Modal
         title={t`Login`}
-        icon={<ArrowCircleRightIcon className="text-brand h-5 w-5" />}
+        icon={<ArrowRightCircleIcon className="text-brand h-5 w-5" />}
         show={showAuthModal}
         onClose={() => setShowAuthModal(false)}
         dataTestId="login-modal"

--- a/apps/web/src/components/Shared/ImageCropperController.tsx
+++ b/apps/web/src/components/Shared/ImageCropperController.tsx
@@ -1,6 +1,9 @@
 import 'rc-slider/assets/index.css';
 
-import { ZoomInIcon, ZoomOutIcon } from '@heroicons/react/outline';
+import {
+  MagnifyingGlassMinusIcon,
+  MagnifyingGlassPlusIcon
+} from '@heroicons/react/24/outline';
 import ImageCropper from '@lenster/image-cropper/ImageCropper';
 import type { Area, Point, Size } from '@lenster/image-cropper/types';
 import Slider from 'rc-slider';
@@ -66,7 +69,7 @@ const ImageCropperController: FC<ImageCropperControllerProps> = ({
         className="flex py-2"
         style={{ width: cropSize.width + borderSize * 2 }}
       >
-        <ZoomOutIcon className="m-1 h-6 w-6" />
+        <MagnifyingGlassMinusIcon className="m-1 h-6 w-6" />
         <Slider
           className="m-2"
           min={0}
@@ -75,7 +78,7 @@ const ImageCropperController: FC<ImageCropperControllerProps> = ({
           onChange={onSliderChange}
           value={Math.log(zoom)}
         />
-        <ZoomInIcon className="m-1 h-6 w-6" />
+        <MagnifyingGlassPlusIcon className="m-1 h-6 w-6" />
       </div>
     </div>
   );

--- a/apps/web/src/components/Shared/IndexStatus.tsx
+++ b/apps/web/src/components/Shared/IndexStatus.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { POLYGONSCAN_URL } from '@lenster/data/constants';
 import { useHasTxHashBeenIndexedQuery } from '@lenster/lens';
 import { Spinner } from '@lenster/ui';

--- a/apps/web/src/components/Shared/Lexical/Plugins/AtMentionsPlugin.tsx
+++ b/apps/web/src/components/Shared/Lexical/Plugins/AtMentionsPlugin.tsx
@@ -1,4 +1,7 @@
-import { BadgeCheckIcon, ExclamationCircleIcon } from '@heroicons/react/solid';
+import {
+  CheckBadgeIcon,
+  ExclamationCircleIcon
+} from '@heroicons/react/24/solid';
 import { AVATAR } from '@lenster/data/constants';
 import type {
   MediaSet,
@@ -162,7 +165,7 @@ const MentionsTypeaheadMenuItem: FC<MentionsTypeaheadMenuItemProps> = ({
           <div className="flex items-center space-x-1 text-sm">
             <span>{option.name}</span>
             {isVerified(option.id) ? (
-              <BadgeCheckIcon className="text-brand h-4 w-4" />
+              <CheckBadgeIcon className="text-brand h-4 w-4" />
             ) : null}
             {hasMisused(option.id) ? (
               <ExclamationCircleIcon className="h-4 w-4 text-red-500" />

--- a/apps/web/src/components/Shared/Login/New/Pending.tsx
+++ b/apps/web/src/components/Shared/Login/New/Pending.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon } from '@heroicons/react/outline';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
 import { HANDLE_SUFFIX } from '@lenster/data/constants';
 import { useHasTxHashBeenIndexedQuery } from '@lenster/lens';
 import { Button, Spinner } from '@lenster/ui';

--- a/apps/web/src/components/Shared/Login/New/index.tsx
+++ b/apps/web/src/components/Shared/Login/New/index.tsx
@@ -1,5 +1,5 @@
 import ChooseFile from '@components/Shared/ChooseFile';
-import { PlusIcon } from '@heroicons/react/outline';
+import { PlusIcon } from '@heroicons/react/24/outline';
 import { APP_NAME, ZERO_ADDRESS } from '@lenster/data/constants';
 import { Regex } from '@lenster/data/regex';
 import { RelayErrorReasons, useCreateProfileMutation } from '@lenster/lens';

--- a/apps/web/src/components/Shared/Login/WalletSelector.tsx
+++ b/apps/web/src/components/Shared/Login/WalletSelector.tsx
@@ -1,6 +1,6 @@
 import SwitchNetwork from '@components/Shared/SwitchNetwork';
-import { KeyIcon } from '@heroicons/react/outline';
-import { XCircleIcon } from '@heroicons/react/solid';
+import { KeyIcon } from '@heroicons/react/24/outline';
+import { XCircleIcon } from '@heroicons/react/24/solid';
 import { Errors } from '@lenster/data/errors';
 import { Localstorage } from '@lenster/data/storage';
 import { AUTH } from '@lenster/data/tracking';

--- a/apps/web/src/components/Shared/Modal/Collectors.tsx
+++ b/apps/web/src/components/Shared/Modal/Collectors.tsx
@@ -1,6 +1,6 @@
 import UserProfile from '@components/Shared/UserProfile';
 import WalletProfile from '@components/Shared/WalletProfile';
-import { CollectionIcon } from '@heroicons/react/outline';
+import { RectangleStackIcon } from '@heroicons/react/24/outline';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type {
   Profile,
@@ -55,7 +55,7 @@ const Collectors: FC<CollectorsProps> = ({ publicationId }) => {
       <div className="p-5">
         <EmptyState
           message={t`No collectors.`}
-          icon={<CollectionIcon className="text-brand h-8 w-8" />}
+          icon={<RectangleStackIcon className="text-brand h-8 w-8" />}
           hideCard
         />
       </div>

--- a/apps/web/src/components/Shared/Modal/Invites/Invited.tsx
+++ b/apps/web/src/components/Shared/Modal/Invites/Invited.tsx
@@ -1,5 +1,5 @@
-import { TicketIcon } from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { TicketIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import type { InvitedResult } from '@lenster/lens';
 import formatAddress from '@lenster/lib/formatAddress';
 import { EmptyState, Input } from '@lenster/ui';

--- a/apps/web/src/components/Shared/Modal/Likes.tsx
+++ b/apps/web/src/components/Shared/Modal/Likes.tsx
@@ -1,5 +1,5 @@
 import UserProfile from '@components/Shared/UserProfile';
-import { HeartIcon } from '@heroicons/react/outline';
+import { HeartIcon } from '@heroicons/react/24/outline';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type { Profile, WhoReactedPublicationRequest } from '@lenster/lens';
 import { useLikesQuery } from '@lenster/lens';

--- a/apps/web/src/components/Shared/Modal/Mirrors.tsx
+++ b/apps/web/src/components/Shared/Modal/Mirrors.tsx
@@ -1,5 +1,5 @@
 import UserProfile from '@components/Shared/UserProfile';
-import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type { Profile, ProfileQueryRequest } from '@lenster/lens';
 import { useProfilesQuery } from '@lenster/lens';
@@ -50,7 +50,7 @@ const Mirrors: FC<MirrorsProps> = ({ publicationId }) => {
       <div className="p-5">
         <EmptyState
           message={t`No mirrors.`}
-          icon={<SwitchHorizontalIcon className="text-brand h-8 w-8" />}
+          icon={<ArrowsRightLeftIcon className="text-brand h-8 w-8" />}
           hideCard
         />
       </div>

--- a/apps/web/src/components/Shared/Modal/ReportProfile/index.tsx
+++ b/apps/web/src/components/Shared/Modal/ReportProfile/index.tsx
@@ -1,5 +1,5 @@
 import UserProfile from '@components/Shared/UserProfile';
-import { PencilAltIcon } from '@heroicons/react/outline';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
 import { PROFILE } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import { Button, Card, Form, Radio, TextArea, useZodForm } from '@lenster/ui';
@@ -99,7 +99,7 @@ const ReportProfile: FC<ReportProfileProps> = ({ profile }) => {
           className="flex w-full justify-center"
           type="submit"
           variant="primary"
-          icon={<PencilAltIcon className="h-4 w-4" />}
+          icon={<PencilSquareIcon className="h-4 w-4" />}
           disabled={!form.watch('type')}
         >
           <Trans>Report</Trans>

--- a/apps/web/src/components/Shared/Modal/ReportPublication/index.tsx
+++ b/apps/web/src/components/Shared/Modal/ReportPublication/index.tsx
@@ -1,5 +1,5 @@
-import { PencilAltIcon } from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { PencilSquareIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { PAGEVIEW, PUBLICATION } from '@lenster/data/tracking';
 import type { Publication } from '@lenster/lens';
 import { useReportPublicationMutation } from '@lenster/lens';
@@ -113,7 +113,7 @@ const ReportPublication: FC<ReportProps> = ({ publication }) => {
                     submitLoading ? (
                       <Spinner size="xs" />
                     ) : (
-                      <PencilAltIcon className="h-4 w-4" />
+                      <PencilSquareIcon className="h-4 w-4" />
                     )
                   }
                 >

--- a/apps/web/src/components/Shared/Navbar/BottomNavigation.tsx
+++ b/apps/web/src/components/Shared/Navbar/BottomNavigation.tsx
@@ -1,15 +1,15 @@
 import {
   BellIcon,
+  EnvelopeIcon,
   HomeIcon,
-  MailIcon,
-  ViewGridIcon
-} from '@heroicons/react/outline';
+  Squares2X2Icon
+} from '@heroicons/react/24/outline';
 import {
   BellIcon as BellIconSolid,
+  EnvelopeIcon as EnvelopeIconSolid,
   HomeIcon as HomeIconSolid,
-  MailIcon as MailIconSolid,
-  ViewGridIcon as ViewGridIconSolid
-} from '@heroicons/react/solid';
+  Squares2X2Icon as Squares2X2IconSolid
+} from '@heroicons/react/24/solid';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
@@ -29,9 +29,9 @@ const BottomNavigation = () => {
         </Link>
         <Link href="/explore" className="mx-auto my-3">
           {isActivePath('/explore') ? (
-            <ViewGridIconSolid className="text-brand h-6 w-6" />
+            <Squares2X2IconSolid className="text-brand h-6 w-6" />
           ) : (
-            <ViewGridIcon className="h-6 w-6" />
+            <Squares2X2Icon className="h-6 w-6" />
           )}
         </Link>
         <Link href="/notifications" className="mx-auto my-3">
@@ -43,9 +43,9 @@ const BottomNavigation = () => {
         </Link>
         <Link href="/messages" className="mx-auto my-3">
           {isActivePath('/messages') ? (
-            <MailIconSolid className="text-brand h-6 w-6" />
+            <EnvelopeIconSolid className="text-brand h-6 w-6" />
           ) : (
-            <MailIcon className="h-6 w-6" />
+            <EnvelopeIcon className="h-6 w-6" />
           )}
         </Link>
       </div>

--- a/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
+++ b/apps/web/src/components/Shared/Navbar/MobileDrawerMenu.tsx
@@ -1,4 +1,4 @@
-import { XIcon } from '@heroicons/react/outline';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
@@ -45,7 +45,7 @@ const MobileDrawerMenu: FC = () => {
   return (
     <div className="no-scrollbar fixed inset-0 z-10 h-full w-full overflow-y-auto bg-gray-100 py-4 dark:bg-black md:hidden">
       <button className="px-5" type="button" onClick={closeDrawer}>
-        <XIcon className="h-6 w-6" />
+        <XMarkIcon className="h-6 w-6" />
       </button>
       <div className="w-full space-y-2">
         <Link

--- a/apps/web/src/components/Shared/Navbar/NavItems/Bookmarks.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Bookmarks.tsx
@@ -1,4 +1,4 @@
-import { BookmarkIcon } from '@heroicons/react/outline';
+import { BookmarkIcon } from '@heroicons/react/24/outline';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
 import Link from 'next/link';

--- a/apps/web/src/components/Shared/Navbar/NavItems/Contact.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Contact.tsx
@@ -1,4 +1,4 @@
-import { SupportIcon } from '@heroicons/react/outline';
+import { LifebuoyIcon } from '@heroicons/react/24/outline';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
 import Link from 'next/link';
@@ -19,7 +19,7 @@ const Contact: FC<ContactProps> = ({ onClick, className = '' }) => {
       )}
       onClick={onClick}
     >
-      <SupportIcon className="h-4 w-4" />
+      <LifebuoyIcon className="h-4 w-4" />
       <div>
         <Trans>Contact</Trans>
       </div>

--- a/apps/web/src/components/Shared/Navbar/NavItems/GardenerMode.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/GardenerMode.tsx
@@ -1,5 +1,5 @@
-import { LightningBoltIcon as LightningBoltIconOutline } from '@heroicons/react/outline';
-import { LightningBoltIcon as LightningBoltIconSolid } from '@heroicons/react/solid';
+import { BoltIcon as BoltIconOutline } from '@heroicons/react/24/outline';
+import { BoltIcon as BoltIconSolid } from '@heroicons/react/24/solid';
 import { PREFERENCES_WORKER_URL } from '@lenster/data/constants';
 import { Localstorage } from '@lenster/data/storage';
 import { GARDENER } from '@lenster/data/tracking';
@@ -57,9 +57,9 @@ const GardenerMode: FC<ModModeProps> = ({ className = '' }) => {
       )}
     >
       {gardenerMode ? (
-        <LightningBoltIconSolid className="h-4 w-4 text-green-600" />
+        <BoltIconSolid className="h-4 w-4 text-green-600" />
       ) : (
-        <LightningBoltIconOutline className="h-4 w-4 text-red-500" />
+        <BoltIconOutline className="h-4 w-4 text-red-500" />
       )}
       <div>
         <Trans>Gardener mode</Trans>

--- a/apps/web/src/components/Shared/Navbar/NavItems/Invites.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Invites.tsx
@@ -1,4 +1,4 @@
-import { TicketIcon } from '@heroicons/react/outline';
+import { TicketIcon } from '@heroicons/react/24/outline';
 import { INVITE } from '@lenster/data/tracking';
 import cn from '@lenster/ui/cn';
 import { Leafwatch } from '@lib/leafwatch';

--- a/apps/web/src/components/Shared/Navbar/NavItems/Logout.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Logout.tsx
@@ -1,4 +1,4 @@
-import { LogoutIcon } from '@heroicons/react/outline';
+import { ArrowRightOnRectangleIcon } from '@heroicons/react/24/outline';
 import { PROFILE } from '@lenster/data/tracking';
 import resetAuthData from '@lenster/lib/resetAuthData';
 import cn from '@lenster/ui/cn';
@@ -53,7 +53,7 @@ const Logout: FC<LogoutProps> = ({ onClick, className = '' }) => {
       )}
     >
       <div className="flex items-center space-x-1.5">
-        <LogoutIcon className="h-4 w-4" />
+        <ArrowRightOnRectangleIcon className="h-4 w-4" />
         <div>
           <Trans>Logout</Trans>
         </div>

--- a/apps/web/src/components/Shared/Navbar/NavItems/Mod.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Mod.tsx
@@ -1,4 +1,4 @@
-import { ShieldCheckIcon } from '@heroicons/react/outline';
+import { ShieldCheckIcon } from '@heroicons/react/24/outline';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';

--- a/apps/web/src/components/Shared/Navbar/NavItems/ReportBug.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/ReportBug.tsx
@@ -1,4 +1,7 @@
-import { ExternalLinkIcon, HandIcon } from '@heroicons/react/outline';
+import {
+  ArrowTopRightOnSquareIcon,
+  HandRaisedIcon
+} from '@heroicons/react/24/outline';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
 import Link from 'next/link';
@@ -21,12 +24,12 @@ const ReportBug: FC<ReportBugProps> = ({ onClick, className = '' }) => {
       onClick={onClick}
     >
       <div className="flex items-center space-x-1.5">
-        <HandIcon className="h-4 w-4" />
+        <HandRaisedIcon className="h-4 w-4" />
         <div>
           <Trans>Report a bug</Trans>
         </div>
       </div>
-      <ExternalLinkIcon className="h-4 w-4 md:hidden" />
+      <ArrowTopRightOnSquareIcon className="h-4 w-4 md:hidden" />
     </Link>
   );
 };

--- a/apps/web/src/components/Shared/Navbar/NavItems/Settings.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Settings.tsx
@@ -1,4 +1,4 @@
-import { CogIcon } from '@heroicons/react/outline';
+import { Cog6ToothIcon } from '@heroicons/react/24/outline';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';
@@ -15,7 +15,7 @@ const Settings: FC<SettingsProps> = ({ className = '' }) => {
         className
       )}
     >
-      <CogIcon className="h-4 w-4" />
+      <Cog6ToothIcon className="h-4 w-4" />
       <div>
         <Trans>Settings</Trans>
       </div>

--- a/apps/web/src/components/Shared/Navbar/NavItems/StaffMode.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/StaffMode.tsx
@@ -1,5 +1,5 @@
-import { ShieldCheckIcon as ShieldCheckIconOutline } from '@heroicons/react/outline';
-import { ShieldCheckIcon as ShieldCheckIconSolid } from '@heroicons/react/solid';
+import { ShieldCheckIcon as ShieldCheckIconOutline } from '@heroicons/react/24/outline';
+import { ShieldCheckIcon as ShieldCheckIconSolid } from '@heroicons/react/24/solid';
 import { PREFERENCES_WORKER_URL } from '@lenster/data/constants';
 import { Localstorage } from '@lenster/data/storage';
 import { STAFFTOOLS } from '@lenster/data/tracking';

--- a/apps/web/src/components/Shared/Navbar/NavItems/Status.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/Status.tsx
@@ -1,4 +1,4 @@
-import { EmojiHappyIcon } from '@heroicons/react/outline';
+import { FaceSmileIcon } from '@heroicons/react/24/outline';
 import getProfileAttribute from '@lenster/lib/getProfileAttribute';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
@@ -42,7 +42,7 @@ const Status: FC<StatusProps> = ({ className = '' }) => {
         </>
       ) : (
         <>
-          <EmojiHappyIcon className="h-4 w-4" />
+          <FaceSmileIcon className="h-4 w-4" />
           <span>
             <Trans>Set status</Trans>
           </span>

--- a/apps/web/src/components/Shared/Navbar/NavItems/SwitchProfile.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/SwitchProfile.tsx
@@ -1,4 +1,4 @@
-import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';
@@ -23,7 +23,7 @@ const SwitchProfile: FC<SwitchProfileProps> = ({ className = '' }) => {
       onClick={() => setShowProfileSwitchModal(true)}
     >
       <div className="flex items-center space-x-2">
-        <SwitchHorizontalIcon className="h-4 w-4" />
+        <ArrowsRightLeftIcon className="h-4 w-4" />
         <span>
           <Trans>Switch profile</Trans>
         </span>

--- a/apps/web/src/components/Shared/Navbar/NavItems/ThemeSwitch.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/ThemeSwitch.tsx
@@ -1,4 +1,4 @@
-import { MoonIcon, SunIcon } from '@heroicons/react/outline';
+import { MoonIcon, SunIcon } from '@heroicons/react/24/outline';
 import { SYSTEM } from '@lenster/data/tracking';
 import cn from '@lenster/ui/cn';
 import { Leafwatch } from '@lib/leafwatch';

--- a/apps/web/src/components/Shared/Navbar/NavItems/YourProfile.tsx
+++ b/apps/web/src/components/Shared/Navbar/NavItems/YourProfile.tsx
@@ -1,4 +1,4 @@
-import { UserIcon } from '@heroicons/react/outline';
+import { UserIcon } from '@heroicons/react/24/outline';
 import cn from '@lenster/ui/cn';
 import { Trans } from '@lingui/macro';
 import type { FC } from 'react';

--- a/apps/web/src/components/Shared/Navbar/Search.tsx
+++ b/apps/web/src/components/Shared/Navbar/Search.tsx
@@ -1,4 +1,4 @@
-import { SearchIcon, XIcon } from '@heroicons/react/outline';
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import type { Profile, ProfileSearchResult } from '@lenster/lens';
 import {
   CustomFiltersTypes,
@@ -84,9 +84,9 @@ const Search: FC<SearchProps> = ({
           className="px-3 py-2 text-sm"
           placeholder={placeholder}
           value={searchText}
-          iconLeft={<SearchIcon />}
+          iconLeft={<MagnifyingGlassIcon />}
           iconRight={
-            <XIcon
+            <XMarkIcon
               className={cn(
                 'cursor-pointer',
                 searchText ? 'visible' : 'invisible'

--- a/apps/web/src/components/Shared/Navbar/StaffBar/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/StaffBar/index.tsx
@@ -1,8 +1,8 @@
 import {
   GlobeAltIcon,
   HashtagIcon,
-  TemplateIcon
-} from '@heroicons/react/outline';
+  RectangleGroupIcon
+} from '@heroicons/react/24/outline';
 import {
   GIT_COMMIT_SHA,
   IS_MAINNET,
@@ -58,7 +58,7 @@ const StaffBar: FC = () => {
       </div>
       <div className="flex items-center">
         <Link href="/stafftools">
-          <TemplateIcon className="h-4 w-4" />
+          <RectangleGroupIcon className="h-4 w-4" />
         </Link>
       </div>
     </div>

--- a/apps/web/src/components/Shared/Navbar/index.tsx
+++ b/apps/web/src/components/Shared/Navbar/index.tsx
@@ -1,6 +1,6 @@
 import MessageIcon from '@components/Messages/MessageIcon';
 import NotificationIcon from '@components/Notification/NotificationIcon';
-import { SearchIcon, XIcon } from '@heroicons/react/outline';
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import cn from '@lenster/ui/cn';
@@ -81,9 +81,9 @@ const Navbar: FC = () => {
               onClick={() => setShowSearch(!showSearch)}
             >
               {showSearch ? (
-                <XIcon className="h-6 w-6" />
+                <XMarkIcon className="h-6 w-6" />
               ) : (
-                <SearchIcon className="h-6 w-6" />
+                <MagnifyingGlassIcon className="h-6 w-6" />
               )}
             </button>
             <Link href="/" className="hidden md:block">

--- a/apps/web/src/components/Shared/Pending.tsx
+++ b/apps/web/src/components/Shared/Pending.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon } from '@heroicons/react/outline';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
 import { gql, useQuery } from '@lenster/lens/apollo';
 import { Button, Spinner } from '@lenster/ui';
 import { Trans } from '@lingui/macro';

--- a/apps/web/src/components/Shared/ProtectProfile.tsx
+++ b/apps/web/src/components/Shared/ProtectProfile.tsx
@@ -1,4 +1,4 @@
-import { LockClosedIcon, LockOpenIcon } from '@heroicons/react/outline';
+import { LockClosedIcon, LockOpenIcon } from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { LENSHUB_PROXY } from '@lenster/data/constants';
 import { SETTINGS } from '@lenster/data/tracking';

--- a/apps/web/src/components/Shared/ReferralAlert.tsx
+++ b/apps/web/src/components/Shared/ReferralAlert.tsx
@@ -1,5 +1,5 @@
 import Slug from '@components/Shared/Slug';
-import { HeartIcon } from '@heroicons/react/solid';
+import { HeartIcon } from '@heroicons/react/24/solid';
 import type { ElectedMirror, Publication } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import { Trans } from '@lingui/macro';

--- a/apps/web/src/components/Shared/SmallUserProfile.tsx
+++ b/apps/web/src/components/Shared/SmallUserProfile.tsx
@@ -1,4 +1,7 @@
-import { BadgeCheckIcon, ExclamationCircleIcon } from '@heroicons/react/solid';
+import {
+  CheckBadgeIcon,
+  ExclamationCircleIcon
+} from '@heroicons/react/24/solid';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
@@ -45,7 +48,7 @@ const SmallUserProfile: FC<UserProfileProps> = ({
         {sanitizeDisplayName(profile?.name) ?? formatHandle(profile?.handle)}
       </div>
       {isVerified(profile.id) ? (
-        <BadgeCheckIcon className="text-brand mr-1 h-4 w-4" />
+        <CheckBadgeIcon className="text-brand mr-1 h-4 w-4" />
       ) : null}
       {hasMisused(profile.id) ? (
         <ExclamationCircleIcon className="mr-2 h-4 w-4 text-red-500" />

--- a/apps/web/src/components/Shared/SmallWalletProfile.tsx
+++ b/apps/web/src/components/Shared/SmallWalletProfile.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon } from '@heroicons/react/outline';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { POLYGONSCAN_URL } from '@lenster/data/constants';
 import type { Wallet } from '@lenster/lens';
 import formatAddress from '@lenster/lib/formatAddress';
@@ -50,7 +50,7 @@ const SmallWalletProfile: FC<SmallWalletProfileProps> = ({
             <div>
               {loading ? formatAddress(wallet?.address) : formatAddress(ens)}
             </div>
-            <ExternalLinkIcon className="h-4 w-4" />
+            <ArrowTopRightOnSquareIcon className="h-4 w-4" />
           </div>
         </div>
       </Link>

--- a/apps/web/src/components/Shared/Status.tsx
+++ b/apps/web/src/components/Shared/Status.tsx
@@ -1,4 +1,4 @@
-import { PencilIcon } from '@heroicons/react/outline';
+import { PencilIcon } from '@heroicons/react/24/outline';
 import { LensPeriphery } from '@lenster/abis';
 import { LENS_PERIPHERY } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';

--- a/apps/web/src/components/Shared/SuperFollow/FollowModule.tsx
+++ b/apps/web/src/components/Shared/SuperFollow/FollowModule.tsx
@@ -1,5 +1,5 @@
 import AllowanceButton from '@components/Settings/Allowance/Button';
-import { StarIcon, UserIcon } from '@heroicons/react/outline';
+import { StarIcon, UserIcon } from '@heroicons/react/24/outline';
 import { LensHub } from '@lenster/abis';
 import { LENSHUB_PROXY, POLYGONSCAN_URL } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';

--- a/apps/web/src/components/Shared/SuperFollow/index.tsx
+++ b/apps/web/src/components/Shared/SuperFollow/index.tsx
@@ -1,4 +1,4 @@
-import { StarIcon } from '@heroicons/react/outline';
+import { StarIcon } from '@heroicons/react/24/outline';
 import { PROFILE } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';

--- a/apps/web/src/components/Shared/SwitchNetwork.tsx
+++ b/apps/web/src/components/Shared/SwitchNetwork.tsx
@@ -1,4 +1,4 @@
-import { SwitchHorizontalIcon } from '@heroicons/react/outline';
+import { ArrowsRightLeftIcon } from '@heroicons/react/24/outline';
 import { SYSTEM } from '@lenster/data/tracking';
 import { Button } from '@lenster/ui';
 import { Leafwatch } from '@lib/leafwatch';
@@ -27,7 +27,7 @@ const SwitchNetwork: FC<SwitchNetworkProps> = ({
       className={className}
       type="button"
       variant="danger"
-      icon={<SwitchHorizontalIcon className="h-4 w-4" />}
+      icon={<ArrowsRightLeftIcon className="h-4 w-4" />}
       onClick={() => {
         onSwitch?.();
         if (switchNetwork) {

--- a/apps/web/src/components/Shared/SwitchProfiles.tsx
+++ b/apps/web/src/components/Shared/SwitchProfiles.tsx
@@ -1,5 +1,5 @@
-import { UserAddIcon } from '@heroicons/react/outline';
-import { CheckCircleIcon } from '@heroicons/react/solid';
+import { UserPlusIcon } from '@heroicons/react/24/outline';
+import { CheckCircleIcon } from '@heroicons/react/24/solid';
 import { IS_MAINNET } from '@lenster/data/constants';
 import { PROFILE } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
@@ -80,7 +80,7 @@ const SwitchProfiles: FC = () => {
         >
           <span className="flex items-center space-x-2">
             <div className="dark:border-brand-700 border-brand-400 bg-brand-500/20 flex h-6 w-6 items-center justify-center rounded-full border">
-              <UserAddIcon className="text-brand h-3 w-3" />
+              <UserPlusIcon className="text-brand h-3 w-3" />
             </div>
             <div>
               <Trans>Create Profile</Trans>

--- a/apps/web/src/components/Shared/Unfollow.tsx
+++ b/apps/web/src/components/Shared/Unfollow.tsx
@@ -1,4 +1,4 @@
-import { UserRemoveIcon } from '@heroicons/react/outline';
+import { UserMinusIcon } from '@heroicons/react/24/outline';
 import { FollowNft } from '@lenster/abis';
 import { Errors } from '@lenster/data/errors';
 import { PROFILE } from '@lenster/data/tracking';
@@ -118,7 +118,7 @@ const Unfollow: FC<UnfollowProps> = ({
         isLoading ? (
           <Spinner variant="danger" size="xs" />
         ) : (
-          <UserRemoveIcon className="h-4 w-4" />
+          <UserMinusIcon className="h-4 w-4" />
         )
       }
     >

--- a/apps/web/src/components/Shared/UserPreview.tsx
+++ b/apps/web/src/components/Shared/UserPreview.tsx
@@ -1,4 +1,7 @@
-import { BadgeCheckIcon, ExclamationCircleIcon } from '@heroicons/react/solid';
+import {
+  CheckBadgeIcon,
+  ExclamationCircleIcon
+} from '@heroicons/react/24/solid';
 import { FollowUnfollowSource } from '@lenster/data/tracking';
 import type { Profile } from '@lenster/lens';
 import { useProfileLazyQuery } from '@lenster/lens';
@@ -67,7 +70,7 @@ const UserPreview: FC<UserPreviewProps> = ({
             formatHandle(lazyProfile?.handle)}
         </div>
         {isVerified(lazyProfile.id) ? (
-          <BadgeCheckIcon className="text-brand h-4 w-4" />
+          <CheckBadgeIcon className="text-brand h-4 w-4" />
         ) : null}
         {hasMisused(lazyProfile.id) ? (
           <ExclamationCircleIcon className="h-4 w-4 text-red-500" />

--- a/apps/web/src/components/Shared/UserProfile.tsx
+++ b/apps/web/src/components/Shared/UserProfile.tsx
@@ -1,5 +1,8 @@
 import Unfollow from '@components/Shared/Unfollow';
-import { BadgeCheckIcon, ExclamationCircleIcon } from '@heroicons/react/solid';
+import {
+  CheckBadgeIcon,
+  ExclamationCircleIcon
+} from '@heroicons/react/24/solid';
 import type { Profile } from '@lenster/lens';
 import formatHandle from '@lenster/lib/formatHandle';
 import getAvatar from '@lenster/lib/getAvatar';
@@ -85,7 +88,7 @@ const UserProfile: FC<UserProfileProps> = ({
           </div>
         </div>
         {isVerified(profile.id) ? (
-          <BadgeCheckIcon className="text-brand ml-1 h-4 w-4" />
+          <CheckBadgeIcon className="text-brand ml-1 h-4 w-4" />
         ) : null}
         {hasMisused(profile.id) ? (
           <ExclamationCircleIcon className="ml-1 h-4 w-4 text-red-500" />

--- a/apps/web/src/components/Shared/WalletProfile.tsx
+++ b/apps/web/src/components/Shared/WalletProfile.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon } from '@heroicons/react/outline';
+import { ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import { POLYGONSCAN_URL } from '@lenster/data/constants';
 import type { Wallet } from '@lenster/lens';
 import formatAddress from '@lenster/lib/formatAddress';
@@ -44,7 +44,7 @@ const WalletProfile: FC<WalletProfileProps> = ({ wallet }) => {
             <div>
               {loading ? formatAddress(wallet?.address) : formatAddress(ens)}
             </div>
-            <ExternalLinkIcon className="h-4 w-4" />
+            <ArrowTopRightOnSquareIcon className="h-4 w-4" />
           </div>
           <Slug className="text-sm" slug={formatAddress(wallet?.address)} />
         </div>

--- a/apps/web/src/components/StaffTools/Panels/Profile/Access.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Profile/Access.tsx
@@ -1,4 +1,4 @@
-import { AdjustmentsIcon } from '@heroicons/react/solid';
+import { AdjustmentsVerticalIcon } from '@heroicons/react/24/solid';
 import { PREFERENCES_WORKER_URL } from '@lenster/data/constants';
 import { Localstorage } from '@lenster/data/storage';
 import type { Profile } from '@lenster/lens';
@@ -109,7 +109,7 @@ const Access: FC<RankProps> = ({ profile }) => {
   return (
     <>
       <div className="mt-5 flex items-center space-x-2 text-yellow-600">
-        <AdjustmentsIcon className="h-5 w-5" />
+        <AdjustmentsVerticalIcon className="h-5 w-5" />
         <div className="text-lg font-bold">
           <Trans>Access</Trans>
         </div>

--- a/apps/web/src/components/StaffTools/Panels/Profile/Rank.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Profile/Rank.tsx
@@ -1,11 +1,11 @@
 import {
   CheckCircleIcon,
   CurrencyDollarIcon,
-  HandIcon,
-  UserAddIcon,
-  UserCircleIcon
-} from '@heroicons/react/outline';
-import { HashtagIcon } from '@heroicons/react/solid';
+  HandRaisedIcon,
+  UserCircleIcon,
+  UserPlusIcon
+} from '@heroicons/react/24/outline';
+import { HashtagIcon } from '@heroicons/react/24/solid';
 import type { Profile } from '@lenster/lens';
 import { formatDate } from '@lib/formatTime';
 import { t, Trans } from '@lingui/macro';
@@ -80,7 +80,7 @@ const Rank: FC<RankProps> = ({ profile }) => {
       </div>
       <div className="mt-3 space-y-2">
         <MetaDetails
-          icon={<UserAddIcon className="lt-text-gray-500 h-4 w-4" />}
+          icon={<UserPlusIcon className="lt-text-gray-500 h-4 w-4" />}
           value={followship?.rank}
           title={t`Followship Rank`}
         >
@@ -91,7 +91,7 @@ const Rank: FC<RankProps> = ({ profile }) => {
           )}
         </MetaDetails>
         <MetaDetails
-          icon={<HandIcon className="lt-text-gray-500 h-4 w-4" />}
+          icon={<HandRaisedIcon className="lt-text-gray-500 h-4 w-4" />}
           value={engagement?.rank}
           title={t`Engagement Rank`}
         >

--- a/apps/web/src/components/StaffTools/Panels/Profile/index.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Profile/index.tsx
@@ -1,12 +1,12 @@
 import {
-  CashIcon,
-  HandIcon,
+  BanknotesIcon,
+  HandRaisedIcon,
   HashtagIcon,
   IdentificationIcon,
   LinkIcon,
-  PhotographIcon
-} from '@heroicons/react/outline';
-import { ShieldCheckIcon } from '@heroicons/react/solid';
+  PhotoIcon
+} from '@heroicons/react/24/outline';
+import { ShieldCheckIcon } from '@heroicons/react/24/solid';
 import {
   ACHIEVEMENTS_WORKER_URL,
   APP_NAME,
@@ -86,7 +86,7 @@ const ProfileStaffTool: FC<ProfileStaffToolProps> = ({ profile }) => {
           {profile?.id}
         </MetaDetails>
         <MetaDetails
-          icon={<CashIcon className="lt-text-gray-500 h-4 w-4" />}
+          icon={<BanknotesIcon className="lt-text-gray-500 h-4 w-4" />}
           value={profile?.ownedBy}
           title={t`Address`}
         >
@@ -94,7 +94,7 @@ const ProfileStaffTool: FC<ProfileStaffToolProps> = ({ profile }) => {
         </MetaDetails>
         {profile?.followNftAddress ? (
           <MetaDetails
-            icon={<PhotographIcon className="lt-text-gray-500 h-4 w-4" />}
+            icon={<PhotoIcon className="lt-text-gray-500 h-4 w-4" />}
             value={profile?.followNftAddress}
             title={t`NFT address`}
           >
@@ -102,14 +102,14 @@ const ProfileStaffTool: FC<ProfileStaffToolProps> = ({ profile }) => {
           </MetaDetails>
         ) : null}
         <MetaDetails
-          icon={<HandIcon className="lt-text-gray-500 h-4 w-4" />}
+          icon={<HandRaisedIcon className="lt-text-gray-500 h-4 w-4" />}
           value={profile.dispatcher?.canUseRelay ? 'Yes' : 'No'}
           title={t`Can use relay`}
         >
           {profile.dispatcher?.canUseRelay ? 'Yes' : 'No'}
         </MetaDetails>
         <MetaDetails
-          icon={<HandIcon className="lt-text-gray-500 h-4 w-4" />}
+          icon={<HandRaisedIcon className="lt-text-gray-500 h-4 w-4" />}
           value={profile.dispatcher?.sponsor ? 'Yes' : 'No'}
           title={t`Gas sponsored`}
         >

--- a/apps/web/src/components/StaffTools/Panels/Publication.tsx
+++ b/apps/web/src/components/StaffTools/Panels/Publication.tsx
@@ -1,5 +1,9 @@
-import { CollectionIcon, HashtagIcon, TagIcon } from '@heroicons/react/outline';
-import { ShieldCheckIcon } from '@heroicons/react/solid';
+import {
+  HashtagIcon,
+  RectangleStackIcon,
+  TagIcon
+} from '@heroicons/react/24/outline';
+import { ShieldCheckIcon } from '@heroicons/react/24/solid';
 import type { Publication } from '@lenster/lens';
 import { Card } from '@lenster/ui';
 import { t, Trans } from '@lingui/macro';
@@ -47,7 +51,7 @@ const PublicationStaffTool: FC<PublicationStaffToolProps> = ({
         ) : null}
         {publication?.collectModule?.type ? (
           <MetaDetails
-            icon={<CollectionIcon className="lt-text-gray-500 h-4 w-4" />}
+            icon={<RectangleStackIcon className="lt-text-gray-500 h-4 w-4" />}
             value={publication?.collectModule?.type}
             title={t`Collect module`}
           >

--- a/apps/web/src/components/StaffTools/Sidebar.tsx
+++ b/apps/web/src/components/StaffTools/Sidebar.tsx
@@ -1,5 +1,5 @@
 import Sidebar from '@components/Shared/Sidebar';
-import { ChartPieIcon, ViewListIcon } from '@heroicons/react/outline';
+import { ChartPieIcon, QueueListIcon } from '@heroicons/react/24/outline';
 import { t } from '@lingui/macro';
 import type { FC } from 'react';
 
@@ -14,7 +14,7 @@ const StaffToolsSidebar: FC = () => {
         },
         {
           title: t`Relay queues`,
-          icon: <ViewListIcon className="h-4 w-4" />,
+          icon: <QueueListIcon className="h-4 w-4" />,
           url: '/stafftools/relayqueues'
         }
       ]}

--- a/apps/web/src/components/StaffTools/Stats/index.tsx
+++ b/apps/web/src/components/StaffTools/Stats/index.tsx
@@ -1,15 +1,15 @@
 import MetaTags from '@components/Common/MetaTags';
 import {
   ArrowDownIcon,
+  ArrowsRightLeftIcon,
   ArrowUpIcon,
-  ChatAlt2Icon,
-  CollectionIcon,
+  ChatBubbleLeftRightIcon,
   FireIcon,
-  SwitchHorizontalIcon,
-  UserAddIcon,
+  RectangleStackIcon,
+  UserPlusIcon,
   UsersIcon
-} from '@heroicons/react/outline';
-import { PencilAltIcon } from '@heroicons/react/solid';
+} from '@heroicons/react/24/outline';
+import { PencilSquareIcon } from '@heroicons/react/24/solid';
 import { APP_NAME } from '@lenster/data/constants';
 import { Errors } from '@lenster/data/errors';
 import { PAGEVIEW } from '@lenster/data/tracking';
@@ -57,7 +57,7 @@ const StatBox: FC<StatBoxProps> = ({
         <div className="text-lg font-bold">{humanize(value)}</div>
         <div className="flex items-center space-x-1 text-xs">
           {differenceValue === 0 ? (
-            <SwitchHorizontalIcon className="h-3 w-3 text-yellow-500" />
+            <ArrowsRightLeftIcon className="h-3 w-3 text-yellow-500" />
           ) : differenceValue <= 0 ? (
             <ArrowDownIcon className="h-3 w-3 text-red-500" />
           ) : (
@@ -162,7 +162,7 @@ const Stats: NextPage = () => {
                   title={t`profiles burnt`}
                 />
                 <StatBox
-                  icon={<PencilAltIcon className="h-6 w-6" />}
+                  icon={<PencilSquareIcon className="h-6 w-6" />}
                   value={stats?.totalPosts}
                   todayValue={todayStats?.totalPosts}
                   differenceValue={
@@ -173,7 +173,7 @@ const Stats: NextPage = () => {
               </div>
               <div className="block justify-between space-y-3 sm:flex sm:space-x-3 sm:space-y-0">
                 <StatBox
-                  icon={<SwitchHorizontalIcon className="h-6 w-6" />}
+                  icon={<ArrowsRightLeftIcon className="h-6 w-6" />}
                   value={stats?.totalMirrors}
                   todayValue={todayStats?.totalMirrors}
                   differenceValue={
@@ -182,7 +182,7 @@ const Stats: NextPage = () => {
                   title={t`total mirrors`}
                 />
                 <StatBox
-                  icon={<ChatAlt2Icon className="h-6 w-6" />}
+                  icon={<ChatBubbleLeftRightIcon className="h-6 w-6" />}
                   value={stats?.totalComments}
                   todayValue={todayStats?.totalComments}
                   differenceValue={
@@ -193,7 +193,7 @@ const Stats: NextPage = () => {
               </div>
               <div className="block justify-between space-y-3 sm:flex sm:space-x-3 sm:space-y-0">
                 <StatBox
-                  icon={<CollectionIcon className="h-6 w-6" />}
+                  icon={<RectangleStackIcon className="h-6 w-6" />}
                   value={stats?.totalCollects}
                   todayValue={todayStats?.totalCollects}
                   differenceValue={
@@ -202,7 +202,7 @@ const Stats: NextPage = () => {
                   title={t`total collects`}
                 />
                 <StatBox
-                  icon={<UserAddIcon className="h-6 w-6" />}
+                  icon={<UserPlusIcon className="h-6 w-6" />}
                   value={stats?.totalFollows}
                   todayValue={todayStats?.totalFollows}
                   differenceValue={

--- a/apps/web/src/pages/404.tsx
+++ b/apps/web/src/pages/404.tsx
@@ -1,5 +1,5 @@
 import MetaTags from '@components/Common/MetaTags';
-import { HomeIcon } from '@heroicons/react/outline';
+import { HomeIcon } from '@heroicons/react/24/outline';
 import { APP_NAME, STATIC_IMAGES_URL } from '@lenster/data/constants';
 import { Button } from '@lenster/ui';
 import { Trans } from '@lingui/macro';

--- a/apps/web/src/pages/500.tsx
+++ b/apps/web/src/pages/500.tsx
@@ -1,5 +1,5 @@
 import MetaTags from '@components/Common/MetaTags';
-import { HomeIcon } from '@heroicons/react/outline';
+import { HomeIcon } from '@heroicons/react/24/outline';
 import { APP_NAME } from '@lenster/data/constants';
 import { Button } from '@lenster/ui';
 import circluarStd from '@lib/lensterFont';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",
-    "@heroicons/react": "v1",
+    "@heroicons/react": "^2.0.18",
     "@hookform/resolvers": "^3.3.1",
     "@lenster/data": "workspace:*",
     "@lenster/lib": "workspace:*",

--- a/packages/ui/src/HelpTooltip.tsx
+++ b/packages/ui/src/HelpTooltip.tsx
@@ -1,6 +1,6 @@
 import 'tippy.js/dist/tippy.css';
 
-import { InformationCircleIcon } from '@heroicons/react/outline';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import Tippy from '@tippyjs/react';
 import type { FC, ReactNode } from 'react';
 

--- a/packages/ui/src/Modal.tsx
+++ b/packages/ui/src/Modal.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react';
-import { XIcon } from '@heroicons/react/outline';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import type { FC, ReactNode } from 'react';
 import { Fragment } from 'react';
 
@@ -78,7 +78,7 @@ export const Modal: FC<ModalProps> = ({
                       className="rounded-full p-1 text-gray-800 hover:bg-gray-200 dark:text-gray-100 dark:hover:bg-gray-700"
                       onClick={onClose}
                     >
-                      <XIcon className="h-5 w-5" />
+                      <XMarkIcon className="h-5 w-5" />
                     </button>
                   ) : null}
                 </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         specifier: ^1.7.17
         version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
-        specifier: v1
-        version: 1.0.0(react@18.2.0)
+        specifier: ^2.0.18
+        version: 2.0.18(react@18.2.0)
       '@lens-protocol/sdk-gated':
         specifier: ^1.2.0
         version: 1.2.0(ethers@5.5.1)(graphql@16.8.0)(react-dom@18.2.0)(react@18.2.0)
@@ -534,8 +534,8 @@ importers:
         specifier: ^1.7.17
         version: 1.7.17(react-dom@18.2.0)(react@18.2.0)
       '@heroicons/react':
-        specifier: v1
-        version: 1.0.0(react@18.2.0)
+        specifier: ^2.0.18
+        version: 2.0.18(react@18.2.0)
       '@hookform/resolvers':
         specifier: ^3.3.1
         version: 3.3.1(react-hook-form@7.46.1)
@@ -4245,8 +4245,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@heroicons/react@1.0.0(react@18.2.0):
-    resolution: {integrity: sha512-BHu+zsJ37B8RsspItwn2yTrph1Jj+k8YhVGV/UmAbxjhphC+RPdYMKzAJm9kGtA526loPtP+FYQM9GdMYTe13Q==}
+  /@heroicons/react@2.0.18(react@18.2.0):
+    resolution: {integrity: sha512-7TyMjRrZZMBPa+/5Y8lN0iyvUU/01PeMGX2+RE7cQWpEUIcb4QotzUObFkJDejj/HUH4qjP/eQ0gzzKs2f+6Yw==}
     peerDependencies:
       react: '>= 16'
     dependencies:


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a52877e</samp>

This pull request updates the icons of various components in the `web` app to use the new version of the `@heroicons/react` library. The icons are chosen to better match the size and the meaning of the components, and to improve the visual consistency and clarity of the app. The `package.json` file is also updated to reflect the new dependency version.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a52877e</samp>

*  Update the version of the `@heroicons/react` dependency to use the latest icons library that provides more icons and different sizes ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L23-R23))
*  Change the imports of various icons from the `outline` and `solid` modules to use the `24/outline` and `24/solid` sub-modules to use the 24px size of the icons instead of the default 20px size ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-8235322ceb1b2161b71dbae1480650ddb9514efe22bc1399097fa4f61ae16073L3-R3), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-543819ef93feccc82385ee6841a91bd658702e0f93e7f72a7867e19f6f9f8259L3-R4), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-9a91247e1a2005bbe587045d64cea0b1cf5db2f6102e69e89d5cd3c18feb831aL1-R1), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-8b0247ad958206c7b769effec612db871ad803e92f8ae0c920d24e247f810d2dL2-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-42d5943e545d14203bd44a0cd7f4759f7386b706715854f94d40be6a2857b6a6L2-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-65293029fd619762498223755e4c92e2c722206ff24c1688975741e02ea12659L2-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-6ce12af31854556f5f6c00f5d8cf0b7594b94c5f892a3e38f14c2cea3aceffefL2-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-481b6c9e01c18f000763fa350c4b82439dee8a3f5ec3cd2c8eada4990a95518fL2-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-60e3f5b80c2b77b36d4b19d49d0b67eadc64f7c8727c3f1c770435830bc956d0L1-R1), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-a98bb8d5bdf06f11b9097470283fb87b29fca1487aec39aa8e7ebf9e9f2a99b5L1-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-b1ef21472f66e5fadc0d8fa662ca3e850e175cc765275ae386d1fa666025dc36L5-R9), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-54b5b2bd5aae2ded964da8918986b46a8ab55c56506e5712b177ec3cf6dfa046L2-R2))
*  Change the icons that better represent the concept of collections from the `CollectionIcon` to the `RectangleStackIcon` in the `Feed`, `BasicSettings`, `CollectSettings`, and `ChooseThumbnail` components ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-278aef59d67ae7a141423d4dd926a4d4af72323dbb5ee3cb908fcd96a673b2c5L3-R3), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-278aef59d67ae7a141423d4dd926a4d4af72323dbb5ee3cb908fcd96a673b2c5L73-R73), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-56d7a3fad85c9cea8ddd3853d84b8d6ffd5bea121b8287569ed03649cf0f15c0L2-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-56d7a3fad85c9cea8ddd3853d84b8d6ffd5bea121b8287569ed03649cf0f15c0L67-R67), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-d1bae3351544b4672f60209bdfa3efd64d73c70cb0da2746b5cb556838377d10L1-R1), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-d1bae3351544b4672f60209bdfa3efd64d73c70cb0da2746b5cb556838377d10L24-R29), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-54b5b2bd5aae2ded964da8918986b46a8ab55c56506e5712b177ec3cf6dfa046L163-R163))
*  Change the icons that better represent the concept of comments from the `ChatAlt2Icon` to the `ChatBubbleLeftRightIcon` in the `Feed` component of the `Comment` component ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-92573b726b084d05a197c040a5ec0f3a357331fdbe006100cc17662f002ee7f9L4-R4), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-92573b726b084d05a197c040a5ec0f3a357331fdbe006100cc17662f002ee7f9L97-R97))
*  Change the icons that better represent the concept of media types from the `MusicNoteIcon`, the `PhotographIcon`, and the `VideoCameraIcon` to the `MusicalNoteIcon`, the `PhotoIcon`, and the `VideoCameraIcon` in the `Attachment` component of the `Actions` component ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-dc7f47a750043dfcca0d0bca34caa131ec068b8537fbe5ba40dd64efcb5718ceL4-R7), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-dc7f47a750043dfcca0d0bca34caa131ec068b8537fbe5ba40dd64efcb5718ceL88-R88), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-dc7f47a750043dfcca0d0bca34caa131ec068b8537fbe5ba40dd64efcb5718ceL110-R110), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-dc7f47a750043dfcca0d0bca34caa131ec068b8537fbe5ba40dd64efcb5718ceL155-R155))
*  Change the icons that better represent the concept of referral rewards from the `SwitchHorizontalIcon` to the `ArrowsRightLeftIcon` in the `ReferralConfig` component of the `CollectSettings` component ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-09749d66332cb7e88f6c5ddfeae39f25115953b56fbb181374b6b80f7d31e79cL2-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-09749d66332cb7e88f6c5ddfeae39f25115953b56fbb181374b6b80f7d31e79cL30-R30))
*  Change the icons that better represent the concept of split settings from the `PlusIcon`, the `SwitchHorizontalIcon`, the `UsersIcon`, and the `XCircleIcon` to the `PlusIcon`, the `ArrowsRightLeftIcon`, the `UsersIcon`, and the `XCircleIcon` in the `SplitConfig` component of the `CollectSettings` component ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-167e43ca14e31af121fc91851e280702f844b51a386e0dd70764c1e8651bdc1bL4-R8), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-167e43ca14e31af121fc91851e280702f844b51a386e0dd70764c1e8651bdc1bL185-R185))
*  Change the icons that better represent the concept of polls from the `MenuAlt2Icon` to the `Bars3BottomLeftIcon` in the `PollSettings` component of the `Actions` component and the `PollEditor` component of the `PollSettings` component ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-60e3f5b80c2b77b36d4b19d49d0b67eadc64f7c8727c3f1c770435830bc956d0L1-R1), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-60e3f5b80c2b77b36d4b19d49d0b67eadc64f7c8727c3f1c770435830bc956d0L26-R26), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-a98bb8d5bdf06f11b9097470283fb87b29fca1487aec39aa8e7ebf9e9f2a99b5L1-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-a98bb8d5bdf06f11b9097470283fb87b29fca1487aec39aa8e7ebf9e9f2a99b5L22-R22))
*  Change the icons that better represent the concept of deletion from the `XIcon` to the `XMarkIcon` in the `PollEditor` component of the `PollSettings` component ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-a98bb8d5bdf06f11b9097470283fb87b29fca1487aec39aa8e7ebf9e9f2a99b5L1-R2), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-a98bb8d5bdf06f11b9097470283fb87b29fca1487aec39aa8e7ebf9e9f2a99b5L117-R117))
*  Change the icons that better represent the concept of my follows from the `UserAddIcon` to the `UserPlusIcon` in the `ReferenceSettings` component of the `Actions` component ([link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-b1ef21472f66e5fadc0d8fa662ca3e850e175cc765275ae386d1fa666025dc36L5-R9), [link](https://github.com/lensterxyz/lenster/pull/3772/files?diff=unified&w=0#diff-b1ef21472f66e5fadc0d8fa662ca3e850e175cc765275ae386d1fa666025dc36L133-R133))

## Emoji

<!--
copilot:emoji
-->

🆙🔎🎨

<!--
1.  🆙 - This emoji can represent the upgrade of the icons library dependency to the latest version, as well as the general improvement of the icons' appearance and meaning.
2.  🔎 - This emoji can represent the change of the icons' size to 24px, which makes them more visible and consistent across the app.
3.  🎨 - This emoji can represent the change of the icons' design and shape, which adds more variety and clarity to the app's interface.
-->
