### PR TITLE
feat: add join or leave api for channels

### DIFF
--- a/packages/supabase/database.types.ts
+++ b/packages/supabase/database.types.ts
@@ -9,6 +9,31 @@ export type Json =
 export interface Database {
   public: {
     Tables: {
+      channel_memberships: {
+        Row: {
+          channel_id: string;
+          joined_at: string;
+          profile_id: string;
+        };
+        Insert: {
+          channel_id: string;
+          joined_at?: string;
+          profile_id: string;
+        };
+        Update: {
+          channel_id?: string;
+          joined_at?: string;
+          profile_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'channel_memberships_channel_id_fkey';
+            columns: ['channel_id'];
+            referencedRelation: 'channels';
+            referencedColumns: ['id'];
+          }
+        ];
+      };
       channels: {
         Row: {
           avatar: string;

--- a/packages/workers/channels/package.json
+++ b/packages/workers/channels/package.json
@@ -16,6 +16,7 @@
     "@lenster/data": "workspace:*",
     "@lenster/lib": "workspace:*",
     "@lenster/supabase": "workspace:*",
+    "@tsndr/cloudflare-worker-jwt": "^2.2.2",
     "itty-router": "^4.0.23",
     "zod": "^3.22.2"
   },

--- a/packages/workers/channels/src/handlers/joinOrLeave.ts
+++ b/packages/workers/channels/src/handlers/joinOrLeave.ts
@@ -1,0 +1,94 @@
+import { Errors } from '@lenster/data/errors';
+import hasOwnedLensProfiles from '@lenster/lib/hasOwnedLensProfiles';
+import response from '@lenster/lib/response';
+import validateLensAccount from '@lenster/lib/validateLensAccount';
+import createSupabaseClient from '@lenster/supabase/createSupabaseClient';
+import jwt from '@tsndr/cloudflare-worker-jwt';
+import { object, string } from 'zod';
+
+import type { WorkerRequest } from '../types';
+
+type ExtensionRequest = {
+  profileId: string;
+  channelId: string;
+};
+
+const validationSchema = object({
+  profileId: string(),
+  channelId: string()
+});
+
+export default async (request: WorkerRequest) => {
+  const body = await request.json();
+  if (!body) {
+    return response({ success: false, error: Errors.NoBody });
+  }
+
+  const accessToken = request.headers.get('X-Access-Token');
+  if (!accessToken) {
+    return response({ success: false, error: Errors.NoAccessToken });
+  }
+
+  const validation = validationSchema.safeParse(body);
+
+  if (!validation.success) {
+    return response({ success: false, error: validation.error.issues });
+  }
+
+  const { profileId, channelId } = body as ExtensionRequest;
+
+  try {
+    const isAuthenticated = await validateLensAccount(accessToken, true);
+    if (!isAuthenticated) {
+      return response({ success: false, error: Errors.InvalidAccesstoken });
+    }
+
+    const { payload } = jwt.decode(accessToken);
+    const hasOwned = await hasOwnedLensProfiles(payload.id, profileId, true);
+    if (!hasOwned) {
+      return new Response(
+        JSON.stringify({ success: false, error: Errors.InvalidProfileId })
+      );
+    }
+
+    const client = createSupabaseClient(request.env.SUPABASE_KEY);
+
+    const { data: membershipData, error: membershipError } = await client
+      .from('channel_memberships')
+      .select()
+      .eq('profile_id', profileId)
+      .eq('channel_id', channelId);
+
+    if (membershipError) {
+      throw membershipError;
+    }
+
+    if (membershipData?.length) {
+      // Leave
+      const { error: deleteError } = await client
+        .from('channel_memberships')
+        .delete()
+        .eq('profile_id', profileId)
+        .eq('channel_id', channelId);
+
+      if (deleteError) {
+        throw deleteError;
+      }
+
+      return response({ success: true });
+    }
+
+    // Join
+    const { error: insertError } = await client
+      .from('channel_memberships')
+      .insert({ profile_id: profileId, channel_id: channelId });
+
+    if (insertError) {
+      throw insertError;
+    }
+
+    return response({ success: true });
+  } catch (error) {
+    throw error;
+  }
+};

--- a/packages/workers/channels/src/index.ts
+++ b/packages/workers/channels/src/index.ts
@@ -4,6 +4,7 @@ import { createCors, error, Router, status } from 'itty-router';
 
 import featuredChannels from './handlers/featuredChannels';
 import getChannel from './handlers/getChannel';
+import joinOrLeave from './handlers/joinOrLeave';
 import buildRequest from './helpers/buildRequest';
 import type { Env, WorkerRequest } from './types';
 
@@ -25,6 +26,7 @@ router
   )
   .get('/get/:slug', getChannel)
   .get('/featured', featuredChannels)
+  .post('/joinOrLeave', joinOrLeave)
   .all('*', () => error(404));
 
 export default {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -616,6 +616,9 @@ importers:
       '@lenster/supabase':
         specifier: workspace:*
         version: link:../../supabase
+      '@tsndr/cloudflare-worker-jwt':
+        specifier: ^2.2.2
+        version: 2.2.2
       itty-router:
         specifier: ^4.0.23
         version: 4.0.23


### PR DESCRIPTION
## What does this PR do?

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 94a39b0</samp>

This pull request adds a feature to the `channels` worker that enables profiles to join or leave channels. It also updates the database schema and the dependencies to support this feature.

## Related issues

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking small changes to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Explanation of the changes

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 94a39b0</samp>

*  Add `channel_memberships` table to `Database` interface ([link](https://github.com/lensterxyz/lenster/pull/3792/files?diff=unified&w=0#diff-85d2d958072c93d3c902d2046ca9383f2c82e48ffa83e5b24d16458c47e351d9R12-R36))
*  Add `@tsndr/cloudflare-worker-jwt` dependency to `channels` worker ([link](https://github.com/lensterxyz/lenster/pull/3792/files?diff=unified&w=0#diff-67dcb032d62c31cafe097286fd136e51a83aca296f6b2345078c40c4e9173b42R19), [link](https://github.com/lensterxyz/lenster/pull/3792/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR619-R621))
*  Implement and register `/joinOrLeave` endpoint handler for `channels` worker ([link](https://github.com/lensterxyz/lenster/pull/3792/files?diff=unified&w=0#diff-aa46bb4073dd3cbb3ed1005f10525a7779fad1f7cfca1cc18ed6977aef28518cR7), [link](https://github.com/lensterxyz/lenster/pull/3792/files?diff=unified&w=0#diff-aa46bb4073dd3cbb3ed1005f10525a7779fad1f7cfca1cc18ed6977aef28518cR29))
*  Import `joinOrLeave` function from `./handlers/joinOrLeave` module in `src/index.ts` ([link](https://github.com/lensterxyz/lenster/pull/3792/files?diff=unified&w=0#diff-aa46bb4073dd3cbb3ed1005f10525a7779fad1f7cfca1cc18ed6977aef28518cR7))

## Emoji

<!--
copilot:emoji
-->

🆕🔐🙋

<!--
1.  🆕 - This emoji represents the addition of a new table definition to the `Database` interface. It conveys the idea of creating something new or introducing a new concept.
2.  🔐 - This emoji represents the dependency on the `@tsndr/cloudflare-worker-jwt` library, which is used for authentication and security purposes. It conveys the idea of locking, protecting, or verifying something.
3.  🙋 - This emoji represents the new feature of joining or leaving channels. It conveys the idea of raising one's hand, indicating interest, or participating in something.
-->
